### PR TITLE
Extend Web Storage

### DIFF
--- a/cheatsheets/Session_Management_Cheat_Sheet.md
+++ b/cheatsheets/Session_Management_Cheat_Sheet.md
@@ -224,6 +224,18 @@ Due to the potential to access Web Storage APIs via an XSS attack, session ident
 - [SessionStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
 - [WHATWG Web Storage Spec](https://html.spec.whatwg.org/multipage/webstorage.html#webstorage)
 
+## Web Workers
+
+Web Workers run JavaScript code in a global context separate from the one of the current window. A communication channel with the main execution window exists, which is called `MessageChannel`.
+
+### Use Case
+
+Web Workers are an alternative for browser storage of (session) secrets when storage persistence across page refresh is not a requirement. For Web Workers to provide secure browser storage, any code that requires the secret should exist within the Web Worker and the secret should never be transmitted to the main window context.
+
+Storing secrets within the memory of a Web Worker offers the same security guarantees as an HttpOnly cookie: the confidentiality of the secret is protected. Still, an XSS attack can be used to send messages to the Web Worker to perform an operation that requires the secret. The Web Worker will return the result of the operation to the main execution thread.
+
+The advantage of a Web Worker implementation compared to an HttpOnly cookie is that a Web Worker allows for some isolated JavaScript code to access the secret; an HttpOnly cookie is not accessible to any JavaScript. If the frontend JavaScript code requires access to the secret, the Web Worker implementation is the only browser storage option that preserves the secret confidentiality.
+
 ## Session ID Life Cycle
 
 ### Session ID Generation and Verification: Permissive and Strict Session Management

--- a/cheatsheets/Session_Management_Cheat_Sheet.md
+++ b/cheatsheets/Session_Management_Cheat_Sheet.md
@@ -128,7 +128,7 @@ See also: [SecureFlag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
 
 ### HttpOnly Attribute
 
-The `HttpOnly` cookie attribute instructs web browsers not to allow scripts (e.g. JavaScript or VBscript) an ability to access the cookies via the DOM document.cookie object. This session ID protection is mandatory to prevent session ID stealing through XSS attacks.
+The `HttpOnly` cookie attribute instructs web browsers not to allow scripts (e.g. JavaScript or VBscript) an ability to access the cookies via the DOM document.cookie object. This session ID protection is mandatory to prevent session ID stealing through XSS attacks. However, if an XSS attack is combined with a CSRF attack, the requests sent to the web application will include the session cookie, as the browser always includes the cookies when sending requests. The `HttpOnly` cookie only protects the confidentiality of the cookie; the attacker cannot use it offline, outside of the context of an XSS attack.
 
 See the OWASP [XSS (Cross Site Scripting) Prevention Cheat Sheet](Cross_Site_Scripting_Prevention_Cheat_Sheet.md).
 


### PR DESCRIPTION
This PR is a result of the discussion in https://github.com/OWASP/ASVS/issues/843.

1. Extends the `HttpOnly` section for cookies to clearly state what an HttpOnly cookie protects and how an XSS attack is combined with a CSRF attack can use the HttpOnly cookie
2. Adds a new section about how Web Workers can be used to store secrets. 