### PR TITLE
XSS: remove forward slash

### DIFF
--- a/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
@@ -97,7 +97,7 @@ Rule \#1 is for when you want to put untrusted data directly into the HTML body 
 </div>
 ```
 
-Encode the following characters with HTML entity encoding to prevent switching into any execution context, such as script, style, or event handlers. Using hex entities is recommended in the spec. In addition to the 5 characters significant in XML (`&`, `<`, `>`, `"`, `'`), the forward slash is included as it helps to end an HTML entity.
+Encode the following characters with HTML entity encoding to prevent switching into any execution context, such as script, style, or event handlers. Using hex entities is recommended in the spec. The 5 characters significant in XML (`&`, `<`, `>`, `"`, `'`):
 
 ```text
  & --> &amp;
@@ -105,11 +105,8 @@ Encode the following characters with HTML entity encoding to prevent switching i
  > --> &gt;
  " --> &quot;
  ' --> &#x27;
- / --> &#x2F;
 
  &apos; not recommended because its not in the HTML spec (See: section 24.4.1) &apos; is in the XML and XHTML specs.
-
- Forward slash is included as it helps end an HTML entity
 ```
 
 ### RULE \#2 - Attribute Encode Before Inserting Untrusted Data into HTML Common Attributes


### PR DESCRIPTION
Encoding forward slash is an unneeded usage of the encoding. The only
characters that should be encoded would be the reserved characters `&`, `<`,
`>` and `"`:

https://developer.mozilla.org/Glossary/Entity

Further these implementations from major programming language vendors dont
encode forward slash:

- https://docs.microsoft.com/dotnet/api/system.web.httputility.htmlencode
- https://golang.org/pkg/html#EscapeString
- https://php.net/function.htmlentities
- https://docs.python.org/library/html.html#html.escape
- https://ruby-doc.org/stdlib/libdoc/cgi/rdoc/CGI/Util.html#method-i-escapeHTML

I found other implementations as well with same behavior. Note that these
implementations are doing encoding, but just not with the forward slash
character. Further, its not recommended by the HTML5 specification:

https://w3.org/TR/html52/syntax.html#serializing-html-fragments

or even the HTML Living Standard:

https://html.spec.whatwg.org/multipage/parsing.html#serialising-html-fragments

