### PR TITLE
MD040 Code-Fencing Disabled

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,5 +4,6 @@
     "MD007": {"indent": 4},
     "MD013": false,
     "MD024": { "siblings_only": true},
-    "MD029": false
+    "MD029": false,
+    "MD040": false
 }


### PR DESCRIPTION
Since code fencing isn't a requirement in our CSs, this has been disabled in the rules.