### PR TITLE
Rewrite of vulnerability disclosure CS

### DIFF
--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -170,7 +170,7 @@ Alongside the contact details, it is also good to provide some guidelines for re
 
 ### Bug Bounty Programs
 
-Bug bounty programs incentivise researchers to identify and report vulnerabilities to organisations by offering rewards. These are usually monetary, but can also be physical items (swag). The process is often managed through a third party such as [BugCrowd](https://bugcrowd.com/programs),  [HackerOne](https://hackerone.com/directory/programs), who provide mediation between researchers and organisations.
+Bug bounty programs incentivise researchers to identify and report vulnerabilities to organisations by offering rewards. These are usually monetary, but can also be physical items (swag). The process is often managed through a third party such as [BugCrowd](https://bugcrowd.com/programs) or [HackerOne](https://hackerone.com/directory/programs), who provide mediation between researchers and organisations.
 
 When implementing a bug bounty program, the following areas need to be clearly defined:
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -24,21 +24,21 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 
 There are a number of different models that can be be followed when disclosing vulnerabilities.
 
-## Methods of Disclosure
+# Methods of Disclosure
 
-### Private Disclosure
+## Private Disclosure
 
 In the private disclosure model, the vulnerability is reported privately to the organisation. The organisation may choose to publish the details of the vulnerabilities, but this is done at the discretion of the organisation, not the researcher, meaning that many vulnerabilities may never be made public. The majority of bug bounty programs require that the researcher follows this model.
 
 The main problem with this model is that if the vendor is unresponsive, or decides not to fix the vulnerability, then the details may never be made public. Historically this has lead to researchers getting fed up with companies ignoring and trying to hide vulnerabilities, leading them to the full disclosure approach.
 
-### Full Disclosure
+## Full Disclosure
 
 With the full disclosure approach, the full details of the vulnerability are made public as soon as they are identified. This avoids the problem of organisations ignoring vulnerabilities, however it also means that the full details (sometimes including exploit code) are available to attackers, often before a patch is available.
 
 This makes the full disclosure approach very controversial, and it is seen as irresponsible by many people. Generally it should only be considered as a last resort, when all other methods have failed, or when exploit code is already publicly available.
 
-### Responsible or Coordinated Disclosure
+## Responsible or Coordinated Disclosure
 
 Responsible disclosure attempts to find a reasonable middle ground between these two approaches. With responsible disclosure, the initial report is made privately, but with the full details being published once a patch has been made available (sometimes with a delay to allow more time for the patches to be installed).
 
@@ -61,12 +61,22 @@ This section is intended to provide guidance for security researchers on how to 
 
 ### Finding Contact Details
 
-- See the Publishing Contact Details section below
-- Try other methods of communication:
-  + Generic contact addresses
-  + Phone
-  + Social media (with care)
-  + CERTs or other similar organisations
+The first step in reporting a vulnerability is finding the appropriate person to report it to. Although some organisations have clearly published disclosure policies, many do not, so it can be difficult to find the correct place to report the issue.
+
+Where there is no clear disclosure policy, the following areas may provide contact details:
+
+- Bug bounty programs such as [BugCrowd](https://bugcrowd.com/programs),  [HackerOne](https://hackerone.com/directory/programs) or [Open Bug Bounty](https://www.openbugbounty.org).
+- A [security.txt](https://securitytxt.org) file on the website at `/security.txt` or `/.well-known/security.txt`.
+- An existing issue tracking system.
+- Generic email addresses such as `security@` or `abuse@`.
+- The generic "Contact Us" page on the website.
+- Social media platforms.
+- Phoning the organisation.
+- Reaching out to the community.
+
+When reaching out to people who are not dedicated security contacts, request the details for a relevant member of staff, rather than disclosing the vulnerability details to whoever accepts the initial contact (especially over social media).
+
+If it is not possible to contact the organisation directly, a national or sector-based  [CERT](https://en.wikipedia.org/wiki/Computer_emergency_response_team) may be able to assist.
 
 ### Initial Report
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -111,7 +111,7 @@ Be patient if it's taking a while for the issue to be resolved. The developers m
 
 Despite every effort that you make, some organisations are not interested in in security, are impossible to contact, may may be actively hostile to researchers disclosing vulnerabilities. In some cases they may even threaten to take legal action against researchers. When this happens it is very disheartening for the researcher - it is important not to take this personally. When this happens, there are a number of options that can be taken.
 
-- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, you should ask yourself ** it really worth it?**
+- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, you should ask yourself _it really worth it?_
 - Anonymously disclose the vulnerability. However, if you're already made contact with the organisation and tried to report the vulnerability, it may be pretty obvious who you are.
 - Report the vulnerability to a third party, such as an industry regulator or data protection authority.
 - Move on.

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -274,4 +274,4 @@ Where researchers have identified and reported vulnerabilities outside of a bug 
 
 - [The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure)
 - [HackerOne's Vulnerability Disclosure Guidelines](https://www.hackerone.com/disclosure-guidelines)
-- [BugCrowd's Open Source Vulnerability Disclosure Framework](https://github.com/bugcrowd/disclosure-policy)
+- [Disclose.io's Vulnerability Disclosure Terms](https://github.com/disclose/disclose/tree/master/terms)

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -27,23 +27,23 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 
 **FIXME**
 
-# Methods of Disclosure
+## Methods of Disclosure
 
 There are a number of different models that can be be followed when disclosing vulnerabilities, which are listed in the sections below.
 
-## Private Disclosure
+### Private Disclosure
 
 In the private disclosure model, the vulnerability is reported privately to the organisation. The organisation may choose to publish the details of the vulnerabilities, but this is done at the discretion of the organisation, not the researcher, meaning that many vulnerabilities may never be made public. The majority of bug bounty programs require that the researcher follows this model.
 
 The main problem with this model is that if the vendor is unresponsive, or decides not to fix the vulnerability, then the details may never be made public. Historically this has lead to researchers getting fed up with companies ignoring and trying to hide vulnerabilities, leading them to the full disclosure approach.
 
-## Full Disclosure
+### Full Disclosure
 
 With the full disclosure approach, the full details of the vulnerability are made public as soon as they are identified. This avoids the problem of organisations ignoring vulnerabilities, however it also means that the full details (sometimes including exploit code) are available to attackers, often before a patch is available.
 
 This makes the full disclosure approach very controversial, and it is seen as irresponsible by many people. Generally it should only be considered as a last resort, when all other methods have failed, or when exploit code is already publicly available.
 
-## Responsible or Coordinated Disclosure
+### Responsible or Coordinated Disclosure
 
 Responsible disclosure attempts to find a reasonable middle ground between these two approaches. With responsible disclosure, the initial report is made privately, but with the full details being published once a patch has been made available (sometimes with a delay to allow more time for the patches to be installed).
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -225,34 +225,41 @@ Some individuals may approach an organisation claiming to have found a vulnerabi
 
 One option to request that they carry out the disclosure through a mediated bub bounty platform, which can provide a level of protection for both sides, as scammers are unlikely to be willing to use these platforms.
 
-### Triage
-
-- Confirm whether vulnerability is real
-- Obtain extra details where required
-- Search for other instances of the vulnerability across the systems or codebase
-- Identify the root cause of the vulnerability
-- Consider outsourcing the initial triage to a third party (such as HackerOne)
-
-### Fixing the Issue
-
-- Implement and test fixes internally
-- Request researcher confirms whether fix is effective
-  + Share sufficient details with them
-
 ### Disclosure
 
-#### Products and Open Source Software
+#### Commercial and Open Source Software
 
-- Request CVE if applicable
-- Publish security advisory with details of affected versions
-  + Credit the researcher
-- Have a security-focused changelog on site
-- Have a security-focused mailing list or announcements
-- Publish sufficient details to help defenders
+Once the vulnerability has been resolved (and retested), the details should be published in a security advisory for the software. It is important to remember that publishing the details of security issues **does not make the vendor look bad**. All software has security vulnerabilities, and demonstrating a clear and established process for handling and disclosing them gives far more confidence in the security of the software than trying to hide the issues.
+
+At a minimum, the security advisory must contain:
+
+- A high level summary of the vulnerability, including the impact.
+- A clear list of vulnerable versions.
+- A clear list of patch versions.
+- Any caveats on when the software is vulnerable (for example, if only certain configurations are affected).
+- Any workarounds or mitigation that can be implemented as a temporary fix.
+- A [CVE](https://cve.mitre.org/cve/request_id.html) for the vulnerability.
+
+Where possible it is also good to include:
+
+- The timeline of the vulnerability disclosure process.
+- Credit for the researcher who identified the vulnerability.
+- Technical details of the vulnerability.
+- IDS/IPS signatures or other indicators of compromise.
+
+Security advisories should be easy for developers and system administrators to find. Common ways to publish them include:
+
+- A dedicated "security" or "security advisories" page on the website.
+- A security mailing list or forum.
+- Linked from the main changelogs and release notes.
+
+Some researchers may publish their own technical write ups of the vulnerability, which will usually include the full details required to exploit it (and sometimes even working exploit code). For more serious vulnerabilities, it may be sensible to ask the researcher to delay publishing the full details for a period of time (such as a week), in order to give system administrators more time to install the patches before exploit code is available. However, once the patch has been releases, attackers will be able to reverse engineer the vulnerability and developer their own exploit code, so there is limited value to delaying the full release.
 
 #### Private Systems
 
-- Credit the researcher
+For vulnerabilities in private systems, a decision needs to be made about whether the details should be published once the vulnerability has been resolved. Most bug bounty programs give organisations the option about whether to disclose the details once the issue has been resolved, although it is not typically required.
+
+Publishing these details helps to demonstrate that that the organisation is taking proactive and transparent approach to security, but can also result in potentially embarrassing omissions and misconfigurations being made public. In the event of a future compromise or data breach, they could also potentially be used as evidence of a weak security culture within the organisation. Additionally, they may expose technical details about internal, and could help attackers identify other similar issues. As such, this decision should be carefully evaluated, and it may be wise to take legal advice.
 
 ## Further Reading
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -7,6 +7,7 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 **Researchers should:**
 
 - Ensure that any testing is legal and authorised.
+- Respect the privacy of others.
 - Make reasonable efforts to contact the security team of the organisation.
 - Provide sufficient details to allow the vulnerabilities to be verified and reproduced.
 - Request CVEs where appropriate.
@@ -90,6 +91,7 @@ The initial report should include:
 
 - Sufficient details of the vulnerability to allow it to be understood and reproduced.
 - HTML snippets, screenshots or any other supporting evidence.
+  + Redact any personal data before reporting.
 - Proof of concept code (if available).
 - The impact of the vulnerability.
 - Any references or further reading that may be appropriate.
@@ -214,3 +216,7 @@ This section is intended to provide guidance for organisations on how to accept 
 #### Private Systems
 
 - Credit the researcher
+
+## Further Reading
+
+- [The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure)

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -261,6 +261,15 @@ For vulnerabilities in private systems, a decision needs to be made about whethe
 
 Publishing these details helps to demonstrate that that the organisation is taking proactive and transparent approach to security, but can also result in potentially embarrassing omissions and misconfigurations being made public. In the event of a future compromise or data breach, they could also potentially be used as evidence of a weak security culture within the organisation. Additionally, they may expose technical details about internal, and could help attackers identify other similar issues. As such, this decision should be carefully evaluated, and it may be wise to take legal advice.
 
+### Rewarding Researchers
+
+Where researchers have identified and reported vulnerabilities outside of a bug bounty program (essentially providing free security testing), and have acted professionally and helpfully throughout the vulnerability disclosure process, it is good to offer them some kind of reward to encourage this kind of positive interaction in future. If monetary rewards are not possible then a number of other options should be considered, such as:
+
+- Discounts or credit for services or products offered by the organisation.
+- Virtual rewards (such as special in-game items, custom avatars, etc).
+- T-shirts, stickers and other branded items (swag).
+- Credit in a "hall of fame", or other similar acknowledgement.
+
 ## Further Reading
 
 - [The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure)

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -80,15 +80,21 @@ If it is not possible to contact the organisation directly, a national or sector
 
 ### Initial Report
 
-- Try to send to security contact, not just generic address
-- Encrypt where possible
-- Include
-  + Details of vulnerability
-  + Steps to reproduce
-  + Proof of concept
-  + Impact (if known)
-  + Recommendations on fixing the issue (optional)
-- Explain disclosure process and timeline
+Once a security contact has been identified, an initial report should be made of the details of the vulnerability. Ideally this should be done over an encrypted channel (such as the use of PGP keys), although many organisations do not support this.
+
+The initial report should include:
+
+- Sufficient details of the vulnerability to allow it to be understood and reproduced.
+- HTML snippets, screenshots or any other supporting evidence.
+- Proof of concept code (if available).
+- The impact of the vulnerability.
+- Any references or further reading that may be appropriate.
+
+In many cases, especially in smaller organisations, the security reports may be handled by developers or IT staff who do not have a security background. This means that they may not be familiar with many security concepts or terminology, so reports should be written in clear and simple terms.
+
+It may also be beneficial to provide a recommendation on how the issue could be mitigated or resolved. However, unless the details of the system or application are known, or you are very confident in the recommendation then it may be better to point the developers to some more general guidance (such as an OWASP cheat sheet).
+
+If you are planning to publish the details of the vulnerability after a period of time (as per some [responsible disclosure](#responsible-disclosure] policies), then this should be clearly communicated in the initial email - but try to do so in a tone that doesn't sound threatening to the recipient. 
 
 ### Ongoing Communication
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -2,8 +2,23 @@
 
 ## Introduction
 
-- CS is intended to provide guidance for both researchers and organisations on both side
-- Collaboration between both sides is very important
+This cheat sheet is intended to provide guidance on the vulnerability disclosure process for both security researchers and organisations. This is an area where collaboration is extremely important, but that can often result in conflict between the two parties.
+
+**Researchers should:**
+
+- Ensure that any testing is legal and authorised.
+- Make reasonable efforts to contact the security team of the organisation.
+- Provide sufficient details to allow the vulnerabilities to be verified and reproduced.
+- Request CVEs where appropriate.
+- Not demand payment or rewards for reporting vulnerabilities outside of an established bug bounty program.
+
+**Organisations should:**
+
+- Provide a clear method for researchers to securely report vulnerabilities.
+- Clearly establish the scope and terms of any bug bounty programs.
+- Respond to reports in a reasonable timeline.
+- Communicate openly with researchers.
+- Not threaten legal action against researchers.
 
 ## Contents
 
@@ -12,14 +27,6 @@
 ## Reporting Vulnerabilities
 
 This section is intended to provide guidance for security researchers on how to report vulnerabilities to organisations
-
-### Things Not To Do
-
-- Submitting unverified scan results
-- Reporting junk issues as high
-- Making unreasonable demands (especially about the timeline)
-- Demanding payments
-- Being a dick
 
 ### Warnings and Legality
 
@@ -81,14 +88,6 @@ This section is intended to provide guidance for security researchers on how to 
 
 This section is intended to provide guidance for organisations on how to accept and receive vulnerability reports
 
-### Things Not To Do
-
-- Threatening researchers
-- Being impossible to contact
-- Ignoring reports
-- Pretending vulnerabilities don't exist or are trivial
-- Being a dick
-
 ### Publishing Contact Details
 
 - Make it easy for researchers to contact you
@@ -149,24 +148,3 @@ This section is intended to provide guidance for organisations on how to accept 
 #### Private Systems
 
 - Credit the researcher
-
-## Methods of Disclosure
-
-### Private Disclosure
-
-- Vulnerability privately disclosed to vendor
-- Only published with vendor's explicit approval
-- Required by most bug bounty programs
-- Generally appropriate for private systems
-
-### Responsible or Coordinated Disclosure
-
-- Details provided to vendor
-- Published once a fix has been made available or a specified time limit (90 days?) has passed
-- Consider delay in publishing to allow time to patch
-- Generally appropriate for open source projects and published software
-
-### Full Disclosure
-
-- Full details of vulnerability published online
-- Generally only used with unresponsive vendors or after a timeline has expired

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -101,23 +101,22 @@ If the organisation does not have an established bug bounty program, then avoid 
 
 ### Ongoing Communication
 
-- Maintain communication with vendor
-- Provide further details if asked
-- Retesting of suggested fixes
-- Chase vendor and request updates when unresponsive
+While simpler vulnerabilities might be resolved solely from the initial report, in many cases there will be a number of emails back and forth between the researcher and the organisation. Especially for more complex vulnerabilities, the the developers or administrators may ask for additional information or recommendations on how to resolve the issue. They may also ask for assistance in retesting the issue once a fix has been implemented. Although there is no obligation to carry out this retesting, as long as the request is reasonable then and providing feedback on the fixes is very beneficial.
+
+It may also be necessary to chase up the organisation if they become unresponsive, or if the established deadline for publicly disclosing the vulnerability is approaching. Ensure that this communication stays professional and positive - if the disclosure process becomes hostile then neither party will benefit.
+
+Be patient if it's taking a while for the issue to be resolved. The developers may be under significant pressure from different people within the organisation, and may not be able to be fully open in their communication. Triaging, developing, reviewing, testing and deploying a fix within in an enterprise environment takes **significantly** more time than most researchers expect, and being constantly hassled for updates just adds another level of pressure on the developers.
 
 ### When to Give Up
 
-- Not all vendors are interested
-  + Some are impossible to contact
-  + Some don't care
-  + Some are hostile and threaten legal action
-- Known when to cut your losses and move on
-- Don't get burned out over a specific issue
-- Don't take it personally
-- Don't risk your career and livelihood
-- Focus your time and effort on companies who care
-- Consider very carefully before going down the full disclosure route
+Despite every effort that you make, some organisations are not interested in in security, are impossible to contact, may may be actively hostile to researchers disclosing vulnerabilities. In some cases they may even threaten to take legal action against researchers. When this happens it is very disheartening for the researcher - it is important not to take this personally. When this happens, there are a number of options that can be taken.
+
+- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, you should ask yourself __is it really worth it?__
+- Anonymously disclose the vulnerability. However, if you're already made contact with the organisation and tried to report the vulnerability, it may be pretty obvious who you are.
+- Report the vulnerability to a third party, such as an industry regulator or data protection authority.
+- Move on.
+
+There are many organisations who have a genuine interest in security, and are very open and co-operative with security researchers. Unless the vulnerability is extremely serious, **it is not worth burning yourself out, or risking your career and livelihood over and organisation who doesn't care**.
 
 ### Publishing
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -1,17 +1,19 @@
-# Introduction
+# Vulnerability Disclosure Cheat Sheet
+
+## Introduction
 
 - CS is intended to provide guidance for both researchers and organisations on both side
 - Collaboration between both sides is very important
 
-# Contents
+## Contents
 
 **FIXME**
 
-# Reporting Vulnerabilities
+## Reporting Vulnerabilities
 
 This section is intended to provide guidance for security researchers on how to report vulnerabilities to organisations
 
-## Things Not To Do
+### Things Not To Do
 
 - Submitting unverified scan results
 - Reporting junk issues as high
@@ -19,7 +21,7 @@ This section is intended to provide guidance for security researchers on how to 
 - Demanding payments
 - Being a dick
 
-## Warnings and Legality
+### Warnings and Legality
 
 - Follow rules of bug bounty program if one exists
 - Be aware of the laws in your country
@@ -28,7 +30,7 @@ This section is intended to provide guidance for security researchers on how to 
   + Reporting and managing this is **your responsibility**
 - Consider anonymous disclosure
 
-## Finding Contact Details
+### Finding Contact Details
 
 - See the Publishing Contact Details section below
 - Try other methods of communication:
@@ -37,7 +39,7 @@ This section is intended to provide guidance for security researchers on how to 
   + Social media (with care)
   + CERTs or other similar organisations
 
-## Initial Report
+### Initial Report
 
 - Try to send to security contact, not just generic address
 - Encrypt where possible
@@ -49,14 +51,14 @@ This section is intended to provide guidance for security researchers on how to 
   + Recommendations on fixing the issue (optional)
 - Explain disclosure process and timeline
 
-## Ongoing Communication
+### Ongoing Communication
 
 - Maintain communication with vendor
 - Provide further details if asked
 - Retesting of suggested fixes
 - Chase vendor and request updates when unresponsive
 
-## When to Give Up
+### When to Give Up
 
 - Not all vendors are interested
   + Some are impossible to contact
@@ -69,17 +71,17 @@ This section is intended to provide guidance for security researchers on how to 
 - Focus your time and effort on companies who care
 - Consider very carefully before going down the full disclosure route
 
-## Publishing
+### Publishing
 
 - Discuss with vendor before publishing
 - Consider rules of any bug bounty program and applicable laws
 - May result in legal threats or action from hostile vendors
 
-# Receiving Vulnerability Reports
+## Receiving Vulnerability Reports
 
 This section is intended to provide guidance for organisations on how to accept and receive vulnerability reports
 
-## Things Not To Do
+### Things Not To Do
 
 - Threatening researchers
 - Being impossible to contact
@@ -87,7 +89,7 @@ This section is intended to provide guidance for organisations on how to accept 
 - Pretending vulnerabilities don't exist or are trivial
 - Being a dick
 
-## Publishing Contact Details
+### Publishing Contact Details
 
 - Make it easy for researchers to contact you
   + Contact us page
@@ -96,7 +98,7 @@ This section is intended to provide guidance for organisations on how to accept 
   + Known vulnerability reporting/disclosure sites
 - Provide PGP keys
 
-## Bug Bounty Programs
+### Bug Bounty Programs
 
 - Provide financial rewards for researchers
 - Must clearly define:
@@ -106,20 +108,20 @@ This section is intended to provide guidance for organisations on how to accept 
 - Help mediate between researchers and organisations
 - **Not a replacement for penetration testing or assurance activities**
 
-## Communicating With Researchers
+### Communicating With Researchers
 
 - Use PGP or other encrypted mechanisms
 - Acknowledge initial receipt
 - Provide updates to researcher
 - Respond in a reasonable timeframe
 
-### Researchers Demanding Payment
+#### Researchers Demanding Payment
 
 - Some researchers will demand payment before revealing details
   + Usually a scam
   + Encourage use of a mediated platform for disclosure
 
-## Triage
+### Triage
 
 - Confirm whether vulnerability is real
 - Obtain extra details where required
@@ -127,15 +129,15 @@ This section is intended to provide guidance for organisations on how to accept 
 - Identify the root cause of the vulnerability
 - Consider outsourcing the initial triage to a third party (such as HackerOne)
 
-## Fixing the Issue
+### Fixing the Issue
 
 - Implement and test fixes internally
 - Request researcher confirms whether fix is effective
   + Share sufficient details with them
 
-## Disclosure
+### Disclosure
 
-### Products and Open Source Software
+#### Products and Open Source Software
 
 - Request CVE if applicable
 - Publish security advisory with details of affected versions
@@ -144,27 +146,27 @@ This section is intended to provide guidance for organisations on how to accept 
 - Have a security-focused mailing list or announcements
 - Publish sufficient details to help defenders
 
-### Private Systems
+#### Private Systems
 
 - Credit the researcher
 
-# Methods of Disclosure
+## Methods of Disclosure
 
-## Private Disclosure
+### Private Disclosure
 
 - Vulnerability privately disclosed to vendor
 - Only published with vendor's explicit approval
 - Required by most bug bounty programs
 - Generally appropriate for private systems
 
-## Responsible or Coordinated Disclosure
+### Responsible or Coordinated Disclosure
 
 - Details provided to vendor
 - Published once a fix has been made available or a specified time limit (90 days?) has passed
 - Consider delay in publishing to allow time to patch
 - Generally appropriate for open source projects and published software
 
-## Full Disclosure
+### Full Disclosure
 
 - Full details of vulnerability published online
 - Generally only used with unresponsive vendors or after a timeline has expired

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -146,28 +146,6 @@ Note that many bug bounty programs forbid researchers from publishing the detail
 
 This section is intended to provide guidance for organisations on how to accept and receive vulnerability reports.
 
-### Publishing Contact Details
-
-The most important step in the process is providing a way for security researchers to contact your organisation. The easier it is for them to do so, the more likely it is that you'll receive security reports. The following list includes some of the common mechanisms that are used for this - the more of these that you can implement the better:
-
-- An dedicated security contact on the "Contact Us" page.
-- Dedicated instructions for reporting security issues on a bug tracker.
-- The common `security@` email address.
-- A [security.txt](https://securitytxt.org) file on the website at `/security.txt` or `/.well-known/security.txt`.
-- Using third party [bug bounty](#bug-bounty-programs) program.
-
-It is also important to ensure that frontline staff (such as those who monitor the main contact address, web chat and phone lines) are aware of how to handle reports of security issues, and who to escalate these reports to within the organisation.
-
-#### Providing Reporting Guidelines
-
-Alongside the contact details, it is also good to provide some guidelines for researchers to follow when reporting vulnerabilities. These could include:
-
-- Requesting specific information that may help in confirming and resolving the issue.
-- Using specific categories or marking the issue as confidential on a bug tracker.
-- Providing PGP keys for encrypted communication.
-- Establishing a timeline for an initial response and triage.
-- Establishing safe harbor provisions.
-
 ### Bug Bounty Programs
 
 Bug bounty programs incentivise researchers to identify and report vulnerabilities to organisations by offering rewards. These are usually monetary, but can also be physical items (swag). The process is often managed through a third party such as [BugCrowd](https://bugcrowd.com/programs) or [HackerOne](https://hackerone.com/directory/programs), who provide mediation between researchers and organisations.
@@ -203,18 +181,47 @@ Bug bounty have been adopted by many large organisations such as Microsoft, and 
 
 Despite these potential issues, bug bounty programs are a great way to identify vulnerabilities in applications and systems. However, they should only be used by organisations that already have a mature vulnerability disclosure process, supported by strong internal processes to resolve vulnerabilities.
 
+### Publishing Contact Details
+
+The most important step in the process is providing a way for security researchers to contact your organisation. The easier it is for them to do so, the more likely it is that you'll receive security reports. The following list includes some of the common mechanisms that are used for this - the more of these that you can implement the better:
+
+- An dedicated security contact on the "Contact Us" page.
+- Dedicated instructions for reporting security issues on a bug tracker.
+- The common `security@` email address.
+- A [security.txt](https://securitytxt.org) file on the website at `/security.txt` or `/.well-known/security.txt`.
+- Using third party [bug bounty](#bug-bounty-programs) program.
+
+It is also important to ensure that frontline staff (such as those who monitor the main contact address, web chat and phone lines) are aware of how to handle reports of security issues, and who to escalate these reports to within the organisation.
+
+#### Providing Reporting Guidelines
+
+Alongside the contact details, it is also good to provide some guidelines for researchers to follow when reporting vulnerabilities. These could include:
+
+- Requesting specific information that may help in confirming and resolving the issue.
+- Using specific categories or marking the issue as confidential on a bug tracker.
+- Providing PGP keys for encrypted communication.
+- Establishing a timeline for an initial response and triage.
+- Establishing safe harbor provisions.
+
 ### Communicating With Researchers
 
-- Use PGP or other encrypted mechanisms
-- Acknowledge initial receipt
-- Provide updates to researcher
-- Respond in a reasonable timeframe
+Communication between researchers and organisations is often one of the hardest points of the vulnerability disclosure process, and can easily leave both sides frustrated and unhappy with the process.
+
+The outline below provides an example of the ideal communication process:
+
+- Respond to the initial request for contact details with a clear mechanism for the researcher to provide additional information.
+- Acknowledge the vulnerability details and provide a timeline for carry out triage.
+- Request additional clarification or details if required.
+- Confirm the vulnerability and provide a timeline for implementing a fix.
+  + Confirm the details of any reward or bounty offered.
+- If required, request the researcher to retest the vulnerability.
+- Confirm that the vulnerability has been resolved.
 
 #### Researchers Demanding Payment
 
-- Some researchers will demand payment before revealing details
-  + Usually a scam
-  + Encourage use of a mediated platform for disclosure
+Some individuals may approach an organisation claiming to have found a vulnerability, and demanding payment before they will share the details. Although these requests _may_ be legitimate, in many cases they are simply scams.
+
+One option to request that they carry out the disclosure through a mediated bub bounty platform, which can provide a level of protection for both sides, as scammers are unlikely to be willing to use these platforms.
 
 ### Triage
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -25,9 +25,11 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 
 ## Contents
 
-There are a number of different models that can be be followed when disclosing vulnerabilities.
+**FIXME**
 
 # Methods of Disclosure
+
+There are a number of different models that can be be followed when disclosing vulnerabilities, which are listed in the sections below.
 
 ## Private Disclosure
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -94,7 +94,7 @@ In many cases, especially in smaller organisations, the security reports may be 
 
 It may also be beneficial to provide a recommendation on how the issue could be mitigated or resolved. However, unless the details of the system or application are known, or you are very confident in the recommendation then it may be better to point the developers to some more general guidance (such as an OWASP cheat sheet).
 
-If you are planning to publish the details of the vulnerability after a period of time (as per some [responsible disclosure](#responsible-disclosure) policies), then this should be clearly communicated in the initial email - but try to do so in a tone that doesn't sound threatening to the recipient.
+If you are planning to publish the details of the vulnerability after a period of time (as per some [responsible disclosure](#responsible-or-coordinated-disclosure) policies), then this should be clearly communicated in the initial email - but try to do so in a tone that doesn't sound threatening to the recipient.
 
 ### Ongoing Communication
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -217,6 +217,8 @@ The outline below provides an example of the ideal communication process:
 - If required, request the researcher to retest the vulnerability.
 - Confirm that the vulnerability has been resolved.
 
+Throughout the process, provide regular updates of the current status and expected timeline to triage of fix the vulnerability. Even if there is no firm timeline for these, the ongoing communication provides some reassurance that the vulnerability hasn't been forgotten about, and helps to keep researchers from getting fed up.
+
 #### Researchers Demanding Payment
 
 Some individuals may approach an organisation claiming to have found a vulnerability, and demanding payment before they will share the details. Although these requests _may_ be legitimate, in many cases they are simply scams.

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -96,6 +96,8 @@ It may also be beneficial to provide a recommendation on how the issue could be 
 
 If you are planning to publish the details of the vulnerability after a period of time (as per some [responsible disclosure](#responsible-or-coordinated-disclosure) policies), then this should be clearly communicated in the initial email - but try to do so in a tone that doesn't sound threatening to the recipient.
 
+If the organisation does not have an established bug bounty program, then avoid asking about payments or rewards in the initial contact - leave it until the issue has been acknowledged (or ideally fixed). In particular, **do not demand payment before revealing the details of the vulnerability**. At best this will look like an attempt to scam the company, at worst it may constitute blackmail.
+
 ### Ongoing Communication
 
 - Maintain communication with vendor

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -94,7 +94,7 @@ In many cases, especially in smaller organisations, the security reports may be 
 
 It may also be beneficial to provide a recommendation on how the issue could be mitigated or resolved. However, unless the details of the system or application are known, or you are very confident in the recommendation then it may be better to point the developers to some more general guidance (such as an OWASP cheat sheet).
 
-If you are planning to publish the details of the vulnerability after a period of time (as per some [responsible disclosure](#responsible-disclosure] policies), then this should be clearly communicated in the initial email - but try to do so in a tone that doesn't sound threatening to the recipient. 
+If you are planning to publish the details of the vulnerability after a period of time (as per some [responsible disclosure](#responsible-disclosure) policies), then this should be clearly communicated in the initial email - but try to do so in a tone that doesn't sound threatening to the recipient.
 
 ### Ongoing Communication
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -1,5 +1,8 @@
 # Introduction
 
+- CS is intended to provide guidance for both researchers and organisations on both side
+- Collaboration between both sides is very important
+
 # Contents
 
 **FIXME**
@@ -8,9 +11,81 @@
 
 This section is intended to provide guidance for security researchers on how to report vulnerabilities to organisations
 
+## Things Not To Do
+
+- Submitting unverified scan results
+- Reporting junk issues as high
+- Making unreasonable demands (especially about the timeline)
+- Demanding payments
+- Being a dick
+
+## Warnings and Legality
+
+- Follow rules of bug bounty program if one exists
+- Be aware of the laws in your country
+- Demanding payment __may__ constitute blackmail
+- Bug bounties are usually considered taxable income
+  + Reporting and managing this is **your responsibility**
+- Consider anonymous disclosure
+
+## Finding Contact Details
+
+- See the Publishing Contact Details section below
+- Try other methods of communication:
+  + Generic contact addresses
+  + Phone
+  + Social media (with care)
+  + CERTs or other similar organisations
+
+## Initial Report
+
+- Try to send to security contact, not just generic address
+- Encrypt where possible
+- Include
+  + Details of vulnerability
+  + Steps to reproduce
+  + Proof of concept
+  + Impact (if known)
+  + Recommendations on fixing the issue (optional)
+- Explain disclosure process and timeline
+
+## Ongoing Communication
+
+- Maintain communication with vendor
+- Provide further details if asked
+- Retesting of suggested fixes
+- Chase vendor and request updates when unresponsive
+
+## When to Give Up
+
+- Not all vendors are interested
+  + Some are impossible to contact
+  + Some don't care
+  + Some are hostile and threaten legal action
+- Known when to cut your losses and move on
+- Don't get burned out over a specific issue
+- Don't take it personally
+- Don't risk your career and livelihood
+- Focus your time and effort on companies who care
+- Consider very carefully before going down the full disclosure route
+
+## Publishing
+
+- Discuss with vendor before publishing
+- Consider rules of any bug bounty program and applicable laws
+- May result in legal threats or action from hostile vendors
+
 # Receiving Vulnerability Reports
 
 This section is intended to provide guidance for organisations on how to accept and receive vulnerability reports
+
+## Things Not To Do
+
+- Threatening researchers
+- Being impossible to contact
+- Ignoring reports
+- Pretending vulnerabilities don't exist or are trivial
+- Being a dick
 
 ## Publishing Contact Details
 
@@ -37,7 +112,6 @@ This section is intended to provide guidance for organisations on how to accept 
 - Acknowledge initial receipt
 - Provide updates to researcher
 - Respond in a reasonable timeframe
-- **Do not threaten lawsuits**
 
 ### Researchers Demanding Payment
 
@@ -73,3 +147,24 @@ This section is intended to provide guidance for organisations on how to accept 
 ### Private Systems
 
 - Credit the researcher
+
+# Methods of Disclosure
+
+## Private Disclosure
+
+- Vulnerability privately disclosed to vendor
+- Only published with vendor's explicit approval
+- Required by most bug bounty programs
+- Generally appropriate for private systems
+
+## Responsible or Coordinated Disclosure
+
+- Details provided to vendor
+- Published once a fix has been made available or a specified time limit (90 days?) has passed
+- Consider delay in publishing to allow time to patch
+- Generally appropriate for open source projects and published software
+
+## Full Disclosure
+
+- Full details of vulnerability published online
+- Generally only used with unresponsive vendors or after a timeline has expired

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -53,11 +53,11 @@ This section is intended to provide guidance for security researchers on how to 
 
 ### Warnings and Legality
 
-Before carrying out any security research or reporting vulnerabilities, **ensure that you know and understand that laws in your jurisdiction**. This cheat sheet **does not constitute legal advice, and should not be taken as such.**.
+Before carrying out any security research or reporting vulnerabilities, **ensure that you know and understand the laws in your jurisdiction**. This cheat sheet **does not constitute legal advice, and should not be taken as such.**.
 
 The following points highlight a number of areas that should be considered:
 
-- If you are currying out testing under a bug bounty or similar program, the organisation may have established [safe harbor](https://disclose.io) policies, that allow you to legally carry out testing, **as long as you stay within the scope and rules of their program**. Make sure that you read the scope carefully - stepping outside of the scope and rules may be a criminal offence.
+- If you are carrying out testing under a bug bounty or similar program, the organisation may have established [safe harbor](https://disclose.io) policies, that allow you to legally carry out testing, **as long as you stay within the scope and rules of their program**. Make sure that you read the scope carefully - stepping outside of the scope and rules may be a criminal offence.
 - Some countries have laws restricting reverse engineering, so testing against locally installed software may not be permitted.
 - Do not demand payment or other rewards as a condition of providing information on security vulnerabilities, or in exchange for not publishing the details or reporting them to industry regulators, as this may constitute blackmail.
 - If you receive bug bounty payments, these are generally considered as income, meaning that they may be taxable. Reporting this income and ensuring that you pay the appropriate tax on it is **your** responsibility.

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -10,7 +10,6 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 - Respect the privacy of others.
 - Make reasonable efforts to contact the security team of the organisation.
 - Provide sufficient details to allow the vulnerabilities to be verified and reproduced.
-- Request CVEs where appropriate.
 - Not demand payment or rewards for reporting vulnerabilities outside of an established bug bounty program.
 
 **Organisations should:**
@@ -20,6 +19,8 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 - Respond to reports in a reasonable timeline.
 - Communicate openly with researchers.
 - Not threaten legal action against researchers.
+- Request CVEs where appropriate.
+- Publish clear security advisories and changelogs.
 - Offer rewards and credit.
 
 ## Contents

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -39,7 +39,7 @@ The main problem with this model is that if the vendor is unresponsive, or decid
 
 ### Full Disclosure
 
-With the full disclosure approach, the full details of the vulnerability are made public as soon as they are identified. This avoids the problem of organisations ignoring vulnerabilities, however it also means that the full details (sometimes including exploit code) are available to attackers, often before a patch is available.
+With the full disclosure approach, the full details of the vulnerability are made public as soon as they are identified. This means that the full details (sometimes including exploit code) are available to attackers, often before a patch is available. The full disclosure approach is primarily used in response or organisations ignoring reported vulnerabilities, in order to put pressure on them to develop and publish a fix.
 
 This makes the full disclosure approach very controversial, and it is seen as irresponsible by many people. Generally it should only be considered as a last resort, when all other methods have failed, or when exploit code is already publicly available.
 
@@ -93,8 +93,9 @@ Once a security contact has been identified, an initial report should be made of
 The initial report should include:
 
 - Sufficient details of the vulnerability to allow it to be understood and reproduced.
-- HTML snippets, screenshots or any other supporting evidence.
+- HTTP requests and responses, HTML snippets, screenshots or any other supporting evidence.
   + Redact any personal data before reporting.
+  + Some organisations may try and claim vulnerabilities never existed, so ensure you have sufficient evidence to prove that they did.
 - Proof of concept code (if available).
 - The impact of the vulnerability.
 - Any references or further reading that may be appropriate.
@@ -109,7 +110,7 @@ If the organisation does not have an established bug bounty program, then avoid 
 
 ### Ongoing Communication
 
-While simpler vulnerabilities might be resolved solely from the initial report, in many cases there will be a number of emails back and forth between the researcher and the organisation. Especially for more complex vulnerabilities, the the developers or administrators may ask for additional information or recommendations on how to resolve the issue. They may also ask for assistance in retesting the issue once a fix has been implemented. Although there is no obligation to carry out this retesting, as long as the request is reasonable then and providing feedback on the fixes is very beneficial.
+While simpler vulnerabilities might be resolved solely from the initial report, in many cases there will be a number of emails back and forth between the researcher and the organisation. Especially for more complex vulnerabilities, the developers or administrators may ask for additional information or recommendations on how to resolve the issue. They may also ask for assistance in retesting the issue once a fix has been implemented. Although there is no obligation to carry out this retesting, as long as the request is reasonable then and providing feedback on the fixes is very beneficial.
 
 It may also be necessary to chase up the organisation if they become unresponsive, or if the established deadline for publicly disclosing the vulnerability is approaching. Ensure that this communication stays professional and positive - if the disclosure process becomes hostile then neither party will benefit.
 
@@ -117,14 +118,14 @@ Be patient if it's taking a while for the issue to be resolved. The developers m
 
 ### When to Give Up
 
-Despite every effort that you make, some organisations are not interested in in security, are impossible to contact, may may be actively hostile to researchers disclosing vulnerabilities. In some cases they may even threaten to take legal action against researchers. When this happens it is very disheartening for the researcher - it is important not to take this personally. When this happens, there are a number of options that can be taken.
+Despite every effort that you make, some organisations are not interested in security, are impossible to contact, or may be actively hostile to researchers disclosing vulnerabilities. In some cases they may even threaten to take legal action against researchers. When this happens it is very disheartening for the researcher - it is important not to take this personally. When this happens, there are a number of options that can be taken.
 
-- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, ask yourself _it really worth it?_
-- Anonymously disclose the vulnerability. However, if you're already made contact with the organisation and tried to report the vulnerability, it may be pretty obvious who you are.
+- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, ask yourself _is it really worth it?_
+- Anonymously disclose the vulnerability. However, if you've already made contact with the organisation and tried to report the vulnerability to them, it may be pretty obvious who you was responsible when it was anonymously disclosed. If you are going to take this approach, ensure that you have take sufficient operational security measures to protect yourself.
 - Report the vulnerability to a third party, such as an industry regulator or data protection authority.
 - Move on.
 
-There are many organisations who have a genuine interest in security, and are very open and co-operative with security researchers. Unless the vulnerability is extremely serious, **it is not worth burning yourself out, or risking your career and livelihood over and organisation who doesn't care**.
+There are many organisations who have a genuine interest in security, and are very open and co-operative with security researchers. Unless the vulnerability is extremely serious, **it is not worth burning yourself out, or risking your career and livelihood over an organisation who doesn't care**.
 
 ### Publishing
 
@@ -137,7 +138,7 @@ Once a vulnerability has been patched (or not), then a decision needs to be made
 - Links to the vendor's published advisory.
 - The timeline for the discovery, vendor communication and release.
 
-Some organisations may request that you do not publish the details are all, or that you delay publication to allow more time to their users to install security patches. In the interest of maintaining a positive relationship with the organisation, it is worth trying to find a compromise position on this.
+Some organisations may request that you do not publish the details at all, or that you delay publication to allow more time to their users to install security patches. In the interest of maintaining a positive relationship with the organisation, it is worth trying to find a compromise position on this.
 
 Whether to publish working proof of concept (or functional exploit code) is a subject of debate. Some people will view this as a "blackhat" move, and will argue that by doing so you are directly helping criminals compromise their users. On the other hand, the code can be used to both system administrators and penetration testers to test their systems, and attackers will be able to develop or reverse engineering working exploit code if the vulnerability is sufficiently valuable.
 
@@ -163,7 +164,7 @@ When implementing a bug bounty program, the following areas need to be clearly d
   + The [disclose.io](https://disclose.io) project provides some example policies.
   + Take legal advice from lawyers, **not from this cheat sheet**.
 - How much to offer for bounties, and how is the decision made.
-  + Offering too much could cost end up being very expensive if a large number of vulnerabilities are found.
+  + The program could get very expensive if a large number of vulnerabilities are identified.
   + Too little and researchers may not bother with the program.
 - The timeline for the initial response, confirmation, payout and issue resolution.
 
@@ -188,7 +189,7 @@ Despite these potential issues, bug bounty programs are a great way to identify 
 
 The most important step in the process is providing a way for security researchers to contact your organisation. The easier it is for them to do so, the more likely it is that you'll receive security reports. The following list includes some of the common mechanisms that are used for this - the more of these that you can implement the better:
 
-- An dedicated security contact on the "Contact Us" page.
+- A dedicated security contact on the "Contact Us" page.
 - Dedicated instructions for reporting security issues on a bug tracker.
 - The common `security@` email address.
 - A [security.txt](https://securitytxt.org) file on the website at `/security.txt` or `/.well-known/security.txt`.
@@ -213,20 +214,20 @@ Communication between researchers and organisations is often one of the hardest 
 The outline below provides an example of the ideal communication process:
 
 - Respond to the initial request for contact details with a clear mechanism for the researcher to provide additional information.
-- Acknowledge the vulnerability details and provide a timeline for carry out triage.
+- Acknowledge the vulnerability details and provide a timeline to carry out triage.
 - Request additional clarification or details if required.
 - Confirm the vulnerability and provide a timeline for implementing a fix.
   + Confirm the details of any reward or bounty offered.
 - If required, request the researcher to retest the vulnerability.
 - Confirm that the vulnerability has been resolved.
 
-Throughout the process, provide regular updates of the current status and expected timeline to triage of fix the vulnerability. Even if there is no firm timeline for these, the ongoing communication provides some reassurance that the vulnerability hasn't been forgotten about, and helps to keep researchers from getting fed up.
+Throughout the process, provide regular updates of the current status, and the expected timeline to triage and fix the vulnerability. Even if there is no firm timeline for these, the ongoing communication provides some reassurance that the vulnerability hasn't been forgotten about.
 
 #### Researchers Demanding Payment
 
-Some individuals may approach an organisation claiming to have found a vulnerability, and demanding payment before they will share the details. Although these requests _may_ be legitimate, in many cases they are simply scams.
+Some individuals may approach an organisation claiming to have found a vulnerability, and demanding payment before sharing the details. Although these requests _may_ be legitimate, in many cases they are simply scams.
 
-One option to request that they carry out the disclosure through a mediated bub bounty platform, which can provide a level of protection for both sides, as scammers are unlikely to be willing to use these platforms.
+One option is to request that they carry out the disclosure through a mediated bug bounty platform, which can provide a level of protection for both sides, as scammers are unlikely to be willing to use these platforms.
 
 ### Disclosure
 
@@ -256,7 +257,7 @@ Security advisories should be easy for developers and system administrators to f
 - A security mailing list or forum.
 - Linked from the main changelogs and release notes.
 
-Some researchers may publish their own technical write ups of the vulnerability, which will usually include the full details required to exploit it (and sometimes even working exploit code). For more serious vulnerabilities, it may be sensible to ask the researcher to delay publishing the full details for a period of time (such as a week), in order to give system administrators more time to install the patches before exploit code is available. However, once the patch has been releases, attackers will be able to reverse engineer the vulnerability and developer their own exploit code, so there is limited value to delaying the full release.
+Some researchers may publish their own technical write ups of the vulnerability, which will usually include the full details required to exploit it (and sometimes even working exploit code). For more serious vulnerabilities, it may be sensible to ask the researcher to delay publishing the full details for a period of time (such as a week), in order to give system administrators more time to install the patches before exploit code is available. However, once the patch has been releases, attackers will be able to reverse engineer the vulnerability and develop their own exploit code, so there is limited value to delaying the full release.
 
 #### Private Systems
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -170,23 +170,38 @@ Alongside the contact details, it is also good to provide some guidelines for re
 
 ### Bug Bounty Programs
 
-- Provide financial rewards for researchers
-- Must clearly define:
-  + Scope
-  + Types of vulnerabilities that are included
-  + Reward levels
-- Third party programs can help mediate between researchers and organisations
-- **Not a replacement for penetration testing or assurance activities**
-- Consider legal requirements and safe harbor
-  + https://disclose.io
-  + Needs approval from legal departments
+Bug bounty programs incentivise researchers to identify and report vulnerabilities to organisations by offering rewards. These are usually monetary, but can also be physical items (swag). The process is often managed through a third party such as [BugCrowd](https://bugcrowd.com/programs),  [HackerOne](https://hackerone.com/directory/programs), who provide mediation between researchers and organisations.
 
-#### Bug Bounty Considerations
+When implementing a bug bounty program, the following areas need to be clearly defined:
 
-- Encouraging and authorising individuals to target your systems
-- Increase in malicious looking traffic (may impact monitoring)
-- Financial implications
-- Volume of reports (may be low quality)
+- Which systems and applications are in scope.
+  + Live systems or a staging/UAT environment?
+  + Excluding systems managed or owned by third parties.
+- Which types of vulnerabilities are eligible for bounties (SSL/TLS issues? Missing HTTP security headers? Version disclosure?)
+- Legal provisions such as safe harbor policies.
+  + The [disclose.io](https://disclose.io) project provides some example policies.
+  + Take legal advice from lawyers, **not from this cheat sheet**.
+- How much to offer for bounties, and how is the decision made.
+  + Offering too much could cost end up being very expensive if a large number of vulnerabilities are found.
+  + Too little and researchers may not bother with the program.
+- The timeline for the initial response, confirmation, payout and issue resolution.
+
+#### When to Implement a Bug Bounty Program
+
+Bug bounty have been adopted by many large organisations such as Microsoft, and are starting to be used outside of the commercial sector, including the  US Department of Defense. However, for smaller organisations they can bring significant challenges, and require a substantial investment of time and resources. These challenges can include:
+
+- Having sufficient time and resources to respond to reports.
+- Having sufficiently skilled staff to effectively triage reports.
+  + Reports may include a large number of junk or false positives.
+  + Managed bug bounty programs may help by performing initial triage (at a cost).
+- Dealing with large numbers of false positives and junk reports.
+- The impact of individuals testing live systems (including unskilled attackers running automated tools they don't understand).
+- Being unable to differentiate between legitimate testing traffic and malicious attacks.
+- Researchers going out of scope and testing systems that they shouldn't.
+- The financial cost of running the program (some companies pay out hundreds of thousands of dollars a year in bounties).
+- Dealing with researchers who are unhappy with how the program is run (such as disputing bounty amounts, or being angry when reported issues are duplicates or out of scope).
+
+Despite these potential issues, bug bounty programs are a great way to identify vulnerabilities in applications and systems. However, they should only be used by organisations that already have a mature vulnerability disclosure process, supported by strong internal processes to resolve vulnerabilities.
 
 ### Communicating With Researchers
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -144,16 +144,29 @@ Note that many bug bounty programs forbid researchers from publishing the detail
 
 ## Receiving Vulnerability Reports
 
-This section is intended to provide guidance for organisations on how to accept and receive vulnerability reports
+This section is intended to provide guidance for organisations on how to accept and receive vulnerability reports.
 
 ### Publishing Contact Details
 
-- Make it easy for researchers to contact you
-  + Contact us page
-  + Common email addresses (security@)
-  + Security.txt
-  + Known vulnerability reporting/disclosure sites
-- Provide PGP keys
+The most important step in the process is providing a way for security researchers to contact your organisation. The easier it is for them to do so, the more likely it is that you'll receive security reports. The following list includes some of the common mechanisms that are used for this - the more of these that you can implement the better:
+
+- An dedicated security contact on the "Contact Us" page.
+- Dedicated instructions for reporting security issues on a bug tracker.
+- The common `security@` email address.
+- A [security.txt](https://securitytxt.org) file on the website at `/security.txt` or `/.well-known/security.txt`.
+- Using third party [bug bounty](#bug-bounty-programs) program.
+
+It is also important to ensure that frontline staff (such as those who monitor the main contact address, web chat and phone lines) are aware of how to handle reports of security issues, and who to escalate these reports to within the organisation.
+
+#### Providing Reporting Guidelines
+
+Alongside the contact details, it is also good to provide some guidelines for researchers to follow when reporting vulnerabilities. These could include:
+
+- Requesting specific information that may help in confirming and resolving the issue.
+- Using specific categories or marking the issue as confidential on a bug tracker.
+- Providing PGP keys for encrypted communication.
+- Establishing a timeline for an initial response and triage.
+- Establishing safe harbor provisions.
 
 ### Bug Bounty Programs
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -24,21 +24,21 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 
 There are a number of different models that can be be followed when disclosing vulnerabilities.
 
-# Methods of Disclosure
+## Methods of Disclosure
 
-## Private Disclosure
+### Private Disclosure
 
 In the private disclosure model, the vulnerability is reported privately to the organisation. The organisation may choose to publish the details of the vulnerabilities, but this is done at the discretion of the organisation, not the researcher, meaning that many vulnerabilities may never be made public. The majority of bug bounty programs require that the researcher follows this model.
 
 The main problem with this model is that if the vendor is unresponsive, or decides not to fix the vulnerability, then the details may never be made public. Historically this has lead to researchers getting fed up with companies ignoring and trying to hide vulnerabilities, leading them to the full disclosure approach.
 
-## Full Disclosure
+### Full Disclosure
 
 With the full disclosure approach, the full details of the vulnerability are made public as soon as they are identified. This avoids the problem of organisations ignoring vulnerabilities, however it also means that the full details (sometimes including exploit code) are available to attackers, often before a patch is available.
 
 This makes the full disclosure approach very controversial, and it is seen as irresponsible by many people. Generally it should only be considered as a last resort, when all other methods have failed, or when exploit code is already publicly available.
 
-## Responsible or Coordinated Disclosure
+### Responsible or Coordinated Disclosure
 
 Responsible disclosure attempts to find a reasonable middle ground between these two approaches. With responsible disclosure, the initial report is made privately, but with the full details being published once a patch has been made available (sometimes with a delay to allow more time for the patches to be installed).
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -25,7 +25,30 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 
 ## Contents
 
-**FIXME**
+* [Contents](#contents)
+* [Methods of Disclosure](#methods-of-disclosure)
+  + [Private Disclosure](#private-disclosure)
+  + [Full Disclosure](#full-disclosure)
+  + [Responsible or Coordinated Disclosure](#responsible-or-coordinated-disclosure)
+* [Reporting Vulnerabilities](#reporting-vulnerabilities)
+  + [Warnings and Legality](#warnings-and-legality)
+  + [Finding Contact Details](#finding-contact-details)
+  + [Initial Report](#initial-report)
+  + [Ongoing Communication](#ongoing-communication)
+  + [When to Give Up](#when-to-give-up)
+  + [Publishing](#publishing)
+* [Receiving Vulnerability Reports](#receiving-vulnerability-reports)
+  + [Bug Bounty Programs](#bug-bounty-programs)
+    - [When to Implement a Bug Bounty Program](#when-to-implement-a-bug-bounty-program)
+  + [Publishing Contact Details](#publishing-contact-details)
+    - [Providing Reporting Guidelines](#providing-reporting-guidelines)
+  + [Communicating With Researchers](#communicating-with-researchers)
+    - [Researchers Demanding Payment](#researchers-demanding-payment)
+  + [Disclosure](#disclosure)
+    - [Commercial and Open Source Software](#commercial-and-open-source-software)
+    - [Private Systems](#private-systems)
+  + [Rewarding Researchers](#rewarding-researchers)
+* [Further Reading](#further-reading)
 
 ## Methods of Disclosure
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -22,11 +22,33 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 
 ## Contents
 
-**FIXME**
+There are a number of different models that can be be followed when disclosing vulnerabilities.
+
+# Methods of Disclosure
+
+## Private Disclosure
+
+In the private disclosure model, the vulnerability is reported privately to the organisation. The organisation may choose to publish the details of the vulnerabilities, but this is done at the discretion of the organisation, not the researcher, meaning that many vulnerabilities may never be made public. The majority of bug bounty programs require that the researcher follows this model.
+
+The main problem with this model is that if the vendor is unresponsive, or decides not to fix the vulnerability, then the details may never be made public. Historically this has lead to researchers getting fed up with companies ignoring and trying to hide vulnerabilities, leading them to the full disclosure approach.
+
+## Full Disclosure
+
+With the full disclosure approach, the full details of the vulnerability are made public as soon as they are identified. This avoids the problem of organisations ignoring vulnerabilities, however it also means that the full details (sometimes including exploit code) are available to attackers, often before a patch is available.
+
+This makes the full disclosure approach very controversial, and it is seen as irresponsible by many people. Generally it should only be considered as a last resort, when all other methods have failed, or when exploit code is already publicly available.
+
+## Responsible or Coordinated Disclosure
+
+Responsible disclosure attempts to find a reasonable middle ground between these two approaches. With responsible disclosure, the initial report is made privately, but with the full details being published once a patch has been made available (sometimes with a delay to allow more time for the patches to be installed).
+
+In many cases, the researcher also provides a deadline for the organisation to respond to the report, or to provide a patch. If this deadline is not met, then the researcher may adopt the full disclosure approach, and publish the full details.
+
+Google's [Project Zero](https://googleprojectzero.blogspot.com/2020/01/policy-and-disclosure-2020-edition.html) adopts a similar approach, where the full details of the vulnerability are published after 90 days regardless of whether or not the organisation has published a patch.
 
 ## Reporting Vulnerabilities
 
-This section is intended to provide guidance for security researchers on how to report vulnerabilities to organisations
+This section is intended to provide guidance for security researchers on how to report vulnerabilities to organisations.
 
 ### Warnings and Legality
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -273,3 +273,5 @@ Where researchers have identified and reported vulnerabilities outside of a bug 
 ## Further Reading
 
 - [The CERT Guide to Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure)
+- [HackerOne's Vulnerability Disclosure Guidelines](https://www.hackerone.com/disclosure-guidelines)
+- [BugCrowd's Open Source Vulnerability Disclosure Framework](https://github.com/bugcrowd/disclosure-policy)

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -120,9 +120,22 @@ There are many organisations who have a genuine interest in security, and are ve
 
 ### Publishing
 
-- Discuss with vendor before publishing
-- Consider rules of any bug bounty program and applicable laws
-- May result in legal threats or action from hostile vendors
+Once a vulnerability has been patched (or not), then a decision needs to be made about publishing the details. This should ideally be done through discussion with the vendor, and at a minimum the vendor should be notified that you intend to publish, and provided with a link to the published details. The disclosure would typically include:
+
+- A high level summary of the vulnerability and its impact.
+- Details of which version(s) are vulnerable, and which are fixed.
+- Technical details or potentially proof of concept code.
+- Mitigations or workarounds.
+- Links to the vendor's published advisory.
+- The timeline for the discovery, vendor communication and release.
+
+Some organisations may request that you do not publish the details are all, or that you delay publication to allow more time to their users to install security patches. In the interest of maintaining a positive relationship with the organisation, it is worth trying to find a compromise position on this.
+
+Whether to publish working proof of concept (or functional exploit code) is a subject of debate. Some people will view this as a "blackhat" move, and will argue that by doing so you are directly helping criminals compromise their users. On the other hand, the code can be used to both system administrators and penetration testers to test their systems, and attackers will be able to develop or reverse engineering working exploit code if the vulnerability is sufficiently valuable.
+
+If you are publishing the details in hostile circumstances (such as an unresponsive organisation, or after a stated period of time has elapsed) then you may face threats and even legal action. Whether there is any legal basis for this will depend on your jurisdiction, and whether you signed any form of non-disclosure agreement with the organisation. Make sure you understand your legal position before doing so.
+
+Note that many bug bounty programs forbid researchers from publishing the details without the agreement of the organisation. If you choose to do so, you may forfeit the bounty or be banned from the platform - so read the rules of the program before publishing.
 
 ## Receiving Vulnerability Reports
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -144,7 +144,7 @@ Be patient if it's taking a while for the issue to be resolved. The developers m
 Despite every effort that you make, some organisations are not interested in security, are impossible to contact, or may be actively hostile to researchers disclosing vulnerabilities. In some cases they may even threaten to take legal action against researchers. When this happens it is very disheartening for the researcher - it is important not to take this personally. When this happens, there are a number of options that can be taken.
 
 - Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, ask yourself _is it really worth it?_
-- Anonymously disclose the vulnerability. However, if you've already made contact with the organisation and tried to report the vulnerability to them, it may be pretty obvious who you was responsible when it was anonymously disclosed. If you are going to take this approach, ensure that you have take sufficient operational security measures to protect yourself.
+- Anonymously disclose the vulnerability. However, if you've already made contact with the organisation and tried to report the vulnerability to them, it may be pretty obvious who's responsible behind the disclosure. If you are going to take this approach, ensure that you have taken sufficient operational security measures to protect yourself.
 - Report the vulnerability to a third party, such as an industry regulator or data protection authority.
 - Move on.
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -145,8 +145,18 @@ This section is intended to provide guidance for organisations on how to accept 
   + Scope
   + Types of vulnerabilities that are included
   + Reward levels
-- Help mediate between researchers and organisations
+- Third party programs can help mediate between researchers and organisations
 - **Not a replacement for penetration testing or assurance activities**
+- Consider legal requirements and safe harbor
+  + https://disclose.io
+  + Needs approval from legal departments
+
+#### Bug Bounty Considerations
+
+- Encouraging and authorising individuals to target your systems
+- Increase in malicious looking traffic (may impact monitoring)
+- Financial implications
+- Volume of reports (may be low quality)
 
 ### Communicating With Researchers
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -4,7 +4,7 @@
 
 This cheat sheet is intended to provide guidance on the vulnerability disclosure process for both security researchers and organisations. This is an area where collaboration is extremely important, but that can often result in conflict between the two parties.
 
-**Researchers should:**
+**[Researchers](#reporting-vulnerabilities) should:**
 
 - Ensure that any testing is legal and authorised.
 - Respect the privacy of others.
@@ -12,7 +12,7 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 - Provide sufficient details to allow the vulnerabilities to be verified and reproduced.
 - Not demand payment or rewards for reporting vulnerabilities outside of an established bug bounty program.
 
-**Organisations should:**
+**[Organisations](#receiving-vulnerability-reports) should:**
 
 - Provide a clear method for researchers to securely report vulnerabilities.
 - Clearly establish the scope and terms of any bug bounty programs.

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -111,7 +111,7 @@ Be patient if it's taking a while for the issue to be resolved. The developers m
 
 Despite every effort that you make, some organisations are not interested in in security, are impossible to contact, may may be actively hostile to researchers disclosing vulnerabilities. In some cases they may even threaten to take legal action against researchers. When this happens it is very disheartening for the researcher - it is important not to take this personally. When this happens, there are a number of options that can be taken.
 
-- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, you should ask yourself _it really worth it?_
+- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, ask yourself _it really worth it?_
 - Anonymously disclose the vulnerability. However, if you're already made contact with the organisation and tried to report the vulnerability, it may be pretty obvious who you are.
 - Report the vulnerability to a third party, such as an industry regulator or data protection authority.
 - Move on.

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -111,7 +111,7 @@ Be patient if it's taking a while for the issue to be resolved. The developers m
 
 Despite every effort that you make, some organisations are not interested in in security, are impossible to contact, may may be actively hostile to researchers disclosing vulnerabilities. In some cases they may even threaten to take legal action against researchers. When this happens it is very disheartening for the researcher - it is important not to take this personally. When this happens, there are a number of options that can be taken.
 
-- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, you should ask yourself __is it really worth it?__
+- Publicly disclose the vulnerability, and deal with any negative reaction and potentially even a lawsuit. Whether or not they have a strong legal case is irrelevant - they have expensive lawyers and fighting any kind of legal action is expensive and time consuming. Before going down this route, you should ask yourself ** it really worth it?**
 - Anonymously disclose the vulnerability. However, if you're already made contact with the organisation and tried to report the vulnerability, it may be pretty obvious who you are.
 - Report the vulnerability to a third party, such as an industry regulator or data protection authority.
 - Move on.

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -133,7 +133,7 @@ This section is intended to provide guidance for organisations on how to accept 
 - Request researcher confirms whether fix is effective
   + Share sufficient details with them
 
-##  Disclosure
+## Disclosure
 
 ### Products and Open Source Software
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -19,6 +19,7 @@ This cheat sheet is intended to provide guidance on the vulnerability disclosure
 - Respond to reports in a reasonable timeline.
 - Communicate openly with researchers.
 - Not threaten legal action against researchers.
+- Offer rewards and credit.
 
 ## Contents
 

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -1,111 +1,75 @@
 # Introduction
 
-This cheatsheet is to help people report vulnerabilities they can find either randomly, either through security research.
- 
-**Disclaimer**: No warranty - consult lawyer!
+# Contents
 
-# Prepare
+**FIXME**
 
-- define the scope
-- check if company has
-    - identified security contacts: typical security@, abuse@, noc@ ([RFC2142](https://www.ietf.org/rfc/rfc2142.txt)) or [public](https://first.org/members/teams/) [CERT](https://www.trusted-introducer.org/directory/teams.html).
-    - a responsible disclosure web page
-    - bug bounty program. Example platforms : hackerone, bugcrowd, synack, bountyfactory.io...
-    - a security.txt file on one of their websites ([website](https://securitytxt.org/), [github repo](https://github.com/securitytxt/security-txt), [ietf draft](https://www.ietf.org/id/draft-foudil-securitytxt-00.txt))
+# Reporting Vulnerabilities
 
-# Identify
+This section is intended to provide guidance for security researchers on how to report vulnerabilities to organisations
 
-Remember if they are rules defined by a bounty program or laws applied to your country. Document every step allowing to identify vulnerability, and if acceptable in your context, how to exploit it.
+# Receiving Vulnerability Reports
 
-# Report
+This section is intended to provide guidance for organisations on how to accept and receive vulnerability reports
 
-It is recommended to use responsible disclosure when dealing with vulnerabilities
+## Publishing Contact Details
 
-- alert the company, multiple times and persons if needed.
-- request [CVE Identification](http://cve.mitre.org/cve/request_id)([RedHat CVE HowTo](https://github.com/RedHatProductSecurity/CVE-HOWTO)).
-- alert trusted 3rd party like National CERT, Data Privacy regulator if apply. Eventually, some security researchers like [Brian Krebs](https://krebsonsecurity.com/) or [Troy Hunt](https://www.troyhunt.com/) (non-exhaustive. check your network first) can be intermediate too or provide support.
-- full/public disclosure
+- Make it easy for researchers to contact you
+  + Contact us page
+  + Common email addresses (security@)
+  + Security.txt
+  + Known vulnerability reporting/disclosure sites
+- Provide PGP keys
 
-Depending on your context, each step may have more or less important time interval. Be flexible. ***Encourage trust, transparency and openness***. Timeline of full disclosure is always a debate especially if there is active exploitation. Be considerate of the work necessary to do the fix while balancing with public interest.
+## Bug Bounty Programs
 
-Examples of public disclosure timeline and methodology
+- Provide financial rewards for researchers
+- Must clearly define:
+  + Scope
+  + Types of vulnerabilities that are included
+  + Reward levels
+- Help mediate between researchers and organisations
+- **Not a replacement for penetration testing or assurance activities**
 
-- RFPolicy, Rain Forest Puppy, 2000: [5d](https://dl.packetstormsecurity.net/papers/general/rfpolicy-2.0.txt) for initial contact
-- Google Project Zero:
-    - [90d](https://googleprojectzero.blogspot.ca/2015/02/feedback-and-data-driven-updates-to.html) after initial notification and 14d grace period
-    - [7d after if actively exploited Microsoft, 2016](https://www.secpod.com/blog/google-discloses-zero-day-in-windows-kernel/)
-- US CERT/CC: [45d](https://www.cert.org/vulnerability-analysis/vul-disclosure.cfm) after initial report
-- Internet Engineering Task Force (IETF): [Responsible Vulnerability Disclosure Process](https://tools.ietf.org/html/draft-christey-wysopal-vuln-disclosure-00). Insisted on joined work with no unique timeline
-- Microsoft: [Coordinated Vulnerability Disclosure](https://technet.microsoft.com/en-us/security/dn467923) (CVD)
-- ISO/IEC [29147:2014](http://www.iso.org/iso/catalogue_detail.htm?csnumber=45170): Vulnerability disclosure
+## Communicating With Researchers
 
-Report should include all details necessary to understand vulnerability and reproduce it (exploit code for example). If you identify limiting factors, include them (Non-Admin user, use of Ms EMET, security HTTP headers...).
+- Use PGP or other encrypted mechanisms
+- Acknowledge initial receipt
+- Provide updates to researcher
+- Respond in a reasonable timeframe
+- **Do not threaten lawsuits**
 
-If possible, use encryption like PGP/GPG to encrypt your report. You can use [Encrypt.to](https://encrypt.to/) to do from a web browser if recipient has a public key. If you want to remain anonymous, it's probably better to use pseudonym and one-time use email on Tor network or similar. Intermediate party might also be available like ZeroDisclo.com but ensure target destination is relevant (In 2017, mostly FR & EU).
+### Researchers Demanding Payment
 
-# Aftermath
+- Some researchers will demand payment before revealing details
+  + Usually a scam
+  + Encourage use of a mediated platform for disclosure
 
-If you think your lessons learned would be useful to community, share it (anonymously or not).
+## Triage
 
-# Legal
+- Confirm whether vulnerability is real
+- Obtain extra details where required
+- Search for other instances of the vulnerability across the systems or codebase
+- Identify the root cause of the vulnerability
+- Consider outsourcing the initial triage to a third party (such as HackerOne)
 
-Most western countries have an exception for interoperability and security research but...
+## Fixing the Issue
 
-- US: Sec. 103(f) of the DMCA (17 U.S.C. § 1201 (f)) but EULA and contract override law.
-- FR: [Art.](https://fr.wikipedia.org/wiki/Rétro-ingénierie#L.C3.A9gislation) [L. 335-3-1 - article 22 du DADVSI](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000266350&categorieLien=id) (2006), [EU Directive 2009/24](http://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX%3A32009L0024)
-- CA: Ambiguous... Bill [C-32](http://www.parl.gc.ca/HousePublications/Publication.aspx?DocId=4580265&Language=e&Mode=1) (2010), Bill [C-11](http://www.parl.gc.ca/HousePublications/Publication.aspx?DocId=5465759) (2011). Criminal code provisions (Bill [C-46](http://laws-lois.justice.gc.ca/eng/acts/C-46/FullText.html)) for testing without permission: 430(1.1) ("Mischief in relation to computer data"), 342.1 ("Unauthorized use of a computer"), 342.2 ("Possession of device to obtain unauthorized use of computer system or to commit mischief").
+- Implement and test fixes internally
+- Request researcher confirms whether fix is effective
+  + Share sufficient details with them
 
-# Definitions
+##  Disclosure
 
-- Full disclosure
+### Products and Open Source Software
 
-*Full disclosure is the practice of publishing analysis of software vulnerabilities as early as possible, making the data accessible to everyone without restriction. The primary purpose of widely disseminating information about vulnerabilities is so that potential victims are as knowledgeable as those who attack them.*, [Wikipedia](https://en.wikipedia.org/wiki/Full_disclosure_%28computer_security%29)
+- Request CVE if applicable
+- Publish security advisory with details of affected versions
+  + Credit the researcher
+- Have a security-focused changelog on site
+- Have a security-focused mailing list or announcements
+- Publish sufficient details to help defenders
 
-- Responsible disclosure
+### Private Systems
 
-*The issue is reported privately to the vendor and no one else until the vendor issues a patch.*, [Microsoft](https://www.microsoft.com/en-us/msrc/cvd), 2010
-
-- Coordinated disclosure
-
-*Coordinate public release happens, ideally, when the vendor releases the update. In the case of publicly verifiable active attacks, details may be released prior to an update being released, with emphasis on giving details to protection providers.*, [Microsoft](https://www.microsoft.com/en-us/msrc/cvd), 2010
-
-- Private disclosure
-
-*The vulnerability is released to a small group of people (not the vendor) or kept private.*
-
-Other definitions : [CERT/CC](https://vuls.cert.org/confluence/pages/viewpage.action?pageId=4718642)
-
-# References
-
-- [Vulnerability Disclosure](https://www.cert.org/vulnerability-analysis/vul-disclosure.cfm).
-- [Debating Full Disclosure](https://www.schneier.com/blog/archives/2007/01/debating_full_d.html), Bruce Schneier, Jan2007.
-- [7 Deadly Sins of Website Vulnerability Disclosure](http://blog.jeremiahgrossman.com/2007/07/7-deadly-sins-of-website-vulnerability.html), Jeremiah Grossman, Jul 2007.
-- [Notification and disclosure Policy](http://blog.zoller.lu/2008/09/notification-and-disclosure-policy.html) (update), Thierry Zoller, Sep 2008.
-- [Matt's Guide to Vendor Response](http://blog.talosintelligence.com/2009/12/matts-guide-to-vendor-response.html), Talos, Dec 2009.
-- [The responsibility of public disclosure](https://www.troyhunt.com/the-responsibility-of-public-disclosure/), Troy Hunt, May 2013.
-- [Approaches to Vulnerability Disclosure](http://blog.opensecurityresearch.com/2014/06/approaches-to-vulnerability-disclosure.html), Brad Antoniewicz, Jun 2014.
-- [Reflections on Vulnerability Disclosure Case Studies & Ethical Dilemmas](https://www.ernw.de/download/ACM_SigComm_ENSR_Rey_Vulnerability_Disclosure.pdf), ERNW, ACM 2015.
-- [Good Practice Guide on Vulnerability Disclosure. From challenges to recommendations](https://www.enisa.europa.eu/publications/vulnerability-disclosure), ENISA, Jan 2016.
-- [Reverse Engineering legality](https://en.wikipedia.org/wiki/Reverse_engineering#Legality).
-- [FireEye takes security firm to court over vulnerability disclosure](http://www.pcworld.com/article/2983144/fireeye-takes-security-firm-to-court-over-vulnerability-disclosure.html), sep 2015.
-- [Google Discloses Windows Zero-Day Before Microsoft Can Issue Patch](http://www.bleepingcomputer.com/news/security/google-discloses-windows-zero-day-before-microsoft-can-issue-patch/), nov 2016.
-- [Bug bounties and extortion](https://scotthelme.co.uk/bug-bounties-and-extortion/), feb 2017.
-
-# Countries specifics
-
-- USA
-    - [Reverse Engineering FAQ](https://www.eff.org/issues/coders/reverse-engineering-faq).
-    - [DMCA exemption](https://www.ftc.gov/news-events/blogs/techftc/2016/10/dmca-security-research-exemption-consumer-devices).
-- CANADA
-    - ['Messenger always gets shot': Hackers say the Canadian government doesn't want their help](http://www.cbc.ca/news/technology/canadian-government-hackers-1.3866336), CBC, Nov 2016.
-    - [Some thoughts on Bill-C-32: An Act to Modernize Canada's copyright laws](http://www.barrysookman.com/2010/06/03/some-thoughts-on-bill-c-32-an-act-to-modernize-canada%E2%80%99s-copyright-laws/), Barry Sookman, Jun 2010.
-- UNITED KINGDOM
-    - [UK surveillance law raises concerns security researchers could be 'deputised' by the state](https://www.theregister.co.uk/2017/05/31/surveillance_law_compulsion/), TheRegister, May 217.
-- FRANCE
-    - [ANSSI: Notify a security issue](https://www.ssi.gouv.fr/en-cas-dincident/vous-souhaitez-declarer-une-faille-de-securite-ou-une-vulnerabilite/).
-- NETHERLAND
-    - [NCSC: Notify a security issue](https://english.ncsc.nl/contact/reporting-a-vulnerability-cvd).
-- LUXEMBURG
-    - [CIRCL: Notify a security issue](http://circl.lu/report/).
-
-*Feel free to provide other countries!*
+- Credit the researcher

--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -53,12 +53,15 @@ This section is intended to provide guidance for security researchers on how to 
 
 ### Warnings and Legality
 
-- Follow rules of bug bounty program if one exists
-- Be aware of the laws in your country
-- Demanding payment __may__ constitute blackmail
-- Bug bounties are usually considered taxable income
-  + Reporting and managing this is **your responsibility**
-- Consider anonymous disclosure
+Before carrying out any security research or reporting vulnerabilities, **ensure that you know and understand that laws in your jurisdiction**. This cheat sheet **does not constitute legal advice, and should not be taken as such.**.
+
+The following points highlight a number of areas that should be considered:
+
+- If you are currying out testing under a bug bounty or similar program, the organisation may have established [safe harbor](https://disclose.io) policies, that allow you to legally carry out testing, **as long as you stay within the scope and rules of their program**. Make sure that you read the scope carefully - stepping outside of the scope and rules may be a criminal offence.
+- Some countries have laws restricting reverse engineering, so testing against locally installed software may not be permitted.
+- Do not demand payment or other rewards as a condition of providing information on security vulnerabilities, or in exchange for not publishing the details or reporting them to industry regulators, as this may constitute blackmail.
+- If you receive bug bounty payments, these are generally considered as income, meaning that they may be taxable. Reporting this income and ensuring that you pay the appropriate tax on it is **your** responsibility.
+- If you find vulnerabilities as part of your work, or on equipment owned by your employer, your employer may prevent you from reporting these or claiming a bug bounty. Read your contract carefully and consider taking legal advice before doing so.
 
 ### Finding Contact Details
 


### PR DESCRIPTION
As discussed in #265, the vulnerability disclosure cheat sheet is....not great.

This PR has an initial outline for a proposed rewrite. At this stage, the main questions are:

- Is the overall structure sensible?
- Is there anything that should be removed?
- Is there anything missing?

Any comments and feedback are very much appreciated.