### PR TITLE
Update Transport_Layer_Protection_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.md
+++ b/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.md
@@ -23,7 +23,7 @@ The terms "SSL", "SSL/TLS" and "TLS" are frequently used interchangeably, and in
 
 ### Only Support Strong Protocols
 
-The SSL protocols have a large number of weaknesses, and should not be used in any circumstances. General purpose web applications should only support TLS 1.2 and TLS 1.3, with all other protocols disabled. Where it is known that a web server must support legacy clients with unsupported an insecure browsers (such as Internet Explorer 10), it may be necessary to enable TLS 1.0 to provide support.
+The SSL protocols have a large number of weaknesses, and should not be used in any circumstances. General purpose web applications should default to TLS 1.3 (support TLS 1.2 if necessary) with all other protocols disabled. Where it is known that a web server must support legacy clients with unsupported an insecure browsers (such as Internet Explorer 10), it may be necessary to enable TLS 1.0 to provide support.
 
 Where legacy protocols are required, the ["TLS_FALLBACK_SCSV" extension](https://tools.ietf.org/html/rfc7507) should be enabled in order to prevent downgrade attacks against clients.
 


### PR DESCRIPTION
suggesting that TLS 1.3 should be the default and that TLS 1.2 can be a fallback if needed
