### PR TITLE
Minor fix in crypto storage CS

### DIFF
--- a/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
+++ b/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
@@ -19,7 +19,7 @@ The use of dedicated secret or key management systems can provide an additional 
 Encryption can be performed on a number of levels in the application stack, such as:
 
 - At the application level.
-- At the database level (e.g, [SQL Server TDE](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption?view=sql-server-ver15)
+- At the database level (e.g, [SQL Server TDE](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption?view=sql-server-ver15))
 - At the filesystem level (e.g, BitLocker or LUKS)
 - At the hardware level (e.g, encrypted RAID cards or SSDs)
 


### PR DESCRIPTION
- The DB level bullet had mismatched brackets.
![image](https://user-images.githubusercontent.com/7570458/96805011-8fbb0d00-13de-11eb-8520-fa948052ee7d.png)

I don't see anything else that's off. I do note both usage of `i.e,` and `e.g,` however that's not necessarily a bad thing.