### PR TITLE
Typo & Small Grammar Fixes

### DIFF
--- a/cheatsheets/NPM_Security_Cheat_Sheet.md
+++ b/cheatsheets/NPM_Security_Cheat_Sheet.md
@@ -23,7 +23,7 @@ In January 2019, npm shared on their blog that they added a [mechanism that auto
 
 We embraced the birth of package lockfiles with open arms, which introduced: deterministic installations across different environments, and enforced dependency expectations across team collaboration. Life is good! Or so I thought… what would have happened had I slipped a change into the project’s `package.json` file but had forgotten to commit the lockfile along side of it?
 
-Both Yarn, and npm act the same during dependency installation . When they detect an inconsistency between the project’s `package.jso`n and the lockfile, they compensate for such change based on the `package.json` manifest by installing different versions than those that were recorded in the lockfile.
+Both Yarn, and npm act the same during dependency installation . When they detect an inconsistency between the project’s `package.json` and the lockfile, they compensate for such change based on the `package.json` manifest by installing different versions than those that were recorded in the lockfile.
 
 This kind of situation can be hazardous for build and production environments as they could pull in unintended package versions and render the entire benefit of a lockfile futile.
 


### PR DESCRIPTION
One instance of "package.jso" was styled as code but the "n" was cut off. This fix brings it into the same style. Per the PR submission instructions, I also fixed all the other typos I saw, as well as any grammatical issues that did not have semantic impact, like duplication. Thanks for the great cheat sheet!
