### PR TITLE
Fix list formatting

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -285,10 +285,11 @@ The following shows techniques presumed to be CSRF mitigations but none of them 
 
 Since CSRF vulnerabilities are reportedly widespread, we recommend using the following best practices to mitigate risk.
 
-1. Logoff immediately after using a Web application.
-2. Do not allow your browser to save username/passwords, and do not allow sites to “remember” your login.
-3. Do not use the same browser to access sensitive applications and to surf the Internet freely (tabbed browsing).
-4. The use of plugins such as No-Script makes POST based CSRF vulnerabilities difficult to exploit. This is because JavaScript is used to automatically submit the form when the exploit is loaded. Without JavaScript, the attacker would have to trick the user into submitting the form manually.
+1. Logoff immediately after using a Web application.
+2. Do not allow your browser to save username/passwords, and do not allow sites to “remember” your login.
+3. Do not use the same browser to access sensitive applications and to surf the Internet freely (tabbed browsing).
+4. The use of plugins such as No-Script makes POST based CSRF vulnerabilities difficult to exploit. This is because JavaScript is used to automatically submit the form when the exploit is loaded. Without JavaScript, the attacker would have to trick the user into submitting the form manually.
+
 Integrated HTML-enabled mail/browser and newsreader/browser environments pose additional risks since simply viewing a mail message or a news message might lead to the execution of an attack. 
 
 # Implementation reference example


### PR DESCRIPTION
The "Personal Safety CSRF Tips for Users" list was showing up as one huge line instead of as a formatted ordered list. Plus the following line was not separated from the list.

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see policy [here](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to website have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g.: defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).