### PR TITLE
Fixed two security issues in disable_functions setting

### DIFF
--- a/cheatsheets/PHP_Configuration_Cheat_Sheet.md
+++ b/cheatsheets/PHP_Configuration_Cheat_Sheet.md
@@ -82,10 +82,7 @@ If your application is not using file uploads, and say the only data the user wi
 
 ```text
 enable_dl               = Off
-disable_functions       = system, exec, shell_exec, passthru, phpinfo, show_source, popen, proc_open
-disable_functions       = fopen_with_path, dbmopen, dbase_open, putenv, move_uploaded_file
-disable_functions       = chdir, mkdir, rmdir, chmod, rename
-disable_functions       = filepro, filepro_rowcount, filepro_retrieve, posix_mkfifo
+disable_functions       = system, exec, shell_exec, passthru, phpinfo, show_source, highlight_file, popen, proc_open, fopen_with_path, dbmopen, dbase_open, putenv, move_uploaded_file, chdir, mkdir, rmdir, chmod, rename, filepro, filepro_rowcount, filepro_retrieve, posix_mkfifo
 # see also: http://ir.php.net/features.safe-mode
 disable_classes         = 
 ```


### PR DESCRIPTION
1) If 'show_source' is disabled, also 'highlight_file' must be disabled. 'show_source' is just an alias name of 'highlight_file'.
2) All disabled function names must be in one line. The previous split into multiple settings/lines resulted in only the last line was active (so all other functions were NOT disabled).
