### PR TITLE
update on php hardening options

### DIFF
--- a/cheatsheets/PHP_Configuration_Cheat_Sheet.md
+++ b/cheatsheets/PHP_Configuration_Cheat_Sheet.md
@@ -111,7 +111,7 @@ html_errors             = Off
 ## Suhosin (PHP 5.X)
 
 Consider using [Suhosin](https://suhosin.org/) if you want to patch many custom security flaws in various parts of PHP. 
-Note: only usable in 5.X branch and should not be used in prod now as 5.X is EOL.
+> **Suhosin is only usable on the 5.X branch and should not be used on production servers as 5.X reached EOL.**
 
 ## Snuggleupagus (PHP 7.X)
 

--- a/cheatsheets/PHP_Configuration_Cheat_Sheet.md
+++ b/cheatsheets/PHP_Configuration_Cheat_Sheet.md
@@ -10,10 +10,6 @@ For general PHP codebase security please refer to the two following great guides
 
 # PHP Configuration and Deployment
 
-## Suhosin
-
-Consider using [Suhosin](http://www.hardened-php.net/suhosin/index.html) if you want to patch many custom security flaws in various parts of PHP. 
-
 ## php.ini
 
 Some of following settings need to be adapted to your system, in particular `session.save_path`, `session.cookie_path` (e.g. `/var/www/mysite`), and `session.cookie_domain` (e.g. `ExampleSite.com`). 
@@ -111,3 +107,14 @@ report_memleaks         = On
 track_errors            = Off
 html_errors             = Off
 ```
+
+
+## Suhosin (only usable in 5.X branch and should not be used in prod now as 5.X is EOL)
+
+Consider using [Suhosin](https://suhosin.org/) if you want to patch many custom security flaws in various parts of PHP. 
+
+
+## Snuggleupagus (7.X Series, beta product use with caution)
+
+[Snuggleupagus](https://github.com/nbs-system/snuffleupagus) is continuing what [Suhosin started](https://github.com/sektioneins/suhosin7#php-73-support-and-snufflepagus). It allows you to control PHP behaviour at a deeper level. [Detailed documentation is available here](https://snuffleupagus.readthedocs.io/)
+

--- a/cheatsheets/PHP_Configuration_Cheat_Sheet.md
+++ b/cheatsheets/PHP_Configuration_Cheat_Sheet.md
@@ -108,13 +108,10 @@ track_errors            = Off
 html_errors             = Off
 ```
 
-
 ## Suhosin (only usable in 5.X branch and should not be used in prod now as 5.X is EOL)
 
 Consider using [Suhosin](https://suhosin.org/) if you want to patch many custom security flaws in various parts of PHP. 
 
-
 ## Snuggleupagus (7.X Series, beta product use with caution)
 
 [Snuggleupagus](https://github.com/nbs-system/snuffleupagus) is continuing what [Suhosin started](https://github.com/sektioneins/suhosin7#php-73-support-and-snufflepagus). It allows you to control PHP behaviour at a deeper level. [Detailed documentation is available here](https://snuffleupagus.readthedocs.io/)
-

--- a/cheatsheets/PHP_Configuration_Cheat_Sheet.md
+++ b/cheatsheets/PHP_Configuration_Cheat_Sheet.md
@@ -108,10 +108,12 @@ track_errors            = Off
 html_errors             = Off
 ```
 
-## Suhosin (only usable in 5.X branch and should not be used in prod now as 5.X is EOL)
+## Suhosin (PHP 5.X)
 
 Consider using [Suhosin](https://suhosin.org/) if you want to patch many custom security flaws in various parts of PHP. 
+Note: only usable in 5.X branch and should not be used in prod now as 5.X is EOL.
 
-## Snuggleupagus (7.X Series, beta product use with caution)
+## Snuggleupagus (PHP 7.X)
 
-[Snuggleupagus](https://github.com/nbs-system/snuffleupagus) is continuing what [Suhosin started](https://github.com/sektioneins/suhosin7#php-73-support-and-snufflepagus). It allows you to control PHP behaviour at a deeper level. [Detailed documentation is available here](https://snuffleupagus.readthedocs.io/)
+[Snuggleupagus](https://github.com/nbs-system/snuffleupagus) is continuing what [Suhosin started](https://github.com/sektioneins/suhosin-ng/wiki/News#2019-07-17-suhosin-is-back). It allows you to control PHP behaviour at a deeper level. [Detailed documentation is available here](https://snuffleupagus.readthedocs.io/)
+Note: 7.X Series, beta product use with caution


### PR DESCRIPTION
1. I have moved suhosin to the bottom as its only applicable for 5.X and not 7.X series and 5.x is EOL
2. I have corrected the link to project page instead of a 3 pager unknown wordpress blog
3. I have added snuggleupagus which is the successor of suhosin however its in beta phase hence added at the bottom.

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 
