### PR TITLE
Fix numbered list indentation

### DIFF
--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -34,18 +34,18 @@ Configuring the container to use an unprivileged user is the best way to prevent
 
 1. During runtime using `-u` option of `docker run` command e.g.:
 
-```bash
-docker run -u 4000 alpine
-```
+    ```bash
+    docker run -u 4000 alpine
+    ```
 
 2. During build time. Simple add user in Dockerfile and use it. For example:
 
-```docker
-FROM alpine
-RUN groupadd -r myuser && useradd -r -g myuser myuser
-<HERE DO WHAT YOU HAVE TO DO AS A ROOT USER LIKE INSTALLING PACKAGES ETC.>
-USER myuser
-```
+    ```docker
+    FROM alpine
+    RUN groupadd -r myuser && useradd -r -g myuser myuser
+    <HERE DO WHAT YOU HAVE TO DO AS A ROOT USER LIKE INSTALLING PACKAGES ETC.>
+    USER myuser
+    ```
 
 3. Enable user namespace support (`--userns-remap=default`) in [Docker daemon](https://docs.docker.com/engine/security/userns-remap/#enable-userns-remap-on-the-daemon)
 


### PR DESCRIPTION
Numbered list with code blocks was incorrectly rendered in MkDocs. I added indentation for code blocks so now they must not break numbered list.

[Source](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user):
![изображение](https://user-images.githubusercontent.com/14791483/145185282-5a34cd60-e916-4e76-b3e3-a1366fcfb452.png)

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).
