### PR TITLE
Header CS Tweaks

### DIFF
--- a/cheatsheets/HTTP_Headers_Cheat_Sheet.md
+++ b/cheatsheets/HTTP_Headers_Cheat_Sheet.md
@@ -191,36 +191,36 @@ The HTTP `Public-Key-Pins` response header is used to associate a specific crypt
 
 This header is deprecated. Use `Expect-CT` instead.
 
-## Adding Http Headers in Different Technologies
+## Adding HTTP Headers in Different Technologies
 
 ### PHP
 
-Below sample code sets the `X-XSS-Protection` header in PHP.
+The sample code below sets the `X-Frame-Options` header in PHP.
 
 ```php
-header("X-XSS-Protection: 1; mode=block");
+header("X-Frame-Options: DENY");
 ```
 
 ### Apache
 
-Below `.htaccess` sample configuration sets the `X-XSS-Protection` header in Apache.
+Below is an `.htaccess` sample configuration which sets the `X-Frame-Options` header in Apache.
 
 ```lang-bsh
 <IfModule mod_headers.c>
-Header set X-XSS-Protection "1; mode=block"
+Header set X-Frame-Options "DENY"
 </IfModule>
 ```
 
 ### IIS
 
-Add below configurations to your `Web.config` in ISS to send the `X-XSS-Protection` header
+Add configurations below to your `Web.config` in ISS to send the `X-Frame-Options` header.
 
 ```xml
 <system.webServer>
 ...
  <httpProtocol>
    <customHeaders>
-     <add name="X-XSS-Protection" value="1; mode=block" />
+     <add name="X-Frame-Options" value="DENY" />
    </customHeaders>
  </httpProtocol>
 ...
@@ -229,23 +229,23 @@ Add below configurations to your `Web.config` in ISS to send the `X-XSS-Protecti
 
 ### HAProxy
 
-Add the below line to your font-end, listen, or backend configurations to send the `X-XSS-Protection` header
+Add the line below to your font-end, listen, or backend configurations to send the `X-Frame-Options` header.
 
 ```lang-none
-http-response set-header X-XSS-Protection 1; mode=block
+http-response set-header X-Frame-Options DENY
 ```
 
 ### Nginx
 
-Below sample configuration, sets the `X-XSS-Protection` header in Nginx.
+Below is a sample configuration, it sets the `X-Frame-Options` header in Nginx.
 
 ```lang-none
-add_header "X-XSS-Protection" "1; mode=block";
+add_header "X-Frame-Options" "DENY";
 ```
 
 ### Express
 
-You can use [helmet](https://www.npmjs.com/package/helmet) to setup HTTP headers in Express. Below code is sample for adding the `X-Frame-Options` header.
+You can use [helmet](https://www.npmjs.com/package/helmet) to setup HTTP headers in Express. The code below is sample for adding the `X-Frame-Options` header.
 
 ```javascript
 const helmet = require('helmet');


### PR DESCRIPTION
* Make the examples heading use fullcaps for HTTP accronym.
* Adjust all examples to use XFO. (Should show something the CS suggests, not something it says to avoid.) [Ref: <https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection>]
* Tweak lead-in sentences on examples to read easier and all have periods.

- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).