### PR TITLE
Security Questions Cheat sheet- Updated Nist reference, background information, typos

### DIFF
--- a/IndexTopTen.md
+++ b/IndexTopTen.md
@@ -54,7 +54,7 @@ This cheat sheet will help users of the [OWASP Top Ten](https://owasp.org/www-pr
 * [Authentication Cheat Sheet](cheatsheets/Authentication_Cheat_Sheet.md)
 * [Session Management Cheat Sheet](cheatsheets/Session_Management_Cheat_Sheet.md)
 * [Forgot Password Cheat Sheet](cheatsheets/Forgot_Password_Cheat_Sheet.md)
-* [Choosing and Using Security Questions_Cheat_Sheet](cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md)
+* [Choosing and Using Security Questions Cheat Sheet](cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md)
 * [Credential Stuffing Prevention Cheat Sheet](cheatsheets/Credential_Stuffing_Prevention_Cheat_Sheet.md)
 * [Denial of Service Cheat Sheet](cheatsheets/Denial_of_Service_Cheat_Sheet.md)
 * [JSON Web Token for Java Cheat Sheet](cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md)

--- a/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md
+++ b/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md
@@ -5,7 +5,7 @@
 **WARNING: Security questions are no longer recognized as an acceptable authentication factor per [NIST SP 800-63](https://pages.nist.gov/800-63-3/sp800-63b.html). Account recovery is just an alternate way to authenticate so it should be no weaker than regular authentication. See [SP 800-63B sec 5.1.1.2 paragraph 4](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5): *Verifiers SHALL NOT prompt subscribers to use specific types of information (e.g., “What was the name of your first pet?”) when choosing memorized secrets*.**
 
 If you are curious, please have a look at this 
-[study](https://www.microsoft.com/en-us/research/publication/its-no-secret-measuring-the-security-and-reliability-of-authentication-via-secret-questions/) by Microsoft Research in 2009 and this [study](https://research.google/pubs/pub43783/) performed at Google in 2015. The [Security blog](https://security.googleblog.com/2015/05/new-research-some-tough-questions-for.html) post includes an infographic of the issues identfied with security questions.
+[study](https://www.microsoft.com/en-us/research/publication/its-no-secret-measuring-the-security-and-reliability-of-authentication-via-secret-questions/) by Microsoft Research in 2009 and this [study](https://research.google/pubs/pub43783/) performed at Google in 2015. The accompanying [Security blog](https://security.googleblog.com/2015/05/new-research-some-tough-questions-for.html) update includes an infographic on the issues identified with security questions.
 
 **Please Note:** While there are no acceptable uses of security questions in secure software, this cheat sheet provides guidance on how to choose strong security questions for legacy purposes.
 

--- a/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md
+++ b/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md
@@ -45,7 +45,7 @@ Any questions that do not have all of the characteristics discussed above should
 | What is your favourite cricket team? | Not applicable to most users. |
 | What is the make and model of your first car? | Fairly small range of likely answers. |
 
-Additionally, when the context of the application must be considered when deciding whether questions are good or bad. For example, a question such as "What was your maths teacher's surname in your 8th year of school?" would be very easy to guess if it was using in a virtual learning environment for your school (as other students probably know this information), but would be much stronger for an online gaming website.
+Additionally, the context of the application must be considered when deciding whether questions are good or bad. For example, a question such as "What was your maths teacher's surname in your 8th year of school?" would be very easy to guess if it was using in a virtual learning environment for your school (as other students probably know this information), but would be much stronger for an online gaming website.
 
 #### Good Questions
 
@@ -96,9 +96,9 @@ The questions that can be used will vary hugely depending on the application, an
 
 ### When to Use Security Questions
 
-Applications should generally use a password along with a second authentication factor (such as an OTP code) to authenticate users. The combination of a password and security questions **does not constitute MFA**, as both factors as the same (i.e, something you know).
+Applications should generally use a password along with a second authentication factor (such as an OTP code) to authenticate users. The combination of a password and security questions **does not constitute MFA**, as both factors as the same (i.e. something you know)..
 
-**Security questions should never be relied upon as the sole mechanism to authenticate a user**. However, they can provide a useful additional layer of security when other stronger factors are not available. Common cases where they would be use include:
+**Security questions should never be relied upon as the sole mechanism to authenticate a user**. However, they can provide a useful additional layer of security when other stronger factors are not available. Common cases where they would be used include:
 
 - Logging in.
 - Resetting a forgotten password.
@@ -120,7 +120,7 @@ Forgotten password functionality often provides a mechanism for attackers to enu
 
 - The user enters email address (and solves a CAPTCHA).
 - The application displays a generic message such as "If the email address was correct, an email will be sent to it".
-- An email email with a randomly generated, single-use link is sent to the user.
+- An email with a randomly generated, single-use link is sent to the user.
 - The user clicks the link.
 - The user is presented with the security question(s).
 - If the answer is correct, the user can enter a new password.

--- a/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md
+++ b/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md
@@ -2,9 +2,12 @@
 
 ## Introduction
 
-**WARNING: Security questions are no longer recognized as an acceptable authentication factor per NIST SP 800-63. Account recovery is just an alternate way to authenticate so it should be no weaker than regular authentication. See SP 800-63B sec 5.1.1.2 paragraph 4: *Verifiers SHALL NOT prompt subscribers to use specific types of information (e.g., “What was the name of your first pet?”) when choosing memorized secrets*.**
+**WARNING: Security questions are no longer recognized as an acceptable authentication factor per [NIST SP 800-63](https://pages.nist.gov/800-63-3/sp800-63b.html). Account recovery is just an alternate way to authenticate so it should be no weaker than regular authentication. See [SP 800-63B sec 5.1.1.2 paragraph 4](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5): *Verifiers SHALL NOT prompt subscribers to use specific types of information (e.g., “What was the name of your first pet?”) when choosing memorized secrets*.**
 
-While there are no acceptable uses of security questions in secure software, this cheat sheet provides guidance on how to choose strong security questions for legacy purposes.
+If you are curious, please have a look at this 
+[study](https://www.microsoft.com/en-us/research/publication/its-no-secret-measuring-the-security-and-reliability-of-authentication-via-secret-questions/) by Microsoft Research in 2009 and this [study](https://research.google/pubs/pub43783/) performed at Google in 2015. The [Security blog](https://security.googleblog.com/2015/05/new-research-some-tough-questions-for.html) post includes an infographic of the issues identfied with security questions.
+
+**Please Note:** While there are no acceptable uses of security questions in secure software, this cheat sheet provides guidance on how to choose strong security questions for legacy purposes.
 
 ## Choosing Security Questions
 

--- a/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md
+++ b/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md
@@ -4,8 +4,7 @@
 
 **WARNING: Security questions are no longer recognized as an acceptable authentication factor per [NIST SP 800-63](https://pages.nist.gov/800-63-3/sp800-63b.html). Account recovery is just an alternate way to authenticate so it should be no weaker than regular authentication. See [SP 800-63B sec 5.1.1.2 paragraph 4](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5): *Verifiers SHALL NOT prompt subscribers to use specific types of information (e.g., “What was the name of your first pet?”) when choosing memorized secrets*.**
 
-If you are curious, please have a look at this 
-[study](https://www.microsoft.com/en-us/research/publication/its-no-secret-measuring-the-security-and-reliability-of-authentication-via-secret-questions/) by Microsoft Research in 2009 and this [study](https://research.google/pubs/pub43783/) performed at Google in 2015. The accompanying [Security blog](https://security.googleblog.com/2015/05/new-research-some-tough-questions-for.html) update includes an infographic on the issues identified with security questions.
+If you are curious, please have a look at this [study](https://www.microsoft.com/en-us/research/publication/its-no-secret-measuring-the-security-and-reliability-of-authentication-via-secret-questions/) by Microsoft Research in 2009 and this [study](https://research.google/pubs/pub43783/) performed at Google in 2015. The accompanying [Security blog](https://security.googleblog.com/2015/05/new-research-some-tough-questions-for.html) update includes an infographic on the issues identified with security questions.
 
 **Please Note:** While there are no acceptable uses of security questions in secure software, this cheat sheet provides guidance on how to choose strong security questions for legacy purposes.
 


### PR DESCRIPTION
Added: references to NIST specification 
The NIST requirement is referenced, but a link to the source was missing.

Added: background information that may help to better understand NIST stance on Security questions
There seems to be an agreement in research that security question as fallback authentication are problematic. The article was missing information that may help better understand the issue.

Changed: Typo in the article and Index page
Unnecessary "_" in the link on the index top 10 page removed + suggested fixes for what i believe are typo in the article





