### PR TITLE
Fix dead links for implementing link checker

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -367,7 +367,7 @@ DO: Use TLS 1.2 for your entire site. Get a free certificate [LetsEncrypt.org](h
 
 DO NOT: [Allow SSL, this is now obsolete](https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#22-use-secure-protocols).
 
-DO: Have a strong TLS policy (see [SSL Best Practises](http://www.ssllabs.com/projects/best-practises/)), use TLS 1.2 wherever possible. Then check the configuration using [SSL Test](https://www.ssllabs.com/ssltest/) or [TestSSL](https://testssl.sh/).
+DO: Have a strong TLS policy (see [SSL Best Practises](https://www.ssllabs.com/projects/best-practices/index.html)), use TLS 1.2 wherever possible. Then check the configuration using [SSL Test](https://www.ssllabs.com/ssltest/) or [TestSSL](https://testssl.sh/).
 
 DO: Ensure headers are not disclosing information about your application. See [HttpHeaders.cs](https://github.com/johnstaveley/SecurityEssentials/blob/master/SecurityEssentials/Core/HttpHeaders.cs) , [Dionach StripHeaders](https://github.com/Dionach/StripHeaders/), disable via `web.config` or [startup.cs](https://medium.com/bugbountywriteup/security-headers-1c770105940b):
 
@@ -391,7 +391,7 @@ e.g Web.config
             <remove name="X-Powered-By"/>
         </customHeaders>
     </httpProtocol>
-</system.webServer>    
+</system.webServer>
 ```
 
 e.g Startup.cs
@@ -459,15 +459,15 @@ Protect LogOn, Registration and password reset methods against brute force attac
 [HttpPost]
 [AllowAnonymous]
 [ValidateAntiForgeryToken]
-[AllowXRequestsEveryXSecondsAttribute(Name = "LogOn", 
-Message = "You have performed this action more than {x} times in the last {n} seconds.", 
+[AllowXRequestsEveryXSecondsAttribute(Name = "LogOn",
+Message = "You have performed this action more than {x} times in the last {n} seconds.",
 Requests = 3, Seconds = 60)]
 public async Task<ActionResult> LogOn(LogOnViewModel model, string returnUrl)
 ```
 
 DO NOT: Roll your own authentication or session management, use the one provided by .Net
 
-DO NOT: Tell someone if the account exists on LogOn, Registration or Password reset. Say something like 'Either the username or password was incorrect', or 'If this account exists then a reset token will be sent to the registered email address'. This protects against account enumeration. 
+DO NOT: Tell someone if the account exists on LogOn, Registration or Password reset. Say something like 'Either the username or password was incorrect', or 'If this account exists then a reset token will be sent to the registered email address'. This protects against account enumeration.
 
 The feedback to the user should be identical whether or not the account exists, both in terms of content and behavior: e.g. if the response takes 50% longer when the account is real then membership information can be guessed and tested.
 
@@ -715,9 +715,9 @@ Then set in config:
 
 ```xml
 <system.web>
-<httpRuntime targetFramework="4.5" 
-enableVersionHeader="false" 
-encoderType="Microsoft.Security.Application.AntiXssEncoder, AntiXssLibrary" 
+<httpRuntime targetFramework="4.5"
+enableVersionHeader="false"
+encoderType="Microsoft.Security.Application.AntiXssEncoder, AntiXssLibrary"
 maxRequestLength="4096" />
 ```
 
@@ -729,8 +729,8 @@ DO: Enable a [Content Security Policy](Content_Security_Policy_Cheat_Sheet.md#co
 <system.webServer>
     <httpProtocol>
         <customHeaders>
-            <add name="Content-Security-Policy" 
-                value="default-src 'none'; style-src 'self'; img-src 'self'; 
+            <add name="Content-Security-Policy"
+                value="default-src 'none'; style-src 'self'; img-src 'self';
                 font-src 'self'; script-src 'self'" />
 ```
 
@@ -743,12 +743,12 @@ Information about Insecure Deserialization can be found on this [cheat sheet](De
 DO NOT: Accept Serialized Objects from Untrusted Sources
 
 DO: Validate User Input
-Malicious users are able to use objects like cookies to insert malicious information to change user roles. In some cases, hackers are able to elevate their privileges to administrator rights by using a pre-existing or cached password hash from a previous session. 
+Malicious users are able to use objects like cookies to insert malicious information to change user roles. In some cases, hackers are able to elevate their privileges to administrator rights by using a pre-existing or cached password hash from a previous session.
 
 DO: Prevent Deserialization of Domain Objects
 
 DO: Run the Deserialization Code with Limited Access Permissions
-If a deserialized hostile object tries to initiate a system processes or access a resource within the server or the host's OS, it will be denied access and a permission flag will be raised so that a system administrator is made aware of any anomalous activity on the server. 
+If a deserialized hostile object tries to initiate a system processes or access a resource within the server or the host's OS, it will be denied access and a permission flag will be raised so that a system administrator is made aware of any anomalous activity on the server.
 
 More information can be found here: [Deserialization Cheat Sheet](Deserialization_Cheat_Sheet.md#net-csharp)
 

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -18,8 +18,8 @@ Remember that third-party libraries have to be updated separately and not all of
 
 Receive security notifications by selecting the "Watch" button at the following repositories:
 
-- [.NET Core Security Announcements](https://github.com/dotnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) 
-- [ASP.NET Core & Entity Framework Core Security Announcements](https://github.com/aspnet/Announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity) 
+- [.NET Core Security Announcements](https://github.com/dotnet/announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity)
+- [ASP.NET Core & Entity Framework Core Security Announcements](https://github.com/aspnet/Announcements/issues?q=is%3Aopen+is%3Aissue+label%3ASecurity)
 
 # .NET Framework Guidance
 
@@ -142,14 +142,14 @@ if ((string)ViewState[AntiXsrfTokenKey] != _antiXsrfTokenValue ||
        <requestFiltering removeServerHeader="true" />
      </security>
      <staticContent>
-       <clientCache cacheControlCustom="public" 
-            cacheControlMode="UseMaxAge"    
-            cacheControlMaxAge="1.00:00:00" 
+       <clientCache cacheControlCustom="public"
+            cacheControlMode="UseMaxAge"
+            cacheControlMaxAge="1.00:00:00"
             setEtag="true" />
      </staticContent>
      <httpProtocol>
        <customHeaders>
-         <add name="Content-Security-Policy" 
+         <add name="Content-Security-Policy"
             value="default-src 'none'; style-src 'self'; img-src 'self'; font-src 'self'" />
          <add name="X-Content-Type-Options" value="NOSNIFF" />
          <add name="X-Frame-Options" value="DENY" />
@@ -217,9 +217,9 @@ HttpContext.Current.Response.Headers.Remove("Server");
 
 # ASP NET MVC Guidance
 
-ASP.NET MVC (Model–View–Controller) is a contemporary web application framework that uses more standardized HTTP communication than the Web Forms postback model. 
+ASP.NET MVC (Model–View–Controller) is a contemporary web application framework that uses more standardized HTTP communication than the Web Forms postback model.
 
-The OWASP Top 10 2017 lists the most prevalent and dangerous threats to web security in the world today and is reviewed every 3 years. 
+The OWASP Top 10 2017 lists the most prevalent and dangerous threats to web security in the world today and is reviewed every 3 years.
 
 This section is based on this. Your approach to securing your web application should be to start at the top threat A1 below and work down, this will ensure that any time spent on security will be spent most effectively spent and cover the top threats first and lesser threats afterwards. After covering the top 10 it is generally advisable to assess for other threats or get a professionally completed Penetration Test.
 
@@ -241,13 +241,13 @@ context.Database.ExecuteSqlCommand(
     new SqlParameter("@Id", id));
 ```
 
-DO NOT: Concatenate strings anywhere in your code and execute them against your database (Known as dynamic sql). 
+DO NOT: Concatenate strings anywhere in your code and execute them against your database (Known as dynamic sql).
 
 NB: You can still accidentally do this with ORMs or Stored procedures so check everywhere.
 
 e.g
 
-```sql 
+```sql
 string strQry = "SELECT * FROM Users WHERE UserName='" + txtUser.Text + "' AND Password='" 
                 + txtPassword.Text + "'";
 EXEC strQry // SQL Injection vulnerability!
@@ -279,11 +279,11 @@ e.g Validating user input using [IPAddress.TryParse Method](https://docs.microso
 ``` csharp
 //User input
 string ipAddress = "127.0.0.1";
- 
-//check to make sure an ip address was provided    
-if (!string.IsNullOrEmpty(ipAddress))  
+
+//check to make sure an ip address was provided
+if (!string.IsNullOrEmpty(ipAddress))
 {
-	// Create an instance of IPAddress for the specified address string (in 
+	// Create an instance of IPAddress for the specified address string (in
 	// dotted-quad, or colon-hexadecimal notation).
 	if (IPAddress.TryParse(ipAddress, out var address))
 	{
@@ -298,10 +298,10 @@ if (!string.IsNullOrEmpty(ipAddress))
     ...
 }
  ```
- 
+
 ### LDAP injection
 
-Almost any characters can be used in Distinguished Names. However, some must be escaped with the backslash `\` escape character. A table showing which characters that should be escaped for Active Directory can be found at the in the [LDAP Injection Prevention Cheat Sheet](LDAP_Injection_Prevention_Cheat_Sheet.md#introduction). 
+Almost any characters can be used in Distinguished Names. However, some must be escaped with the backslash `\` escape character. A table showing which characters that should be escaped for Active Directory can be found at the in the [LDAP Injection Prevention Cheat Sheet](LDAP_Injection_Prevention_Cheat_Sheet.md#introduction).
 
 NB: The space character must be escaped only if it is the leading or trailing character in a component name, such as a Common Name. Embedded spaces should not be escaped.
 
@@ -314,7 +314,7 @@ ASP.net Core Identity framework is well configured by default, where it uses sec
 
 DO: Set secure password policy
 
-e.g ASP.net Core Identity 
+e.g ASP.net Core Identity
 
 ``` csharp
 //startup.cs
@@ -327,20 +327,20 @@ services.Configure<IdentityOptions>(options =>
 	options.Password.RequireUppercase = true;
 	options.Password.RequireLowercase = true;
 	options.Password.RequiredUniqueChars = 6;
- 
- 
+
+
 	options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(30);
 	options.Lockout.MaxFailedAccessAttempts = 3;
- 
+
 	options.SignIn.RequireConfirmedEmail = true;
-	
+
 	options.User.RequireUniqueEmail = true;
 });
 ```
 
 DO: Set a cookie policy
 
-e.g 
+e.g
 
 ``` csharp
 //startup.cs
@@ -365,7 +365,7 @@ Apply the following test: Would you be happy leaving the data on a spreadsheet o
 
 DO: Use TLS 1.2 for your entire site. Get a free certificate [LetsEncrypt.org](https://letsencrypt.org/).
 
-DO NOT: [Allow SSL, this is now obsolete](https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#22-use-secure-protocols).
+DO NOT: [Allow SSL, this is now obsolete](https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices).
 
 DO: Have a strong TLS policy (see [SSL Best Practises](https://www.ssllabs.com/projects/best-practices/index.html)), use TLS 1.2 wherever possible. Then check the configuration using [SSL Test](https://www.ssllabs.com/ssltest/) or [TestSSL](https://testssl.sh/).
 
@@ -786,7 +786,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		_isDevelopment = true;
 		app.UseDeveloperExceptionPage();
 	}
-	
+
 	//Log all errors in the application
 	app.UseExceptionHandler(errorApp =>
 	{
@@ -794,7 +794,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
 		    var errorFeature = context.Features.Get<IExceptionHandlerFeature>();
 		    var exception = errorFeature.Error;
-		    
+
 		    Log.Error(String.Format("Stacktrace of error: {0}",exception.StackTrace.ToString()));
 		});
 	});
@@ -837,7 +837,7 @@ public class AccountsController : Controller
 			Log.Information(String.Format("User: {0}, Incorrect Password", model.Email));
 		}
 	}
-	
+
 	...
 ```
 
@@ -847,7 +847,7 @@ Logging levels for ILogger are listed below, in order of high to low importance:
 
 Monitoring allow us to validate the performance and health of a running system through key performance indicators.
 
-In .NET a great option to add monitoring capabilities is [Application Insights](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-asp-net-core). 
+In .NET a great option to add monitoring capabilities is [Application Insights](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-asp-net-core).
 
 More information about Logging and Monitoring can be found [here](https://microsoft.github.io/code-with-engineering-playbook/Engineering/DevOpsLoggingDetailsCSharp.html).
 

--- a/cheatsheets/Error_Handling_Cheat_Sheet.md
+++ b/cheatsheets/Error_Handling_Cheat_Sheet.md
@@ -4,7 +4,7 @@ Error handling is a part of the overall security of an application. Except in mo
 
 Unhandled errors can assist an attacker in this initial phase, which is very important for the rest the attack.
 
-The following [link](http://blog.cipher.com/the-6-primary-phases-of-penetration-/) provides a description of the different phases of an attack.
+The following [link](https://cipher.com/blog/a-complete-guide-to-the-phases-of-penetration-testing/) provides a description of the different phases of an attack.
 
 # Context
 

--- a/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.md
+++ b/cheatsheets/JSON_Web_Token_Cheat_Sheet_for_Java.md
@@ -543,7 +543,7 @@ There are a number of [guides](https://www.notsosecure.com/crafting-way-json-web
 
 ### How to Prevent
 
-The simplest way to prevent this attack is to ensure that the secret used to sign the JWTs is strong and unique, in order to make it harder for an attacker to crack. As this secret would never need to be typed by a human, it should be at least 64 characters and generated using a [secure source of randomness](Cryptographic_Storage_Cheat_Sheet.html#rule---use-cryptographically-secure-pseudo-random-number-generators-csprng).
+The simplest way to prevent this attack is to ensure that the secret used to sign the JWTs is strong and unique, in order to make it harder for an attacker to crack. As this secret would never need to be typed by a human, it should be at least 64 characters and generated using a [secure source of randomness](Cryptographic_Storage_Cheat_Sheet.md#rule---use-cryptographically-secure-pseudo-random-number-generators-csprng).
 
 Alternatively, consider the use of tokens that are signed with RSA rather than using an HMAC and secret key.
 

--- a/cheatsheets/Virtual_Patching_Cheat_Sheet.md
+++ b/cheatsheets/Virtual_Patching_Cheat_Sheet.md
@@ -192,11 +192,11 @@ It would not be wise to implement a virtual patch that simply blocks that exact 
 
 ## Automated Virtual Patch Creation
 
-Manual patch creation may become unfeasible as the number of vulnerabilities grow and automated means may become necessary. If the vulnerabilities were identified using automated tools and an XML report is available, it is possible to leverage automated processes to auto-convert this vulnerability data into virtual patches for protection systems. 
+Manual patch creation may become unfeasible as the number of vulnerabilities grow and automated means may become necessary. If the vulnerabilities were identified using automated tools and an XML report is available, it is possible to leverage automated processes to auto-convert this vulnerability data into virtual patches for protection systems.
 
 Three examples include:
 
-- **OWASP ModSecurity Core Rule Set (CRS) Scripts** - The OWASP CRS includes scripts to auto-convert XML output from tools such as [OWASP ZAP into ModSecurity Virtual Patches]. Reference [here](http://blog.spiderlabs.com/2012/03/modsecurity-advanced-topic-of-the-week-automated-virtual-patching-using-owasp-zed-attack-proxy.html).
+- **OWASP ModSecurity Core Rule Set (CRS) Scripts** - The OWASP CRS includes scripts to auto-convert XML output from tools such as [OWASP ZAP into ModSecurity Virtual Patches]. Reference [here](https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/modsecurity-advanced-topic-of-the-week-automated-virtual-patching-using-owasp-zed-attack-proxy).
 - **ThreadFix Virtual Patching** - ThreadFix also includes automated processes of converting imported vulnerability XML data into virtual patches for security tools such as ModSecurity. Reference [here](https://github.com/denimgroup/threadfix/wiki/Waf-Types#mod_security).
 - **Direct Importing to WAF Device** - Many commercial WAF products have the capability to import DAST tool XML report data and automatically adjust their protection profiles.
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -104,7 +104,7 @@ Other definitions : [CERT/CC](https://vuls.cert.org/confluence/pages/viewpage.a
 - FRANCE
     - [ANSSI: Notify a security issue](https://www.ssi.gouv.fr/en-cas-dincident/vous-souhaitez-declarer-une-faille-de-securite-ou-une-vulnerabilite/).
 - NETHERLAND
-    - [NCSC: Notify a security issue](https://www.ncsc.nl/english/security).
+    - [NCSC: Notify a security issue](https://english.ncsc.nl/contact/reporting-a-vulnerability-cvd).
 - LUXEMBURG
     - [CIRCL: Notify a security issue](http://circl.lu/report/).
 


### PR DESCRIPTION
This PR is part of  issue #340 

Following links fixed:

[✖] Cryptographic_Storage_Cheat_Sheet.html#rule---use-cryptographically-secure-pseudo-random-number-generators-csprng  → Status: 404
> Typo in url changes .html to .md

[✖] http://blog.spiderlabs.com/2012/03/modsecurity-advanced-topic-of-the-week-automated-virtual-patching-using-owasp-zed-attack-proxy.html → Status: 404
> Replaced with https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/modsecurity-advanced-topic-of-the-week-automated-virtual-patching-using-owasp-zed-attack-proxy

[✖] https://www.ncsc.nl/english/security → Status: 404
> Replaced with https://english.ncsc.nl/contact/reporting-a-vulnerability-cvd

[✖] http://blog.cipher.com/the-6-primary-phases-of-penetration-/  → Status: 404
> Replaced with https://cipher.com/blog/a-complete-guide-to-the-phases-of-penetration-testing/

[✖] http://www.ssllabs.com/projects/best-practises/ → Status: 404
> Replaced with https://www.ssllabs.com/projects/best-practices/index.html

Please make sure that for your contribution:

- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries#editor--validation-policy).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries#conversion-rules).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really effective remediation? Please verify it works!).
- [x] The CI build of your PR pass
