### PR TITLE
CSS 106 - Add Angular bypassSecurityTrust* functions to the XSS CS

### DIFF
--- a/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
@@ -378,7 +378,7 @@ This HTTP [response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/He
 
 ## Bonus Rule \#5: Properly use modern JS frameworks like Angular (2+) or ReactJS
 
-Modern javascript frameworks have pretty good XSS protection built in. It is important how to use them properly to benefit from it.
+Modern javascript frameworks have pretty good XSS protection built in. It is important to use them properly to benefit from it.
 
 When using ReactJS, *do not use [the function `dangerouslySetInnerHTML`](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml)*. When using Angular (2+), *do not use [functions with the pattern `bypassSecurityTrust{something}`](https://angular.io/guide/security#bypass-security-apis)* (i.e. `bypassSecurityTrustHtml`, `bypassSecurityTrustStyle`, etc).  
 If you really, really really have to use these functions remember that now all framework protections are turned off and you have to escape or sanitize all the data by yourself.

--- a/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
@@ -380,7 +380,8 @@ This HTTP [response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/He
 
 Modern javascript frameworks have pretty good XSS protection built in. It is important how to use them properly to benefit from it.
 
-When using ReactJS *do not use `dangerouslySetInnerHTML`*. If you really, really really have to use `dangerouslySetInnerHTML` remember that now all framework protections are turned off and you have to escape or sanitize all the data by yourself.
+When using ReactJS, *do not use [the function `dangerouslySetInnerHTML`](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml)*. When using Angular (2+), *do not use [functions with the pattern `bypassSecurityTrust{something}`](https://angular.io/guide/security#bypass-security-apis)* (i.e. `bypassSecurityTrustHtml`, `bypassSecurityTrustStyle`, etc).  
+If you really, really really have to use these functions remember that now all framework protections are turned off and you have to escape or sanitize all the data by yourself.
 
 For Angular (2+) remember to build Angular templates with `-prod` parameter (`ng build --prod`) in order to avoid template injection.
 


### PR DESCRIPTION
Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see policy [here](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to website have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g.: defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).

**It includes:**

- What we discussed on #106: adding `bypassSecurityTrust*` functions, the same way React's function was already presented ;
- Link to the doc for both Angular and React ;
- The removal of what I think was a typo: "Modern javascript frameworks have pretty good XSS protection built in. It is important ~how~ to use them properly to benefit from it".

This PR covers issue #106.
