### PR TITLE
Fix: broken link to Application Logging Vocabulary cheat sheet & updated reference

### DIFF
--- a/IndexTopTen.md
+++ b/IndexTopTen.md
@@ -69,7 +69,7 @@ This cheat sheet will help users of the [OWASP Top Ten](https://owasp.org/www-pr
 ## [A09:2021 – Security Logging and Monitoring Failures](https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/)
 
 * [Logging Cheat Sheet](cheatsheets/Logging_Cheat_Sheet.md)
-* [Application Logging Vocabulary Cheat Sheet](cheatsheets/Application_Logging_Vocabulary_Cheat_Sheet.md)
+* [Application Logging Vocabulary Cheat Sheet](cheatsheets/Logging_Vocabulary_Cheat_Sheet.md)
 
 ## [A10:2021 – Server-Side Request Forgery (SSRF)](https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/)
 

--- a/cheatsheets/Session_Management_Cheat_Sheet.md
+++ b/cheatsheets/Session_Management_Cheat_Sheet.md
@@ -98,7 +98,7 @@ A web application should make use of cookies for session ID exchange management.
 
 ### Transport Layer Security
 
-In order to protect the session ID exchange from active eavesdropping and passive disclosure in the network traffic, it is essential to use an encrypted HTTPS (TLS) connection for the entire web session, not only for the authentication process where the user credentials are exchanged. This may be mitigated by [HTTP Strict Transport Security (HSTS)](./HTTP_Strict_Transport_Security_Cheat_Sheet.html) for a client that supports it.
+In order to protect the session ID exchange from active eavesdropping and passive disclosure in the network traffic, it is essential to use an encrypted HTTPS (TLS) connection for the entire web session, not only for the authentication process where the user credentials are exchanged. This may be mitigated by [HTTP Strict Transport Security (HSTS)](HTTP_Strict_Transport_Security_Cheat_Sheet.md) for a client that supports it.
 
 Additionally, the `Secure` [cookie attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies) must be used to ensure the session ID is only exchanged through an encrypted channel. The usage of an encrypted communication channel also protects the session against some session fixation attacks where the attacker is able to intercept and manipulate the web traffic to inject (or fix) the session ID on the victim's web browser (see [here](https://media.blackhat.com/bh-eu-11/Raul_Siles/BlackHat_EU_2011_Siles_SAP_Session-Slides.pdf) and [here](https://media.blackhat.com/bh-eu-11/Raul_Siles/BlackHat_EU_2011_Siles_SAP_Session-WP.pdf)).
 


### PR DESCRIPTION
Fix: broken link to Application Logging Vocabulary cheat sheet in Index Top Ten 
Updated: link to the HTTP Security Markdown .md, instead of .html, in Session Management cheat sheet

Generating the site (master) gives two warnings which i hope to address with this.

```
WARNING  -  Documentation file 'IndexTopTen.md' contains a link to 'cheatsheets/Application_Logging_Vocabulary_Cheat_Sheet.md' which is not found in the documentation files.
WARNING  -  Documentation file 'cheatsheets/Session_Management_Cheat_Sheet.md' contains a link to 'cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html' which is not found in the
            documentation files.
```



