### PR TITLE
Remove rbsec from project team

### DIFF
--- a/Preface.md
+++ b/Preface.md
@@ -19,7 +19,6 @@ Core team:
 
 - [Elie Saad](https://github.com/ThunderSon)
 - [Jakub Maćkowski](https://github.com/mackowski)
-- [Robin Bailey](https://github.com/rbsec)
 - [Jim Manico](https://github.com/jmanico)
 
 Project links:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ In order to read the cheat sheets and **reference** them, use the project's [off
 ### Core Team
 
 - [Jakub Maćkowski](https://github.com/mackowski)
-- [Robin Bailey](https://github.com/rbsec)
 
 The core team contains a set of knowledgeable people that assist the project leaders in maintaining the repository and take actions on their own. The team follows a well documented process for issues and pull requests.
 


### PR DESCRIPTION
Based on the actions taken today, I am stepping down from the cheat sheets core team with immediate effect.

This project is meant to be a collaborative effort to create high quality, peer reviewed guidance for developers to follow. I have on interest in staying involved and continuing to contribute to a project where one of the project leads decides to make significant and unilateral changes in this manner.

@ThunderSon or @mackowski please merge.

~rbsec