### PR TITLE
Point to the correct Angular docs

### DIFF
--- a/cheatsheets/AJAX_Security_Cheat_Sheet.md
+++ b/cheatsheets/AJAX_Security_Cheat_Sheet.md
@@ -63,7 +63,7 @@ Take a look at the [Cross-Site Request Forgery (CSRF) Prevention](Cross-Site_Req
 
 #### Review AngularJS JSON Hijacking Defense Mechanism
 
-See the [JSON Vulnerability Protection](https://docs.angularjs.org/api/ng/service/$http) section of the AngularJS documentation.
+See the [JSON Vulnerability Protection](https://docs.angularjs.org/api/ng/service/$http#json-vulnerability-protection) section of the AngularJS documentation.
 
 #### Always return JSON with an Object on the outside
 


### PR DESCRIPTION
This cheat sheet pointed to the wrong angular docs. This was discussed/found in https://chromium-review.googlesource.com/c/chromium/src/+/2134569/2/services/network/cross_origin_read_blocking_explainer.md