### PR TITLE
Web Services Security: Add "Resources Limiting" sub-section under "Availability"

### DIFF
--- a/cheatsheets/Web_Service_Security_Cheat_Sheet.md
+++ b/cheatsheets/Web_Service_Security_Cheat_Sheet.md
@@ -95,6 +95,16 @@ Web services like web applications could be a target for DOS attacks by automati
 
 ## Availability
 
+### Resources Limiting
+
+During regular operation, web services require computational power such as CPU cycles and memory. Due to malfunctioning or while under attack, a web service may required too much resources, leaving the host system unstable.
+
+**Rule**: Limit the amount of CPU cycles the web service can use based on expected service rate, in order to have a stable system.
+
+**Rule**: Limit the amount of memory the web service can use to avoid system running out of memory. In some cases the host system may start killing processes to free up memory.
+
+**Rule**: Limit the number of simultaneous open files, network connections and started processes.
+
 ### Message Throughput
 
 Throughput represents the number of web service requests served during a specific amount of time.


### PR DESCRIPTION
Limiting resources a web service can use will help keeping the
host system stable and mitigate attacks such as Denial-of-Service.

This is an initial draft, open for discussion, and it includes
recommendations to limit the following resources:

* CPU cycles
* Memory
* Simultaneous open files, network connections and started
  processes

The idea to add such recomendations to this Cheat Sheet was first
discussed while working in the GraphQL CS PR #434.