### PR TITLE
Fix AES keysize typo

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -391,7 +391,7 @@ DO: Use a strong hash to store password credentials. Use Argon2, PBKDF2, BCrypt 
 
 DO: Enforce passwords with a minimum complexity that will survive a dictionary attack i.e. longer passwords that use the full character set (numbers, symbols and letters) to increase the entropy.
 
-DO: Use a strong encryption routine such as AES-512 where personally identifiable data needs to be restored to it's original format. Do not encrypt passwords. Protect encryption keys more than any other asset. Apply the following test: Would you be happy leaving the data on a spreadsheet on a bus for everyone to read. Assume the attacker can get direct access to your database and protect it accordingly.
+DO: Use a strong encryption routine such as AES-256 where personally identifiable data needs to be restored to it's original format. Do not encrypt passwords. Protect encryption keys more than any other asset. Apply the following test: Would you be happy leaving the data on a spreadsheet on a bus for everyone to read. Assume the attacker can get direct access to your database and protect it accordingly.
 
 DO: Use TLS 1.2 for your entire site. Get a free certificate [LetsEncrypt.org](https://letsencrypt.org/).
 


### PR DESCRIPTION
Small change since AES-512 wouldn't be a valid key size (https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.197.pdf) changing it to something valid