### PR TITLE
Added JWT explicit revocation notes from JSON CS

### DIFF
--- a/cheatsheets/REST_Security_Cheat_Sheet.md
+++ b/cheatsheets/REST_Security_Cheat_Sheet.md
@@ -54,6 +54,8 @@ Some claims have been standardised and should be present in JWT used for access 
 - `exp` or expiration time - is the current time before the end of the validity period of this token?
 - `nbf` or not before time - is the current time after the start of the validity period of this token?
 
+As JWTs contain details of the authenticated entity (user etc.) a disconnect can occur between the JWT and the current state of the users session, for example, if the session is terminated earlier than the expiration time due to an explicit logout or an idle timeout. When an explicit session termination event occurs, a digest or hash of any associated JWTs should be submitted to a blacklist on the API which will invalidate that JWT for any requests until the expiration of the token. See the [JSON_Web_Token_Cheat_Sheet_for_Java](JSON_Web_Token_Cheat_Sheet_for_Java.md#token-explicit-revocation-by-the-user) for further details.
+
 # API Keys
 
 Public REST services without access control run the risk of being farmed leading to excessive bills for bandwidth or compute cycles. API keys can be used to mitigate this risk. They are also often used by organisation to monetize APIs; instead of blocking high-frequency calls, clients are given access in accordance to a purchased access plan.


### PR DESCRIPTION
Added a summary of the https://github.com/aussieklutz/CheatSheetSeries/blob/master/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.md#token-explicit-revocation-by-the-user section, along with a relative link to this section of the JSON_Web_Token_Cheat_Sheet_for_Java Cheat Sheet

This PR covers issue #144 .