### PR TITLE
Updating Clickjacking SameSite cookie link

### DIFF
--- a/cheatsheets/Clickjacking_Defense_Cheat_Sheet.md
+++ b/cheatsheets/Clickjacking_Defense_Cheat_Sheet.md
@@ -7,7 +7,7 @@ This cheat sheet is intended to provide guidance for developers on how to defend
 There are three main mechanisms that can be used to defend against these attacks:
 
 - Preventing the browser from loading the page in frame using the [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) or [Content Security Policy (frame-ancestors)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) HTTP headers.
-- Preventing session cookies from being included when the page is loaded in a frame using the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives) cookie attribute.
+- Preventing session cookies from being included when the page is loaded in a frame using the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) cookie attribute.
 - Implementing JavaScript code in the page to attempt to prevent it being loaded in a frame (known as a "frame-buster").
 
 Note that these mechanisms are all independent of each other, and where possible more than one of them should be implemented in order to provide defense in depth.


### PR DESCRIPTION
Fixing the link on the Clickjacking page to have the correct link to the SameSite cookie flag MDN page.