### PR TITLE
build(deps): bump dependencies

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -14,13 +14,13 @@ jobs:
       WORKFLOW_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install Python dependencies
@@ -37,8 +37,8 @@ jobs:
       run: cd generated && zip -r ../bundle.zip site
     - name: Test bundle
       run: zip -T bundle.zip
-    - name: Upload bundle as artifcact
-      uses: actions/upload-artifact@v1
+    - name: Upload bundle as artifact
+      uses: actions/upload-artifact@v2
       with:
         name: Bundle
         path: bundle.zip
@@ -50,7 +50,7 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install dependencies
       run: sudo apt-get install -y unzip zip
     - name: Swith to offline website (gh-pages) branch

--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -12,13 +12,13 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: SetUp python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install python dependencies

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -13,9 +13,9 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: Install dependencies

--- a/.github/workflows/md_lint_check.yml
+++ b/.github/workflows/md_lint_check.yml
@@ -13,9 +13,9 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: Install dependencies

--- a/.github/workflows/publishing-check.yml
+++ b/.github/workflows/publishing-check.yml
@@ -13,13 +13,13 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: SetUp python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install python dependencies

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "markdownlint-cli": "^0.19.0",
+    "markdownlint-cli": "^0.26.0",
     "textlint": "^11.6.3",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-filter-rule-whitelist": "^2.0.0",


### PR DESCRIPTION
Bump both node and GitHub Actions dependencies to latest versions.

- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

