### PR TITLE
Update DotNet_Security_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -281,7 +281,7 @@ e.g Validating user input using [IPAddress.TryParse Method](https://docs.microso
 string ipAddress = "127.0.0.1";
  
 //check to make sure an ip address was provided    
-if (string.IsNullOrEmpty(ipAddress))  
+if (!string.IsNullOrEmpty(ipAddress))  
 {
 	// Create an instance of IPAddress for the specified address string (in 
 	// dotted-quad, or colon-hexadecimal notation).


### PR DESCRIPTION
**What is the issue?**
The comment for this line says we're "check[ing] to make sure an ip address was provided" but we only execute the code after it if the string is null or empty. 

**How is it being solved?**
Check the string is NOT null or empty.