### PR TITLE
Improve .NET-Security section about Antiforgery-Tokens

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -563,7 +563,7 @@ e.g Startup.cs in the Configure()
 
 ### Cross-site request forgery
 
-DO NOT: Send sensitive data without validating Anti-Forgery-Tokens ([.NET](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks) / [.NET Core](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration)).
+DO NOT: Send sensitive data without validating Anti-Forgery-Tokens ([.NET](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks) / [.NET Core](https://docs.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-3.0#aspnet-core-antiforgery-configuration)).
 
 DO: Send the anti-forgery token with every POST/PUT request:
 
@@ -615,10 +615,9 @@ public void RemoveAntiForgeryCookie(Controller controller)
 
 #### Using .NET Core 2.0 or later:
 
-Starting with .NET Core 2.0 it is possible to [automatically generate and verify the antiforgery token](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration).
+Starting with .NET Core 2.0 it is possible to [automatically generate and verify the antiforgery token](https://docs.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-3.0#aspnet-core-antiforgery-configuration).
 
-If you are using [tag-helpers](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro), which is the default for most web project templates, then all forms will automatically send the anti-forgery token.
-You can check if tag-helpers are enabled by checking if your main `_ViewImports.cshtml` file contains:
+If you are using [tag-helpers](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro), which is the default for most web project templates, then all forms will automatically send the anti-forgery token. You can check if tag-helpers are enabled by checking if your main `_ViewImports.cshtml` file contains:
 
 ```csharp
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -563,11 +563,11 @@ e.g Startup.cs in the Configure()
 
 ### Cross-site request forgery
 
-DO NOT: Send sensitive data without validating Anti-Forgery-Tokens.
+DO NOT: Send sensitive data without validating Anti-Forgery-Tokens ([.NET](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks) / [.NET Core](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration)).
 
 DO: Send the anti-forgery token with every POST/PUT request:
 
-#### Using the full .NET-Framework :
+#### Using .NET Framework:
 
 ```csharp
 using (Html.BeginForm("LogOff", "Account", FormMethod.Post, new { id = "logoutForm", 
@@ -615,9 +615,9 @@ public void RemoveAntiForgeryCookie(Controller controller)
 
 #### Using .NET Core 2.0 or later:
 
-After .NET Core 2.0 it is possible to automatically generate and verify the antiforgery token.
+After .NET Core 2.0 it is possible to [automatically generate and verify the antiforgery token](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration).
 
-If you are using tag-helpers - which is the default for most web project templates - all forms will automatically send the anti-forgery token.
+If you are using [tag-helpers](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro) - which is the default for most web project templates - all forms will automatically send the anti-forgery token.
 You can check if tag-helpers are enabled by checking if your main `_ViewImports.cshtml` file contains:
 
 ```csharp
@@ -636,11 +636,11 @@ If you are not using tag-helpers or `IHtmlHelper.BeginForm`, forms must have the
 
 And then add the `[AutoValidateAntiforgeryToken]` attribute to the action method. This will validate the token for all HTTP methods other than GET, HEAD, OPTIONS and TRACE.
 
-#### Using .Net Core 2.0 or full .NET-Framework with AJAX
+#### Using .Net Core 2.0 or .NET Framework with AJAX
 
 You will need to attach the anti-forgery token to AJAX requests.
 
-If you are using jQuery in an ASP .NET Core MVC view this can be achieved using this snippet:
+If you are using jQuery in an ASP.NET Core MVC view this can be achieved using this snippet:
 
 ```javascript
 @inject  Microsoft.AspNetCore.Antiforgery.IAntiforgery antiforgeryProvider
@@ -656,11 +656,9 @@ $.ajax(
 })
 ```
 
-If you are using the full .NET-Framework you can find some snippets [here](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks#anti-csrf-and-ajax).
+If you are using the .NET Framework, you can find some code snippets [here](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks#anti-csrf-and-ajax).
 
 More information can be found [here](Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md) for Cross-Site Request Forgery.
-
-More information about Anti-Forgery-Tokens can be found [here](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration) for .NET Core and [here](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks) for the full .NET-Framework.
 
 ## A7 Cross-Site Scripting (XSS)
 

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -617,8 +617,8 @@ public void RemoveAntiForgeryCookie(Controller controller)
 
 After .NET Core 2.0 it is possible to automatically generate and verify the antiforgery token.
 
-If you are using tag-helpers - what is the default for most web project templates - all forms will automatically send the anti-forgery token.
-You can check if tag-helpers are enabled by checking if your main `_ViewImports.cshtml`- file contains:
+If you are using tag-helpers - which is the default for most web project templates - all forms will automatically send the anti-forgery token.
+You can check if tag-helpers are enabled by checking if your main `_ViewImports.cshtml` file contains:
 
 ```csharp
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
@@ -638,7 +638,7 @@ And then add the `[AutoValidateAntiforgeryToken]` attribute to the action method
 
 #### Using .Net Core 2.0 or full .NET-Framework with AJAX
 
-You will need to attach the anti-forgery token to Ajax requests.
+You will need to attach the anti-forgery token to AJAX requests.
 
 If you are using jQuery in an ASP .NET Core MVC view this can be achieved using this snippet:
 
@@ -656,11 +656,11 @@ $.ajax(
 })
 ```
 
-If you are using the full .NET-Framework you can find some snippets [here](https://docs.microsoft.com/de-de/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks#anti-csrf-and-ajax).
+If you are using the full .NET-Framework you can find some snippets [here](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks#anti-csrf-and-ajax).
 
 More information can be found [here](Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md) for Cross-Site Request Forgery.
 
-More information about Anti-Forgery-Tokens can be found [here](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration) for .NET Core and [here](https://docs.microsoft.com/de-de/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks) for the full .NET-Framework.
+More information about Anti-Forgery-Tokens can be found [here](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration) for .NET Core and [here](https://docs.microsoft.com/en-us/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks) for the full .NET-Framework.
 
 ## A7 Cross-Site Scripting (XSS)
 

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -568,6 +568,7 @@ DO NOT: Send sensitive data without validating Anti-Forgery-Tokens.
 DO: Send the anti-forgery token with every POST/PUT request:
 
 #### Using the full .NET-Framework :
+
 ```csharp
 using (Html.BeginForm("LogOff", "Account", FormMethod.Post, new { id = "logoutForm", 
                         @class = "pull-right" }))
@@ -612,7 +613,6 @@ public void RemoveAntiForgeryCookie(Controller controller)
 }
 ```
 
-
 #### Using .NET Core 2.0 or later:
 
 After .NET Core 2.0 it is possible to automatically generate and verify the antiforgery token.
@@ -641,6 +641,7 @@ And then add the `[AutoValidateAntiforgeryToken]` attribute to the action method
 You will need to attach the anti-forgery token to Ajax requests.
 
 If you are using jQuery in an ASP .NET Core MVC view this can be achieved using this snippet:
+
 ```javascript
 @inject  Microsoft.AspNetCore.Antiforgery.IAntiforgery antiforgeryProvider
 $.ajax(

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -615,9 +615,9 @@ public void RemoveAntiForgeryCookie(Controller controller)
 
 #### Using .NET Core 2.0 or later:
 
-After .NET Core 2.0 it is possible to [automatically generate and verify the antiforgery token](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration).
+Starting with .NET Core 2.0 it is possible to [automatically generate and verify the antiforgery token](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration).
 
-If you are using [tag-helpers](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro) - which is the default for most web project templates - all forms will automatically send the anti-forgery token.
+If you are using [tag-helpers](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro), which is the default for most web project templates, then all forms will automatically send the anti-forgery token.
 You can check if tag-helpers are enabled by checking if your main `_ViewImports.cshtml` file contains:
 
 ```csharp
@@ -626,7 +626,7 @@ You can check if tag-helpers are enabled by checking if your main `_ViewImports.
 
 `IHtmlHelper.BeginForm` also sends anti-forgery-tokens automatically.
 
-If you are not using tag-helpers or `IHtmlHelper.BeginForm`, forms must have the requisite helper as seen here:
+Unless you are using tag-helpers or `IHtmlHelper.BeginForm`, you must use the requisite helper on forms as seen here:
 
 ```html
 <form action="RelevantAction" >
@@ -643,11 +643,27 @@ services.AddMvc(options =>
 });
 ```
 
-If you need to disable the attribute validation for a specific method you can add the [IgnoreAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.ignoreantiforgerytokenattribute?view=aspnetcore-2.2) attribute to this action method. 
+If you need to disable the attribute validation for a specific method you can add the [IgnoreAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.ignoreantiforgerytokenattribute?view=aspnetcore-2.2) attribute to this action method: 
 
-If you need to also validate the token on GET, HEAD, OPTIONS or TRACE - requests you can add the [ValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.validateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to the action method or parent class.
+```csharp
+[IgnoreAntiforgeryToken]
+public IActionResult OnPostAsync()
+```
 
-In case you can't use a global action filter, add the [AutoValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.autovalidateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to your controller classes.
+If you need to also validate the token on GET, HEAD, OPTIONS or TRACE - requests you can add the [ValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.validateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to the action method or parent class:
+
+```csharp
+[HttpGet]
+[ValidateAntiforgeryToken]
+public IActionResult DoSomethingDangerous()
+```
+
+In case you can't use a global action filter, add the [AutoValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.autovalidateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to your controller classes:
+
+```csharp
+[AutoValidateAntiforgeryToken]
+public class UserController
+```
 
 #### Using .Net Core 2.0 or .NET Framework with AJAX
 

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -634,7 +634,20 @@ If you are not using tag-helpers or `IHtmlHelper.BeginForm`, forms must have the
 </form>
 ```
 
-And then add the `[AutoValidateAntiforgeryToken]` attribute to the action method. This will validate the token for all HTTP methods other than GET, HEAD, OPTIONS and TRACE.
+To automatically validate all requests other than GET, HEAD, OPTIONS and TRACE you need to add a global action filter with the [AutoValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.autovalidateantiforgerytokenattribute?view=aspnetcore-2.2) attribute inside your `Startup.cs` ([Source](https://andrewlock.net/automatically-validating-anti-forgery-tokens-in-asp-net-core-with-the-autovalidateantiforgerytokenattribute/)):
+
+```csharp
+services.AddMvc(options =>
+{
+    options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
+});
+```
+
+If you need to disable the attribute validation for a specific method you can add the [IgnoreAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.ignoreantiforgerytokenattribute?view=aspnetcore-2.2) attribute to this action method. 
+
+If you need to also validate the token on GET, HEAD, OPTIONS or TRACE - requests you can add the [ValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.validateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to the action method or parent class.
+
+In case you can't use a global action filter, add the [AutoValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.autovalidateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to your controller classes.
 
 #### Using .Net Core 2.0 or .NET Framework with AJAX
 

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -634,7 +634,7 @@ If you are not using tag-helpers or `IHtmlHelper.BeginForm`, forms must have the
 </form>
 ```
 
-To automatically validate all requests other than GET, HEAD, OPTIONS and TRACE you need to add a global action filter with the [AutoValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.autovalidateantiforgerytokenattribute?view=aspnetcore-2.2) attribute inside your `Startup.cs` ([Source](https://andrewlock.net/automatically-validating-anti-forgery-tokens-in-asp-net-core-with-the-autovalidateantiforgerytokenattribute/)):
+To automatically validate all requests other than GET, HEAD, OPTIONS and TRACE you need to add a global action filter with the [AutoValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.autovalidateantiforgerytokenattribute?view=aspnetcore-2.2) attribute inside your `Startup.cs` as mentioned in the following [article](https://andrewlock.net/automatically-validating-anti-forgery-tokens-in-asp-net-core-with-the-autovalidateantiforgerytokenattribute/):
 
 ```csharp
 services.AddMvc(options =>

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -563,8 +563,11 @@ e.g Startup.cs in the Configure()
 
 ### Cross-site request forgery
 
+DO NOT: Send sensitive data without validating Anti-Forgery-Tokens.
+
 DO: Send the anti-forgery token with every POST/PUT request:
 
+#### Using the full .NET-Framework :
 ```csharp
 using (Html.BeginForm("LogOff", "Account", FormMethod.Post, new { id = "logoutForm", 
                         @class = "pull-right" }))
@@ -609,9 +612,21 @@ public void RemoveAntiForgeryCookie(Controller controller)
 }
 ```
 
-NB: You will need to attach the anti-forgery token to Ajax requests.
 
-After .NET Core 2.0 it is possible to automatically generate and verify the antiforgery token. Forms must have the requisite helper as seen here:
+#### Using .NET Core 2.0 or later:
+
+After .NET Core 2.0 it is possible to automatically generate and verify the antiforgery token.
+
+If you are using tag-helpers - what is the default for most web project templates - all forms will automatically send the anti-forgery token.
+You can check if tag-helpers are enabled by checking if your main `_ViewImports.cshtml`- file contains:
+
+```csharp
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+```
+
+`IHtmlHelper.BeginForm` also sends anti-forgery-tokens automatically.
+
+If you are not using tag-helpers or `IHtmlHelper.BeginForm`, forms must have the requisite helper as seen here:
 
 ```html
 <form action="RelevantAction" >
@@ -619,9 +634,32 @@ After .NET Core 2.0 it is possible to automatically generate and verify the anti
 </form>
 ```
 
-And then add the `[AutoValidateAntiforgeryToken]` attribute to the action result.
+And then add the `[AutoValidateAntiforgeryToken]` attribute to the action method. This will validate the token for all HTTP methods other than GET, HEAD, OPTIONS and TRACE.
+
+#### Using .Net Core 2.0 or full .NET-Framework with AJAX
+
+You will need to attach the anti-forgery token to Ajax requests.
+
+If you are using jQuery in an ASP .NET Core MVC view this can be achieved using this snippet:
+```javascript
+@inject  Microsoft.AspNetCore.Antiforgery.IAntiforgery antiforgeryProvider
+$.ajax(
+{
+    type: "POST",
+    url: '@Url.Action("Action", "Controller")',
+    contentType: "application/x-www-form-urlencoded; charset=utf-8",
+    data: {
+        id: id,
+        '__RequestVerificationToken': '@antiforgeryProvider.GetAndStoreTokens(this.Context).RequestToken'
+    }
+})
+```
+
+If you are using the full .NET-Framework you can find some snippets [here](https://docs.microsoft.com/de-de/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks#anti-csrf-and-ajax).
 
 More information can be found [here](Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md) for Cross-Site Request Forgery.
+
+More information about Anti-Forgery-Tokens can be found [here](https://github.com/aspnet/AspNetCore.Docs/blob/master/aspnetcore/security/anti-request-forgery.md#aspnet-core-antiforgery-configuration) for .NET Core and [here](https://docs.microsoft.com/de-de/aspnet/web-api/overview/security/preventing-cross-site-request-forgery-csrf-attacks) for the full .NET-Framework.
 
 ## A7 Cross-Site Scripting (XSS)
 

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -643,14 +643,20 @@ services.AddMvc(options =>
 });
 ```
 
-If you need to disable the attribute validation for a specific method you can add the [IgnoreAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.ignoreantiforgerytokenattribute?view=aspnetcore-2.2) attribute to this action method: 
+If you need to disable the attribute validation for a specific method on a controller you can add the [IgnoreAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.ignoreantiforgerytokenattribute?view=aspnetcore-2.2) attribute to the controller method (for MVC controllers) or parent class (for Razor pages): 
 
 ```csharp
 [IgnoreAntiforgeryToken]
-public IActionResult OnPostAsync()
+[HttpDelete]
+public IActionResult Delete()
 ```
 
-If you need to also validate the token on GET, HEAD, OPTIONS or TRACE - requests you can add the [ValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.validateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to the action method or parent class:
+```csharp
+[IgnoreAntiforgeryToken]
+public class UnsafeModel : PageModel
+```
+
+If you need to also validate the token on GET, HEAD, OPTIONS or TRACE - requests you can add the [ValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.validateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to the controller method (for MVC controllers) or parent class (for Razor pages):
 
 ```csharp
 [HttpGet]
@@ -658,11 +664,22 @@ If you need to also validate the token on GET, HEAD, OPTIONS or TRACE - requests
 public IActionResult DoSomethingDangerous()
 ```
 
-In case you can't use a global action filter, add the [AutoValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.autovalidateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to your controller classes:
+```csharp
+[HttpGet]
+[ValidateAntiforgeryToken]
+public class SafeModel : PageModel
+```
+
+In case you can't use a global action filter, add the [AutoValidateAntiforgeryToken](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.autovalidateantiforgerytokenattribute?view=aspnetcore-2.2) attribute to your controller classes or razor page models:
 
 ```csharp
 [AutoValidateAntiforgeryToken]
 public class UserController
+```
+
+```csharp
+[AutoValidateAntiforgeryToken]
+public class SafeModel : PageModel
 ```
 
 #### Using .Net Core 2.0 or .NET Framework with AJAX


### PR DESCRIPTION
Mainly update information about .NET Core and AJAX with Antiforgery-Tokens and add some reference links.

This PR covers issue #108.