### PR TITLE
OS Command Injection - Grammar/Typo Fixes

### DIFF
--- a/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md
+++ b/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Command injection (or OS Command Injection) is a type of injection where the software, that constructs a system command using externally influenced input, does not correctly neutralizes the input from special elements that can modify the initially intended command.
+Command injection (or OS Command Injection) is a type of injection where software that constructs a system command using externally influenced input does not correctly neutralize the input from special elements that can modify the initially intended command.
 
 For example, if the supplied value is:
 
@@ -10,29 +10,29 @@ calc
 
 when typed in a Windows command prompt, the application *Calculator* is displayed.
 
-However, if the supplied value has been tempered with, and now it is:
+However, if the supplied value has been tampered with, and now it is:
 
 ``` shell
 calc & echo "test"
 ```
 
-When execute, it changes the meaning of the initial intended value. 
+when executed, it changes the meaning of the initial intended value. 
 
 Now, both the *Calculator* application and the value *test* are displayed:
 
 ![CommandInjection](../assets/OS_Command_Injection_Defense_Cheat_Sheet_CmdInjection.png)
 
-The problem is exacerbated if the compromised process does not follow the principle of least privilege principle and attacker-controlled commands end up running with special system privileges that increases the amount of damage.
+The problem is exacerbated if the compromised process does not follow the principle of least privileges and attacker-controlled commands end up running with special system privileges that increase the amount of damage.
 
 # Primary Defenses
 
 ## Defense Option 1: Avoid calling OS commands directly
 
-The primary defense is to avoid calling OS commands directly. Built-in library functions are a very good alternative to OS Commands, and they cannot be manipulated to perform tasks other than those it is intended to do.
+The primary defense is to avoid calling OS commands directly. Built-in library functions are a very good alternative to OS Commands, as they cannot be manipulated to perform tasks other than those it is intended to do.
 
 For example use `mkdir()` instead of `system("mkdir /dir_name")`.
 
-If there are available libraries or APIs for the language you used, this is the preferred method.
+If there are available libraries or APIs for the language you use, this is the preferred method.
 
 ## Defense option 2: Escape values added to OS commands specific to each OS
 
@@ -42,19 +42,19 @@ For examples, see [escapeshellarg()](https://www.php.net/manual/en/function.esca
 
 ## Defense option 3: Parameterization in conjunction with Input Validation
 
-If it is considered unavoidable the call to a system command incorporated with user-supplied, the following two layers of defense should be used within software in order to prevent attacks
+If calling a system command that incorporates user-supplied cannot be avoided, the following two layers of defense should be used within software to prevent attacks:
 
 ### Layer 1
 
-**Parameterization:** If available, use structured mechanisms that automatically enforce the separation between data and command. These mechanisms can help to provide the relevant quoting, encoding.
+**Parameterization:** If available, use structured mechanisms that automatically enforce the separation between data and command. These mechanisms can help provide the relevant quoting and encoding.
 
 ### Layer 2
 
-**Input validation:** The values for commands and the relevant arguments should be both validated. There are different degrees of validation for the actual command and its arguments:
+**Input validation:** The values for commands and the relevant arguments should both be validated. There are different degrees of validation for the actual command and its arguments:
 - When it comes to the **commands** used, these must be validated against a whitelist of allowed commands.
 - In regards to the **arguments** used for these commands, they should be validated using the following options:
-    - **Positive or whitelist input validation**: Where are the arguments allowed explicitly defined.
-    - **White list Regular Expression**: Where is explicitly defined a whitelist of good characters allowed and the maximum length of the string. Ensure that metacharacters like ones specified in `Note A` and white-spaces are not part of the Regular Expression. For example, the following regular expression only allows lowercase letters and numbers, and does not contain metacharacters. The length is also being limited to 3-10 characters: `^[a-z0-9]{3,10}$`
+    - **Positive or whitelist input validation**: Where the arguments allowed are explicitly defined.
+    - **White list Regular Expression**: Where a whitelist of good, allowed characters and the maximum length of the string are defined. Ensure that metacharacters like ones specified in `Note A` and white-spaces are not part of the Regular Expression. For example, the following regular expression only allows lowercase letters and numbers and does not contain metacharacters. The length is also being limited to 3-10 characters: `^[a-z0-9]{3,10}$`
 
 **Note A:**
 
@@ -64,7 +64,7 @@ If it is considered unavoidable the call to a system command incorporated with u
 
 # Additional Defenses
 
-On top of primary defences, parameterizations and input validation, we also recommend adopting all of these additional defenses in order to provide defense in depth.
+On top of primary defenses, parameterizations, and input validation, we also recommend adopting all of these additional defenses to provide defense in depth.
 
 These additional defenses are:
 
@@ -83,9 +83,9 @@ There are many sites that will tell you that Java's `Runtime.exec` is exactly th
 
 However, `C`'s system function passes its arguments to the shell (`/bin/sh`) to be parsed, whereas `Runtime.exec` tries to split the string into an array of words, then executes the first word in the array with the rest of the words as parameters. 
 
-**`Runtime.exec` does NOT try to invoke the shell at any point and do not support shell metacharacters**. 
+**`Runtime.exec` does NOT try to invoke the shell at any point and does not support shell metacharacters**. 
 
-The key difference is that much of the functionality provided by the shell that could be used for mischief (chaining commands using  `&`, `&&`, `|`, `||`, etc,  redirecting input and output) would simply end up as a parameter being passed to the first command, and likely causing a syntax error, or being thrown out as an invalid parameter.
+The key difference is that much of the functionality provided by the shell that could be used for mischief (chaining commands using  `&`, `&&`, `|`, `||`, etc,  redirecting input and output) would simply end up as a parameter being passed to the first command, likely causing a syntax error or being thrown out as an invalid parameter.
 
 *Code to test the note above:*
 
@@ -162,11 +162,11 @@ ERROR :
 ProcessBuilder b = new ProcessBuilder("C:\DoStuff.exe -arg1 -arg2");
 ```    
 
-In this example, the command together with the arguments are passed as a one string, making easy to manipulate that expression and inject malicious strings.
+In this example, the command together with the arguments are passed as a one string, making it easy to manipulate that expression and inject malicious strings.
 
 *Correct Usage:*
 
-Here is an example that starts a process with a modified working directory. The command and each of the arguments are passed separately. This make it easy to validated each term and reduces the risk to insert malicious strings.
+Here is an example that starts a process with a modified working directory. The command and each of the arguments are passed separately. This makes it easy to validate each term and reduces the risk of malicious strings being inserted.
 
 ``` java
 ProcessBuilder pb = new ProcessBuilder("TrustedCmd", "TrustedArg1", "TrustedArg2");


### PR DESCRIPTION
This PR fixes some typos/grammar issues in the OS Command Injection cheatsheet.