### PR TITLE
Corrected cookie_lifetime to match comment

### DIFF
--- a/cheatsheets/PHP_Configuration_Cheat_Sheet.md
+++ b/cheatsheets/PHP_Configuration_Cheat_Sheet.md
@@ -106,7 +106,7 @@ Session settings are some of the MOST important values to concentrate on in conf
  session.use_strict_mode          = 1
  session.use_cookies              = 1
  session.use_only_cookies         = 1
- session.cookie_lifetime          = 864000 # 4 hours 
+ session.cookie_lifetime          = 14400 # 4 hours 
  session.cookie_secure            = 1
  session.cookie_httponly          = 1
  session.cookie_samesite          = Strict


### PR DESCRIPTION
Previous cookie_lifetime was 10 days (864000 seconds), but the comment for this line reads, "4 hours"

Thank you for submitting a Pull Request to the Cheat Sheet Series. 

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see policy [here](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to website have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g.: defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).

If your PR is related to an issue. Please end your PR text with the following line:

```
This PR covers issue #30.
```

Thanks you again for your contribution :smiley:
