### PR TITLE
Add link to OSHP in references

### DIFF
--- a/cheatsheets/HTTP_Headers_Cheat_Sheet.md
+++ b/cheatsheets/HTTP_Headers_Cheat_Sheet.md
@@ -286,3 +286,4 @@ Online tools usually test the homepage of the given address. But SmartScanner sc
 - [Mozilla: Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy)
 - [Mozilla: Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy)
 - [Mozilla: Server Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server)
+- [Linked OWASP project: Secure Headers Project](https://owasp.org/www-project-secure-headers/)


### PR DESCRIPTION
Hi,

This PR just add a link to the [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/) in the **References** section of the [HTTP Headers CS](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/HTTP_Headers_Cheat_Sheet.md).

The goal is just to let reader be aware of the existence of the *OWASP Secure Headers Project* regarding information about HTTP headers than can be used by an app.

Thank in advance 😃 