### PR TITLE
NodeJS Backticks HTML elements

### DIFF
--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -402,7 +402,7 @@ app.use(helmet.hsts()); // default configuration
 app.use(helmet.hsts("<max-age>", "<includeSubdomains>")); // custom configuration
 ```
 
-- **[X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options):** determines if a page can be loaded via a \<frame> or an \<iframe> element. Allowing the page to be framed may result in [Clickjacking](https://owasp.org/www-community/attacks/Clickjacking) attacks. This header can be used with [helmet](https://www.npmjs.com/package/helmet) module as follows:
+- **[X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options):** determines if a page can be loaded via a `<frame>` or an `<iframe>` element. Allowing the page to be framed may result in [Clickjacking](https://owasp.org/www-community/attacks/Clickjacking) attacks. This header can be used with [helmet](https://www.npmjs.com/package/helmet) module as follows:
 
 ```JavaScript
 app.use(helmet.xframe()); // default behavior (DENY)


### PR DESCRIPTION
Raw HTML elements were parsed in the publishing. Frames now are set in backticks.