### PR TITLE
Update HIBP link to latest (v3) version of API

### DIFF
--- a/cheatsheets/Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Authentication_Cheat_Sheet.md
@@ -33,7 +33,7 @@ A key concern when using passwords for authentication is password strength. A "s
 - Ensure credential rotation when a password leak, or at the time of compromise identification.
 - Include password strength meter to help users create a more complex password and block common and previously breached passwords
     - [zxcvbn library](https://github.com/dropbox/zxcvbn) can be used for this purpose. (Note that this library is no longer maintained)
-    - [Pwned Passwords](https://haveibeenpwned.com/Passwords) is a service where passwords can be checked against previously breached passwords. You can host it yourself or use [API](https://haveibeenpwned.com/API/v2#PwnedPasswords).
+    - [Pwned Passwords](https://haveibeenpwned.com/Passwords) is a service where passwords can be checked against previously breached passwords. You can host it yourself or use [API](https://haveibeenpwned.com/API/v3#PwnedPasswords).
 
 #### For more detailed information check
 


### PR DESCRIPTION
Minor fix.

Currently the cheat sheet links to v2.

The docs are roughly the same, but the v2 says at the top "...this documentation remains for historic reasons only."

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 