### PR TITLE
Office 365 now supports sub-addressing

### DIFF
--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -227,7 +227,7 @@ Sub-addressing allows a user to specify a _tag_ in the local part of the email a
 - `user+site1@example.org`
 - `user+site2@example.org`
 
-Many mail providers (such as Microsoft Exchange/Office 365) do not support sub-addressing. The most notable provider who does is Gmail, although there are many others that also do.
+Many mail providers (such as Microsoft Exchange) do not support sub-addressing. The most notable provider who does is Gmail, although there are many others that also do.
 
 Some users will use a different _tag_ for each website they register on, so that if they start receiving spam to one of the sub-addresses they can identify which website leaked or sold their email address.
 


### PR DESCRIPTION
Remove "Office 365" from examples of mail providers which do not support
sub-addressing. They do since September 2020 [1] but configuration per
organization ("AllowPlusAddressInRecipients") is needed [2].

[1] https://www.microsoft.com/en-us/microsoft-365/roadmap?filters=&searchterms=59441
[2] https://docs.microsoft.com/en-us/powershell/module/exchange/set-organizationconfig?view=exchange-ps

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
