### PR TITLE
XSS CS Update

### DIFF
--- a/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
@@ -339,11 +339,10 @@ The `SanitizeHelper` module provides a set of methods for scrubbing text of unde
 ```
 
 **Other libraries that provide HTML Sanitization include:**
-- [HTML sanitizer](https://github.com/google/closure-library/tree/master/closure/goog/html/sanitizer) from [Google Closure Library](https://developers.google.com/closure/library/)
-- [PHP HTML Purifier](http://htmlpurifier.org/).
-- [JavaScript (DOM-only, requires JSDOM for Node.js)](https://github.com/cure53/DOMPurify).
-- [Node.js (depends on htmlparser2)](https://github.com/punkave/sanitize-html).
-- [Python Bleach](https://pypi.python.org/pypi/bleach).
+- [HTML sanitizer](https://github.com/google/closure-library/blob/master/closure/goog/html/sanitizer/htmlsanitizer.js) from [Google Closure Library](https://developers.google.com/closure/library/) (JavaScript/Node.js, [docs](https://google.github.io/closure-library/api/goog.html.sanitizer.HtmlSanitizer.html))
+- [DOMPurify](https://github.com/cure53/DOMPurify) (JavaScript, requires [jsdom](https://github.com/jsdom/jsdom) for Node.js)
+- [PHP HTML Purifier](http://htmlpurifier.org/)
+- [Python Bleach](https://pypi.python.org/pypi/bleach)
 
 ## RULE \#7 - Avoid JavaScript URL's
 

--- a/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
@@ -341,7 +341,8 @@ The `SanitizeHelper` module provides a set of methods for scrubbing text of unde
 **Other libraries that provide HTML Sanitization include:**
 - [HTML sanitizer](https://github.com/google/closure-library/tree/master/closure/goog/html/sanitizer) from [Google Closure Library](https://developers.google.com/closure/library/)
 - [PHP HTML Purifier](http://htmlpurifier.org/).
-- [JavaScript/Node.js Bleach](https://github.com/ecto/bleach).
+- [JavaScript (DOM-only, requires JSDOM for Node.js)](https://github.com/cure53/DOMPurify).
+- [Node.js (depends on htmlparser2)](https://github.com/punkave/sanitize-html).
 - [Python Bleach](https://pypi.python.org/pypi/bleach).
 
 ## RULE \#7 - Avoid JavaScript URL's


### PR DESCRIPTION
This PR covers issue #101

Update JS/Node.js libs in Cross Site Scripting Prevention Rule 6 "Other libraries that provide HTML Sanitization":

Line 344 linked to [ecto/bleach](https://github.com/ecto/bleach) as "JavaScript/Node.js Bleach"

Now Line 344-5 link to:
- [cure53/DOMPurify](https://github.com/cure53/DOMPurify), a DOM-only library that requires [JSDOM](https://github.com/jsdom/jsdom) on Node.js
- [punkave/sanitize-html](https://github.com/punkave/sanitize-html), a Node.js-only library that depends on [htmlparser2](https://github.com/fb55/htmlparser2)

...as:
- [JavaScript (DOM-only, requires JSDOM for Node.js)](https://github.com/cure53/DOMPurify)
- [Node.js (depends on htmlparser2)](https://github.com/punkave/sanitize-html)
