### PR TITLE
Remove extraneous 'Table of contents'

### DIFF
--- a/IndexProactiveControls.md
+++ b/IndexProactiveControls.md
@@ -1,20 +1,5 @@
 # Proactive Controls Index
 
-## Table of Contents
-
-- [Table of contents](#table-of-contents)
-- [Objective](#objective)
-- [1. Define Security Requirements](#1-define-security-requirements)
-- [2. Leverage Security Frameworks and Libraries](#2-leverage-security-frameworks-and-libraries)
-- [3. Secure Database Access](#3-secure-database-access)
-- [4. Encode and Escape Data](#4-encode-and-escape-data)
-- [5. Validate All Inputs](#5-validate-all-inputs)
-- [6. Implement Digital Identity](#6-implement-digital-identity)
-- [7. Enforce Access Controls](#7-enforce-access-controls)
-- [8. Protect Data Everywhere](#8-protect-data-everywhere)
-- [9. Implement Security Logging and Monitoring](#9-implement-security-logging-and-monitoring)
-- [10. Handle All Errors and Exceptions](#10-handle-all-errors-and-exceptions)
-
 ## Objective
 
 This cheatsheet will help users of the [OWASP Proactive Controls](https://owasp.org/www-project-proactive-controls/) identify which cheatsheets map to each proactive controls item. This mapping is based the [OWASP Proactive Controls](https://owasp.org/www-project-proactive-controls/) version 3.0 (2018).

--- a/cheatsheets/Microservices_security.md
+++ b/cheatsheets/Microservices_security.md
@@ -4,26 +4,6 @@
 
 The microservice architecture is being increasingly used for designing and implementing application systems in both cloud-based and on-premise infrastructures, high-scale applications and services. There are many security challenges need to be addressed in the application design and implementation phases. The fundamental security requirements that have to be addressed during design phase are authentication and authorization. Therefore, it is vital for applications security architects to understand and properly use existing architecture patterns to implement authentication and authorization in microservices-based systems. The goal of this cheat sheet is to identify such patterns and to do recommendations for applications security architect on possible way to use it.
 
-## Table of contents
-
-- [Edge-level authorization](#edge-level-authorization)
-- [Service-level authorization](#service-level-authorization)
-    - [Service-level authorization: existing patterns](#service-level-authorization:-existing-patterns)
-        - [Decentralized pattern](#decentralized-pattern)
-        - [Centralized pattern with single policy decision point](#centralized-pattern-with-single-policy-decision-point)
-        - [Centralized pattern with embedded policy decision point](#centralized-pattern-with-embedded-policy-decision-point)
-    - [Recommendation on how to implement authorization](#recommendation-on-how-to-implement-authorization)
-- [External entity identity propagation](#external-entity-identity-propagation)
-    - [Identity propagation: existing patterns](#identity-propagation:-existing-patterns)
-        - [Send the external entity identity as a clear or self-signed data structures](#send-the-external-entity-identity-as-a-clear-or-self-signed-data-structures)
-        - [Using a data structures signed by a trusted issuer](#using-a-data-structures-signed-by-a-trusted-issuer)
-    - [Recommendation on how to implement identity propogation](#recommendation-on-how-to-implement-identity-propogation)
-- [Service-to-service authentication](#service-to-service-authentication)
-    - [Service-to-service authentication: existing patterns](#service-to-service-authentication:-existing-patterns)
-        - [Mutual transport layer security](#mutual-transport-layer-security)
-        - [Token based](#token-based)
-- [References](#references)
-
 ## Edge-level authorization
 
 In simple scenario, authorization can happen only at the edge level (API gateway). The API gateway can be leveraged to centralize enforcement of authorization for all downstream microservices, eliminating the need to provide authentication and access control for each of the individual services. In such case, [NIST recommends](https://doi.org/10.6028/NIST.SP.800-204) to implement mitigating controls such as mutual authentication to prevent direct, anonymous connections to the internal services (API gateway bypass). It should be noted that authorization at the edge layer has a [following limitations](https://www.youtube.com/watch?v=UnXjwCWgBKU):


### PR DESCRIPTION
Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
----
This PR removes the extraneous 'Table of contents' from two files:
- cheatsheets/Microservices_security.md 
- IndexProactiveControls.md

These TOCs are extraneous because `mkdocs.yml` is configured to create TOCs for everything; the duplicate cheatsheets are visible [here](https://cheatsheetseries.owasp.org/IndexProactiveControls.html#table-of-contents) and [here](https://cheatsheetseries.owasp.org/cheatsheets/Microservices_security.html#table-of-contents).

I had just written some code to *add* TOCs into each of the cheatsheet files, but belatedly discovered that the official website already generated TOCs.  D'oh!
