### PR TITLE
Grammar

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 
 
-> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issue on the current cheat sheet.
+> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues on the current cheat sheet.
 
 Please make sure that for your contribution:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.
 Please make sure that for your contribution:
 
 - [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
-- [ ] All the markdown files do not raise any validation policy violation, see the policy [here](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
+- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
 - [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
 - [ ] All your assets are stored in the **assets** folder.
 - [ ] All the images used are in the **PNG** format.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Please make sure that for your contribution:
 - [ ] You verified/tested the effectiveness of your contribution (e.g.: the defensive code proposed is really an effective remediation? Please verify it works!).
 - [ ] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).
 
-If your PR is related to an issue. Please end your PR text with the following line:
+If your PR is related to an issue, please finish your PR text with the following line:
 
 This PR covers issue #<insert number here>.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.
 Please make sure that for your contribution:
 
 - [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
-- [ ] All the markdown files do not raise any validation policy violation, see policy [here](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
+- [ ] All the markdown files do not raise any validation policy violation, see the policy [here](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
 - [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
 - [ ] All your assets are stored in the **assets** folder.
 - [ ] All the images used are in the **PNG** format.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 
 
-> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double check the file for other mistakes in order to fix all the issue on the current cheat sheet.
+> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issue on the current cheat sheet.
 
 Please make sure that for your contribution:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Please make sure that for your contribution:
 - [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
 - [ ] All your assets are stored in the **assets** folder.
 - [ ] All the images used are in the **PNG** format.
-- [ ] Any references to website have been formatted as [TEXT](URL)
+- [ ] Any references to websites have been formatted as [TEXT](URL)
 - [ ] You verified/tested the effectiveness of your contribution (e.g.: defensive code proposed is really an effective remediation? Please verify it works!).
 - [ ] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 
 
-> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues on the current cheat sheet.
+> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.
 
 Please make sure that for your contribution:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Please make sure that for your contribution:
 - [ ] All your assets are stored in the **assets** folder.
 - [ ] All the images used are in the **PNG** format.
 - [ ] Any references to websites have been formatted as [TEXT](URL)
-- [ ] You verified/tested the effectiveness of your contribution (e.g.: defensive code proposed is really an effective remediation? Please verify it works!).
+- [ ] You verified/tested the effectiveness of your contribution (e.g.: the defensive code proposed is really an effective remediation? Please verify it works!).
 - [ ] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).
 
 If your PR is related to an issue. Please end your PR text with the following line:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Please make sure that for your contribution:
 - [ ] All your assets are stored in the **assets** folder.
 - [ ] All the images used are in the **PNG** format.
 - [ ] Any references to websites have been formatted as [TEXT](URL)
-- [ ] You verified/tested the effectiveness of your contribution (e.g.: the defensive code proposed is really an effective remediation? Please verify it works!).
+- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
 - [ ] The CI build of your PR pass, see the build status [here](https://travis-ci.org/OWASP/CheatSheetSeries/pull_requests).
 
 If your PR is related to an issue, please finish your PR text with the following line:


### PR DESCRIPTION
> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double check the file for other mistakes in order to fix all the issue on the current cheat sheet.

Done.

Note: most of these corrections were suggested by app.grammarly.com. The choices are all mine, but advertising credit goes to them. While I've marked the first commit as a spelling fix, that's arguable, both `double` and `check` are words, but they aren't the intended word. So, it's a misspelling of `double-check` just as `their` and `they're` are both words and using the wrong word would be a misspelling.