### PR TITLE
Add setting XMLConstants.ACCESS_EXTERNAL_DTD to XMLInputFactory

### DIFF
--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -180,6 +180,8 @@ To protect a Java `XMLInputFactory` from XXE, do this:
 ``` java
 // This disables DTDs entirely for that factory
 xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+// This causes XMLStreamException to be thrown if external DTDs are accessed.
+xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 // disable external entities
 xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 ```


### PR DESCRIPTION
This PR adds `xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "")` to the XMLInputFactory code snippet. This guarantees an XMLStreamException to be thrown if external DTDs are accessed.

This PR covers issue #758.
