### PR TITLE
Explain X-XSS-Protection:0 recommendation

### DIFF
--- a/cheatsheets/HTTP_Headers_Cheat_Sheet.md
+++ b/cheatsheets/HTTP_Headers_Cheat_Sheet.md
@@ -26,6 +26,8 @@ The HTTP `X-XSS-Protection` response header is a feature of Internet Explorer, C
 Do not set this header or explicitly turn it off.
 > `X-XSS-Protection: 0`
 
+Please read [X-XSS_Protection should be disabled](https://github.com/OWASP/CheatSheetSeries/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md#x-xss-protection-header) for details.
+
 ### X-Content-Type-Options
 
 The `X-Content-Type-Options` response HTTP header is used by the server to prevent browsers from guessing the media type ( MIME type).


### PR DESCRIPTION
I was surprised to see the recommendation to not set or disable the X-XSS-Protection header. Then I remembered reading some articles about enabling it could have the opposite effect, i.e. more XSS.

This PR adds a link to the XSS prevention cheat sheet which does a good job of explain why it should be turned off. Could be handy for those who are not yet "in the know" of these reasons.

Please make sure that for your contribution:

- [X] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [X] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [X] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [X] All your assets are stored in the **assets** folder.
- [X] All the images used are in the **PNG** format.
- [X] Any references to websites have been formatted as [TEXT](URL)
- [X] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [X] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).
