### PR TITLE
build(deps): bump dependencies

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         node-version: 12.x
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2.2.1
       with:
         python-version: '3.x'
     - name: Install Python dependencies

--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -37,8 +37,8 @@ jobs:
       run: cd generated && zip -r ../bundle.zip site
     - name: Test bundle
       run: zip -T bundle.zip
-    - name: Upload bundle as artifcact
-      uses: actions/upload-artifact@v1
+    - name: Upload bundle as artifact
+      uses: actions/upload-artifact@v2.2.2
       with:
         name: Bundle
         path: bundle.zip

--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Action
       uses: actions/checkout@v1
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
       with:
         node-version: 12.x
     - name: Setup Python

--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Action
       uses: actions/checkout@v1
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
       with:
         node-version: 12.x
     - name: SetUp python

--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -12,7 +12,7 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.4
     - name: Setup Node
       uses: actions/setup-node@v2.1.5
       with:

--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: 12.x
     - name: SetUp python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2.2.1
       with:
         python-version: '3.x'
     - name: Install python dependencies

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -13,7 +13,7 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.4
     - name: Setup Node
       uses: actions/setup-node@v2.1.5
       with:

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Action
       uses: actions/checkout@v1
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
       with:
         node-version: 12.x
     - name: Install dependencies

--- a/.github/workflows/md_lint_check.yml
+++ b/.github/workflows/md_lint_check.yml
@@ -13,7 +13,7 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.4
     - name: Setup Node
       uses: actions/setup-node@v2.1.5
       with:

--- a/.github/workflows/md_lint_check.yml
+++ b/.github/workflows/md_lint_check.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Action
       uses: actions/checkout@v1
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
       with:
         node-version: 12.x
     - name: Install dependencies

--- a/.github/workflows/publishing-check.yml
+++ b/.github/workflows/publishing-check.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Action
       uses: actions/checkout@v1
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2.1.5
       with:
         node-version: 12.x
     - name: SetUp python

--- a/.github/workflows/publishing-check.yml
+++ b/.github/workflows/publishing-check.yml
@@ -13,7 +13,7 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.4
     - name: Setup Node
       uses: actions/setup-node@v2.1.5
       with:

--- a/.github/workflows/publishing-check.yml
+++ b/.github/workflows/publishing-check.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: 12.x
     - name: SetUp python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2.2.1
       with:
         python-version: '3.x'
     - name: Install python dependencies

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "markdownlint-cli": "^0.19.0",
+    "markdownlint-cli": "^0.26.0",
     "textlint": "^11.6.3",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-filter-rule-whitelist": "^2.0.0",


### PR DESCRIPTION
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).


This PR closes #549 

I was unable to bump `actions/checkout` in `build-and-deploy-site.yml` as that was throwing an error when attempting to build, as noted in #549, but was able to update that action successfully in all other GitHub workflow files.
