### PR TITLE
Add argument escaping to .NET OS Command injection examples to resolve #774

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -300,6 +300,27 @@ if (!string.IsNullOrEmpty(ipAddress))
 }
 ```
 
+DO: Use character escaping where allow-list validation cannot be relied upon.
+
+e.g. escaping double quotes within arguments and then surrounding the arguments with double quotes.
+
+``` csharp
+// This list will contain the arguments which we want to escape before passing to the function
+var arguments = new List<string>(){"Argument1", "Argument\"2&|", "\"Argument3\""};
+
+// Escaping Stage 1: All " (double quote) characters within the arguments are doubled to escape  
+// them on the command line so they will only ever be interpreted as data and not as an
+// argument separator
+arguments = arguments.ConvertAll(s => s.Replace("\"", "\"\""));
+
+// Escaping Stage 2: The arguments should be surrounded by " (double quote) characters to 
+// ensure that the data in the arguments cannot break out of the current argument
+arguments = arguments.ConvertAll(s => $"\"{s}\"");
+
+// Pass the escaped arguments to the "ProcessStartInfo" object
+process.Arguments = string.Join(" ", arguments);
+```
+
 #### LDAP injection
 
 Almost any characters can be used in Distinguished Names. However, some must be escaped with the backslash `\` escape character. A table showing which characters that should be escaped for Active Directory can be found at the in the [LDAP Injection Prevention Cheat Sheet](LDAP_Injection_Prevention_Cheat_Sheet.md#introduction).

--- a/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md
+++ b/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md
@@ -198,6 +198,7 @@ process.StartInfo = startInfo;
 
 process.Start();
 ```
+
 Where input validation cannot be relied upon, arguments can be made safe by escaping double quotes within the arguments and then surrounding each argument with double quotes.
 
 ``` csharp

--- a/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md
+++ b/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md
@@ -198,6 +198,24 @@ process.StartInfo = startInfo;
 
 process.Start();
 ```
+Where input validation cannot be relied upon, arguments can be made safe by escaping double quotes within the arguments and then surrounding each argument with double quotes.
+
+``` csharp
+// This list will contain the arguments which we want to escape before passing to the function
+var arguments = new List<string>(){"Argument1", "Argument\"2&|", "\"Argument3\""};
+
+// Escaping Stage 1: All " (double quote) characters within the arguments are doubled to escape  
+// them on the command line so they will only ever be interpreted as data and not as an
+// argument separator
+arguments = arguments.ConvertAll(s => s.Replace("\"", "\"\""));
+
+// Escaping Stage 2: The arguments should be surrounded by " (double quote) characters to 
+// ensure that the data in the arguments cannot break out of the current argument
+arguments = arguments.ConvertAll(s => $"\"{s}\"");
+
+// Pass the escaped arguments to the "ProcessStartInfo" object
+process.Arguments = string.Join(" ", arguments);
+```
 
 ### PHP
 


### PR DESCRIPTION
Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

~~- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).~~
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
~~- [ ] All your assets are stored in the **assets** folder.~~
~~- [ ] All the images used are in the **PNG** format.~~
~~- [ ] Any references to websites have been formatted as [TEXT](URL)~~
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #774

Thank you again for your contribution :smiley:
