### PR TITLE
Add insecure PHP functions to cryptographic cheatsheet

### DIFF
--- a/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
+++ b/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
@@ -63,11 +63,11 @@ Ensure that random algorithms are seeded with sufficient entropy.
 
 Tools like [NIST RNG Test tool](http://csrc.nist.gov/groups/ST/toolkit/rng/documentation_software.html) (as used in PCI PTS Derived Test Requirements) can be used to comprehensively assess the quality of a Random Number Generator by reading e.g. 128MB of data from the RNG source and then assessing its randomness properties with the tool.
 
-The following functions are considered **weak** random numbers generators and should not be used.
+The following functions are considered **weak** random number generators and should not be used.
 
 - C : `random()`, `rand()` instead use [getrandom(2)](http://man7.org/linux/man-pages/man2/getrandom.2.html)
 - Java : `java.util.Random()` instead use `java.security.SecureRandom`
-- PHP : `rand()`, `mt_rand()`, `array_rand()`, `uniqid()` instead use `random_bytes()`, `random_int()` (PHP 7) or `openssl_random_pseudo_bytes()` (PHP 5)
+- PHP : `rand()`, `mt_rand()`, `array_rand()`, `uniqid()` instead use [random_bytes()](https://www.php.net/manual/en/function.random-bytes.php), [random_int()](https://www.php.net/manual/en/function.random-int.php) (PHP 7) or [openssl_random_pseudo_bytes()](https://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php) (PHP 5 - **deprecated**)
 
 For secure random number generation, refer to NIST SP 800-90A. CTR-DRBG, HASH-DRBG or HMAC-DRBG are recommended. Refer to NIST SP800-22 A Statistical Test Suite for Random and Pseudorandom Number Generators for Cryptographic Applications, and the testing toolkit.
 

--- a/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
+++ b/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
@@ -63,12 +63,13 @@ Ensure that random algorithms are seeded with sufficient entropy.
 
 Tools like [NIST RNG Test tool](http://csrc.nist.gov/groups/ST/toolkit/rng/documentation_software.html) (as used in PCI PTS Derived Test Requirements) can be used to comprehensively assess the quality of a Random Number Generator by reading e.g. 128MB of data from the RNG source and then assessing its randomness properties with the tool.
 
-The following libraries are considered **weak** random numbers generators and should not be used.
+The following functions are considered **weak** random numbers generators and should not be used.
 
-- C library: `random()`, `rand()` instead use [getrandom(2)](http://man7.org/linux/man-pages/man2/getrandom.2.html) instead
-- Java library: `java.util.Random()` instead use `java.security.SecureRandom` instead
+- C : `random()`, `rand()` instead use [getrandom(2)](http://man7.org/linux/man-pages/man2/getrandom.2.html)
+- Java : `java.util.Random()` instead use `java.security.SecureRandom`
+- PHP : `rand()`, `mt_rand()`, `array_rand()`, `uniqid()` instead use `random_bytes()`, `random_int()` (PHP 7) or `openssl_random_pseudo_bytes()` (PHP 5)
 
-For secure random number generation, refer to NIST SP 800-90A. CTR-DRBG、HASH-DRBG、HMAC-DRBG are recommended. Refer to NIST SP800-22 A Statistical Test Suite for Random and Pseudorandom Number Generators for Cryptographic Applications, and the testing toolkit.
+For secure random number generation, refer to NIST SP 800-90A. CTR-DRBG, HASH-DRBG or HMAC-DRBG are recommended. Refer to NIST SP800-22 A Statistical Test Suite for Random and Pseudorandom Number Generators for Cryptographic Applications, and the testing toolkit.
 
 References:
 - http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-22r1a.pdf

--- a/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
+++ b/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
@@ -67,7 +67,7 @@ The following functions are considered **weak** random number generators and sho
 
 - C : `random()`, `rand()` instead use [getrandom(2)](http://man7.org/linux/man-pages/man2/getrandom.2.html)
 - Java : `java.util.Random()` instead use `java.security.SecureRandom`
-- PHP : `rand()`, `mt_rand()`, `array_rand()`, `uniqid()` instead use [random_bytes()](https://www.php.net/manual/en/function.random-bytes.php), [random_int()](https://www.php.net/manual/en/function.random-int.php) (PHP 7) or [openssl_random_pseudo_bytes()](https://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php) (PHP 5 - **deprecated**)
+- PHP : `rand()`, `mt_rand()`, `array_rand()`, `uniqid()` instead use [random_bytes()](https://www.php.net/manual/en/function.random-bytes.php), [random_int()](https://www.php.net/manual/en/function.random-int.php) in PHP 7 or [openssl_random_pseudo_bytes()](https://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php) in PHP 5 (which is **deprecated** and **should not be used**)
 
 For secure random number generation, refer to NIST SP 800-90A. CTR-DRBG, HASH-DRBG or HMAC-DRBG are recommended. Refer to NIST SP800-22 A Statistical Test Suite for Random and Pseudorandom Number Generators for Cryptographic Applications, and the testing toolkit.
 


### PR DESCRIPTION
Also tidied up some of the formatting (strange commas) and wording around them.