### PR TITLE
Added Docker Inspec + DevSec, Docker log level guideline

### DIFF
--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -235,7 +235,7 @@ To detect misconfigurations in Docker:
 
 ## RULE \#10 - Set the logging level to at least INFO
 
-By default, the Docker daemon is configured to have a base logging level of 'info', if this is not the case: set the Docker daemon log level to 'info'. Rationale: Setting up an appropriate log level, configures the Docker daemon to log events that you would want to review later. A ase log level of 'info' and above would capture all logs except debug logs. Until and unless required, you should not run docker daemon at 'debug' log level.
+By default, the Docker daemon is configured to have a base logging level of 'info', and if this is not the case: set the Docker daemon log level to 'info'. Rationale: Setting up an appropriate log level, configures the Docker daemon to log events that you would want to review later. A base log level of 'info' and above would capture all logs except debug logs. Until and unless required, you should not run docker daemon at 'debug' log level.
 
 To configure the log level in docker-compose:
 

--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -235,13 +235,7 @@ To detect misconfigurations in Docker:
 
 ## RULE \#10 - Set the logging level to at least INFO
 
-Set Docker daemon log level to 'info'. Rationale: Setting up an appropriate log level, configures the Docker daemon to log events that you would want to review later. A ase log level of 'info' and above would capture all logs except debug logs. Until and unless required, you should not run docker daemon at 'debug' log level.
-
-To configure the log level per container:
-
-```
-$ docker --log-level info run -it alpine
-```
+By default, the Docker daemon is configured to have a base logging level of 'info', if this is not the case: set the Docker daemon log level to 'info'. Rationale: Setting up an appropriate log level, configures the Docker daemon to log events that you would want to review later. A ase log level of 'info' and above would capture all logs except debug logs. Until and unless required, you should not run docker daemon at 'debug' log level.
 
 To configure the log level in docker-compose:
 

--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -233,6 +233,30 @@ To detect misconfigurations in Docker:
  - [inspec.io](https://www.inspec.io/docs/reference/resources/docker/)
  - [dev-sec.io](https://dev-sec.io/baselines/docker/)
 
+## RULE \#10 - Set the logging level to at least INFO
+
+Set Docker daemon log level to 'info'. Rationale: Setting up an appropriate log level, configures the Docker daemon to log events that you would want to review later. A ase log level of 'info' and above would capture all logs except debug logs. Until and unless required, you should not run docker daemon at 'debug' log level.
+
+To configure the log level per container:
+
+```
+$ docker --log-level info run -it alpine
+```
+
+To configure the log level in docker-compose:
+
+```
+$ docker-compose --log-level info up
+```
+
+References:
+
+ - [Docker Baselines on DevSec](https://dev-sec.io/baselines/docker/)
+ - [Use the Docker command line](https://docs.docker.com/engine/reference/commandline/cli/)
+ - [Overview of docker-compose CLI](https://docs.docker.com/compose/reference/overview/)
+ - [Configuring Logging Drivers](https://docs.docker.com/config/containers/logging/configure/)
+ - [View logs for a container or service](https://docs.docker.com/config/containers/logging/)
+
 # Related Projects
 
 [OWASP Docker Top 10](https://github.com/OWASP/Docker-Security)

--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -224,10 +224,14 @@ To detect containers with known vulnerabilities - scan images using static analy
   - [JFrog XRay](https://jfrog.com/xray/) 
   - [Qualys](https://www.qualys.com/apps/container-security/)
 
-To detect missconfigurations in Kubernetes:
+To detect misconfigurations in Kubernetes:
  - [kubeaudit](https://github.com/Shopify/kubeaudit)
  - [kubesec.io](https://kubesec.io/)
  - [kube-bench](https://github.com/aquasecurity/kube-bench)
+
+To detect misconfigurations in Docker:
+ - [inspec.io](https://www.inspec.io/docs/reference/resources/docker/)
+ - [dev-sec.io](https://dev-sec.io/baselines/docker/)
 
 # Related Projects
 


### PR DESCRIPTION
Hi there! I've added two links to detect misconfigurations in Docker using inspec and the related dev-sec snippets website. Also added something about setting the log level to at least INFO, text taken from the [dev-sec](https://dev-sec.io/baselines/docker/) snippet. Extra credit to: @commjoen