### PR TITLE
Not installing security updates is bad advice

### DIFF
--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -257,7 +257,6 @@ Many issues can be prevented by following some best practices when writing the D
 - Ensure the base image version is pinned
 - Ensure the OS packages versions are pinned
 - Avoid the use of `ADD` in favor of `COPY`
-- Avoid the use of `apt/apk upgrade`
 - Avoid curl bashing in `RUN` directives
 
 References:


### PR DESCRIPTION
This is obviously bad advice: security updates are important, and should be installed.

For more detailed explanation of why installing security updates in Docker builds is a good idea (I still can't believe I have to write this sentence, or had to write this article...), see https://pythonspeed.com/articles/security-updates-in-docker/