### PR TITLE
Add the contribution expiration policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,9 @@
 # How to contribute?
 
-**Note:** Regarding fixing of typo in existing cheat sheet, you can directly create a Pull Request otherwise follow the process below.
+**Notes:** 
+* Regarding fixing of a typo in existing cheat sheet, you can directly create a Pull Request otherwise follow the process below.
+* :warning: Pull Request marked as **WAITING_UPDATE** (indicate that the core team wait an update from the author of the Pull Request) that do not receive any update from the author in a timeframe superior to six months then will be closed.
+* :warning: If the assignees of an issue do not provide any Pull Request in a timeframe superior to six months then the issue will go back to the **HELP_WANTED** state and assignees will be removed.
 
 Follow these steps:
 


### PR DESCRIPTION
- [x] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).

This PR introduce the delay for the contribution.
