### PR TITLE
Fixing a typo in Threat_Modeling_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/Threat_Modeling_Cheat_Sheet.md
+++ b/cheatsheets/Threat_Modeling_Cheat_Sheet.md
@@ -216,7 +216,7 @@ During this phase conduct the following activities:
 
 ### Mapping Abuse Cases to Use Cases
 
-This is a very important step that can help identifying application logical threats. list of all possible abuse cases should be developed for each application use case. Being familiar with the types of application logical attack is an important during the mapping process. You can refer to OWASP Testing Guide 4.0: Business Logic Testing and OWASP ASVA for more details.
+This is a very important step that can help identifying application logical threats. list of all possible abuse cases should be developed for each application use case. Being familiar with the types of application logical attack is an important during the mapping process. You can refer to OWASP Testing Guide 4.0: Business Logic Testing and OWASP ASVS for more details.
 
 ### Re-Define attack vectors
 


### PR DESCRIPTION
Correcting a typo. ASVS, not ASVA I think.

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
