### PR TITLE
Minor typo and formatting improvements to authentication cheatsheet

### DIFF
--- a/cheatsheets/Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Authentication_Cheat_Sheet.md
@@ -24,12 +24,12 @@ For information on validating email addresses, please visit the [input validatio
 A key concern when using passwords for authentication is password strength. A "strong" password policy makes it difficult or even improbable for one to guess the password through either manual or automated means. The following characteristics define a strong password:
 
 - Password Length
-    - **Minimum** length of the passwords should be **enforced** by the application. Passwords **shorter than 8 characters** are considered to be weak ([NIST SP800-63B](https://pages.nist.gov/800-63-3/sp800-63b.html)). 
-    - **Maximum** password length should not be set **too low**, as it will prevent users from creating passphrases. Typical maximum length is 128 characters. It is important to set a maximum password length to prevent [long password Denail of Service attacks](https://www.acunetix.com/vulnerabilities/web/long-password-denial-of-service/).
+    - **Minimum** length of the passwords should be **enforced** by the application. Passwords **shorter than 8 characters** are considered to be weak ([NIST SP800-63B](https://pages.nist.gov/800-63-3/sp800-63b.html)).
+    - **Maximum** password length should not be set **too low**, as it will prevent users from creating passphrases. Typical maximum length is 128 characters. It is important to set a maximum password length to prevent [long password Denial of Service attacks](https://www.acunetix.com/vulnerabilities/web/long-password-denial-of-service/).
 
       When selecting maximum password length, limitation of hashing algorithm that will be used for hashing passwords, should be taken into consideration because some of them [have a maximum password length](https://security.stackexchange.com/questions/39849/does-bcrypt-have-a-maximum-password-length/39851#39851).
 
-- Do do not truncate passwords. Make sure that every character the user types in is actually included in the password. 
+- Do do not truncate passwords. Make sure that every character the user types in is actually included in the password.
 
 - Allow usage of **all** characters including unicode and whitespaces. There should be no password composition rules limiting the type of characters permitted.
 
@@ -107,7 +107,7 @@ IF USER_EXISTS(username) THEN
     password_hash=HASH(password)
     IS_VALID=LOOKUP_CREDENTIALS_IN_STORE(username, password_hash)
     IF NOT IS_VALID THEN
-        RETURN Error("Invalid Username or Password!")    
+        RETURN Error("Invalid Username or Password!")
     ENDIF
 ELSE
    RETURN Error("Invalid Username or Password!")
@@ -193,7 +193,7 @@ Open Authorization (OAuth) is a protocol that allows an application to authentic
 
 The recommendation is to use and implement OAuth 1.0a or OAuth 2.0, since the very first version (OAuth1.0) has been found to be vulnerable to session fixation.
 
-OAuth 2.0 relies on HTTPS for security and is currently used and implemented by API's from companies such as Facebook, Google, Twitter and Microsoft. OAuth1.0a is more difficult to use because it requires the use of cryptographic libraries for digital signatures. However, since OAuth1.0a does not rely on HTTPS for security it can be more suited for higher risk transactions.
+OAuth 2.0 relies on HTTPS for security and is currently used and implemented by APIs from companies such as Facebook, Google, Twitter and Microsoft. OAuth1.0a is more difficult to use because it requires the use of cryptographic libraries for digital signatures. However, since OAuth1.0a does not rely on HTTPS for security it can be more suited for higher risk transactions.
 
 ## OpenId
 

--- a/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.md
+++ b/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.md
@@ -197,7 +197,7 @@ DecodedJWT decodedToken = verifier.verify(token);
 
 ### Symptom
 
-This problem is inerrant to JWT token because a token become only invalid when it expires. The user has no built-in feature to explicitly revoke the validity of an token. So, in case of steal, a user cannot revoke the token itself and then block the attacker.
+This problem is inherent to JWT because a token become only invalid when it expires. The user has no built-in feature to explicitly revoke the validity of an token. This means that if it is stolen, a user cannot revoke the token itself and then block the attacker.
 
 ### How to prevent
 
@@ -467,7 +467,7 @@ It's occur when a application store the token in a way allowing this one to be:
 2.  Add it as a *Bearer* with JavaScript when calling services.
 3.  Add [fingerprint](JSON_Web_Token_Cheat_Sheet_for_Java.md#token-sidejacking) information to the token.
 
-By storing the token in browser *sessionStorage* container it expose the token to be steal in case of XSS issue. However, fingerprint added to the token prevent reuse of the stolen token by the attacker on his machine. To close a maximum of exploitation surfaces for an attacker, add a browser [Content Security Policy](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#csp) to harden the execution context.
+By storing the token in browser *sessionStorage* container it expose the token to being stolen by through an XSS attack. However, fingerprints added to the token prevent reuse of the stolen token by the attacker on their machine. To close a maximum of exploitation surfaces for an attacker, add a browser [Content Security Policy](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#csp) to harden the execution context.
 
 *Note:*
 


### PR DESCRIPTION
Fix a couple of typos and remove some trailing whitespace on a few lines