### PR TITLE
Fix spelling error: genererated -> generated

### DIFF
--- a/cheatsheets/Forgot_Password_Cheat_Sheet.md
+++ b/cheatsheets/Forgot_Password_Cheat_Sheet.md
@@ -13,7 +13,7 @@ The following short guidelines can be used as a quick reference to protect the f
 - **Use a side-channel to communicate the method to reset their password.**
 - **Use [URL tokens](#url-tokens) for the simplest and fastest implementation.**
 - **Ensure that generated tokens or codes are:**
-    - **Randomly genererated using a cryptographically safe algorithm.**
+    - **Randomly generated using a cryptographically safe algorithm.**
     - **Sufficiently long to protect against brute-force attacks.**
     - **Stored securely.**
     - **Single use and expire after an appropriate period.**


### PR DESCRIPTION
👋 Dropping by with a small spelling fix.

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

