### PR TITLE
Update Suhosin text in PHP hardening CS

### DIFF
--- a/cheatsheets/PHP_Configuration_Cheat_Sheet.md
+++ b/cheatsheets/PHP_Configuration_Cheat_Sheet.md
@@ -10,10 +10,6 @@ For general PHP codebase security please refer to the two following great guides
 
 # PHP Configuration and Deployment
 
-## Suhosin
-
-Consider using [Suhosin](http://www.hardened-php.net/suhosin/index.html) if you want to patch many custom security flaws in various parts of PHP. 
-
 ## php.ini
 
 Some of following settings need to be adapted to your system, in particular `session.save_path`, `session.cookie_path` (e.g. `/var/www/mysite`), and `session.cookie_domain` (e.g. `ExampleSite.com`). 
@@ -111,3 +107,9 @@ report_memleaks         = On
 track_errors            = Off
 html_errors             = Off
 ```
+
+## Suhosin
+
+[Suhosin](http://www.hardened-php.net/suhosin/index.html) is a patch to PHP which provides a number of hardening and security features that are not available in the default PHP build. However, Suhosin only works with PHP 5, which is **unsupported** and **should not be used**.
+
+There are a number of projects that have attempted to implement similar features for PHP 7 such as [Snuffleupagus](https://snuffleupagus.readthedocs.io/) and [Suhosin-ng](https://github.com/sektioneins/suhosin-ng/wiki/News), but these are both in the pre-release stage, and as such **should not be used in production**.


### PR DESCRIPTION
Implement the changes discussed in #239 about Suhosin, pending a wider review of the CS in #232.

Links to Snuffleupagus and Suhosin-ng are included with an appropriate warning not because we're recommending their use, but because it preempts the obvious question of "what about PHP 7" when it's stated that Suhosin only works for PHP 5.