### PR TITLE
Add details about new way to pin on iOS

### DIFF
--- a/cheatsheets/Pinning_Cheat_Sheet.md
+++ b/cheatsheets/Pinning_Cheat_Sheet.md
@@ -90,6 +90,8 @@ Lastly, if you want to validate whether the pinning is successful, please follow
 
 ### iOS
 
+Apple suggests pinning a CA public key by specifying it in `Info.plist` file under App Transport Security Settings. More details in [Identity Pinning: How to configure server certificates for your app](https://developer.apple.com/news/?id=g9ejcf8y) article.
+
 [TrustKit](https://github.com/datatheorem/TrustKit), an open-source SSL pinning library for iOS and macOS is available. It provides an easy-to-use API for implementing pinning, and has been deployed in many apps.
 
 Otherwise, more details regarding how SSL validation can be customized on iOS (in order to implement pinning) are available in the [HTTPS Server Trust Evaluation](https://developer.apple.com/library/content/technotes/tn2232/_index.html) technical note. However, implementing pinning validation from scratch should be avoided, as implementation mistakes are extremely likely and usually lead to severe vulnerabilities.


### PR DESCRIPTION
This year Apple has introduced a new and easy way to add pinning to the project: by specifying the CA public key in Info.plist file. 
Reference: https://developer.apple.com/news/?id=g9ejcf8y
Added this approach to the Cheat Sheet as the one recommended by Apple.

___
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] Any references to websites have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

This PR covers issue #620.