### PR TITLE
X-Frame-Options is response header, not a client header

### DIFF
--- a/cheatsheets/REST_Security_Cheat_Sheet.md
+++ b/cheatsheets/REST_Security_Cheat_Sheet.md
@@ -133,7 +133,7 @@ Services including script code (e.g. JavaScript) in their responses must be espe
 
 To make sure the content of a given resources is interpreted correctly by the browser, the server should always send the `Content-Type` header with the correct content type, and preferably the `Content-Type` header should include a charset. The server should also send the `X-Content-Type-Options: nosniff` [security header](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#tab=Headers) to make sure the browser does not try to detect a different `Content-Type` than what is actually sent (can lead to XSS).
 
-Additionally the client should send the `X-Frame-Options: deny` [security header](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#tab=Headers) to protect against drag'n drop clickjacking attacks in older browsers.
+Additionally the server should send the `X-Frame-Options: deny` [security header](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#tab=Headers) to protect against drag'n drop clickjacking attacks in older browsers.
 
 # CORS
 


### PR DESCRIPTION
REST_Security_Cheat_Sheet had a typo recommending that the _client_ send the X-Frame-Options header, rather than the server.

This was referenced in an accepted Stack Overflow post here, which confused me: https://stackoverflow.com/a/34346453/544130

-------

Thank you for submitting a **P**ull **R**equest (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double check the file for other mistakes in order to fix all the issue on the current cheat sheet.

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see policy [here](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to website have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g.: defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).

If your PR is related to an issue. Please end your PR text with the following line:

```
This PR covers issue #<insert number here>.
```

Thank you again for your contribution :smiley:
