### PR TITLE
Adjust information on logging as non-repudiation control

### DIFF
--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -15,7 +15,7 @@ Application logging should be always be included for security events. Applicatio
 - Identifying security incidents
 - Monitoring policy violations
 - Establishing baselines
-- Assisting non-repudiation controls (note that the trait non-repudiation is hard to achieve for logs because the their trustworthyness is often just based on the logging party being audited properly while machanisms like digital signatures are hard to utilize here) 
+- Assisting non-repudiation controls (note that the trait non-repudiation is hard to achieve for logs because the their trustworthyness is often just based on the logging party being audited properly while machanisms like digital signatures are hard to utilize here)
 - Providing information about problems and unusual conditions
 - Contributing additional application-specific data for incident investigation which is lacking in other log sources
 - Helping defend against vulnerability identification and exploitation through attack detection

--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -15,7 +15,7 @@ Application logging should be always be included for security events. Applicatio
 - Identifying security incidents
 - Monitoring policy violations
 - Establishing baselines
-- Assisting non-repudiation controls
+- Assisting non-repudiation controls (note that the trait non-repudiation is hard to achieve for logs because the their trustworthyness is often just based on the logging party being audited properly, machanisms like digital signatures are hard to utilize here) 
 - Providing information about problems and unusual conditions
 - Contributing additional application-specific data for incident investigation which is lacking in other log sources
 - Helping defend against vulnerability identification and exploitation through attack detection

--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -15,7 +15,7 @@ Application logging should be always be included for security events. Applicatio
 - Identifying security incidents
 - Monitoring policy violations
 - Establishing baselines
-- Assisting non-repudiation controls (note that the trait non-repudiation is hard to achieve for logs because the their trustworthyness is often just based on the logging party being audited properly, machanisms like digital signatures are hard to utilize here) 
+- Assisting non-repudiation controls (note that the trait non-repudiation is hard to achieve for logs because the their trustworthyness is often just based on the logging party being audited properly while machanisms like digital signatures are hard to utilize here) 
 - Providing information about problems and unusual conditions
 - Contributing additional application-specific data for incident investigation which is lacking in other log sources
 - Helping defend against vulnerability identification and exploitation through attack detection

--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -15,7 +15,7 @@ Application logging should be always be included for security events. Applicatio
 - Identifying security incidents
 - Monitoring policy violations
 - Establishing baselines
-- Assisting non-repudiation controls (note that the trait non-repudiation is hard to achieve for logs because the their trustworthyness is often just based on the logging party being audited properly while machanisms like digital signatures are hard to utilize here)
+- Assisting non-repudiation controls (note that the trait non-repudiation is hard to achieve for logs because their trustworthyness is often just based on the logging party being audited properly while machanisms like digital signatures are hard to utilize here)
 - Providing information about problems and unusual conditions
 - Contributing additional application-specific data for incident investigation which is lacking in other log sources
 - Helping defend against vulnerability identification and exploitation through attack detection


### PR DESCRIPTION
This PR aims to solve a problem that I have had with the cheatsheet. The claim that logging assists with non-repudiation controls had me confused for a while because it was hard for me to imagine that logs could have the trait of non-repudiation. Say I buy something from an online shop and later claim that I did not really buy something. The logs from the retailer are not enough to prove that I bought something because the retailer has full control over his logging. There is no way of ensuring that the retailer has not forged his logs except for auditing his logging solution for correctness and security. Therefore, this is very different from non-repudiation with digital signatures where the actor is in control to a large degree because he signs something that can later not be repudiated.

I hope that you agree that my addition helps clarify what is meant by non-repudiation in the domain of logging. But I would also be happy to hear feedback if you disagree or think that there is something wrong with the edition.


Additional information:
- LogSentinel claims: "Many standards and regulations are leaning towards this property of logs although to make things simpler, many organizations and auditors alike, have accepted solutions that don’t have strong non-repudiation." (https://logsentinel.com/blog/non-repudiation-of-logs-and-blockchain/)