### PR TITLE
Add note on Unmarshaller instances being safe by default on OpenJDK 8+

### DIFF
--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -310,6 +310,10 @@ Unmarshaller um = jc.createUnmarshaller();
 um.unmarshal(xmlSource);
 ```
 
+### Java 8 and up
+
+Since [JDK-8010393](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8010393), which is in OpenJDK 8 beta 86, `javax.xml.bind.Unmarshaller` instances are safe by default. The other classes mentioned here are still unsafe by default in Java 8.
+
 ## XPathExpression
 
 A `javax.xml.xpath.XPathExpression` is similar to an Unmarshaller where it can't be configured securely by itself, so the untrusted data must be parsed through another securable XML parser first.

--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -316,7 +316,7 @@ Since [JDK-8010393](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8010393
 
 ## XPathExpression
 
-A `javax.xml.xpath.XPathExpression` is similar to an Unmarshaller where it can't be configured securely by itself, so the untrusted data must be parsed through another securable XML parser first.
+A `javax.xml.xpath.XPathExpression` can not be configured securely by itself, so the untrusted data must be parsed through another securable XML parser first.
 
 For example:
 


### PR DESCRIPTION
- [x] All the markdown files do not raise any validation policy violation, see policy [here](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
- [x] Any references to website have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g.: defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).

This PR covers issue #207 
