### PR TITLE
[Certificate Pinning Cheat Sheet] General Improvements

### DIFF
--- a/cheatsheets/Pinning_Cheat_Sheet.md
+++ b/cheatsheets/Pinning_Cheat_Sheet.md
@@ -12,13 +12,15 @@ Users, developers, and applications expect end-to-end security on their secure c
 
 Pinning is the process of associating a host with their *expected* X509 certificate or public key. Once a certificate or public key is known or seen for a host, the certificate or public key is associated or 'pinned' to the host. If more than one certificate or public key is acceptable, then the program holds a *pinset* (taking from [Jon Larimer and Kenny Root Google I/O talk](https://developers.google.com/events/io/sessions/gooio2012/107/)). In this case, the advertised identity must match one of the elements in the pinset.
 
+### When to Add a Pin
+
 A host or service's certificate or public key can be added to an application at development time, or it can be added upon first encountering the certificate or public key. The former - adding at development time - is preferred since *preloading* the certificate or public key *out of band* usually means the attacker cannot taint the pin.
 
-### When Do You Pin
+### When Do You Perform Pinning
 
 You should pin anytime you want to be relatively certain of the remote host's identity or when operating in a hostile environment. Since one or both are almost always true, you should probably pin all the time.
 
-### When Do You Allow-list
+### When to Apply Exceptions
 
 If you are working for an organization which practices "egress filtering" as part of a Data Loss Prevention (DLP) strategy, you will likely encounter *Interception Proxies*. I like to refer to these things as **"good" bad actors** (as opposed to **"bad" bad actors**) since both break end-to-end security and we can't tell them apart. In this case, **do not** offer to allow-list the interception proxy since it defeats your security goals. Add the interception proxy's public key to your pinset after being **instructed** to do so by the folks in Risk Acceptance.
 
@@ -26,16 +28,23 @@ If you are working for an organization which practices "egress filtering" as par
 
 The idea is to re-use the exiting protocols and infrastructure, but use them in a hardened manner. For re-use, a program would keep doing the things it used to do when establishing a secure connection.
 
-To harden the channel, the program would take advantage of the `OnConnect` callback offered by a library, framework or platform. In the callback, the program would verify the remote host's identity by validating its certificate or public key.
+To harden the channel, the program would take advantage of the `OnConnect` callback offered by a library, framework or platform. In the callback, the program would verify the remote host's identity by validating its certificate or public key. See [some examples](#examples-of-pinning) below.
 
-## What Should Be Pinned
+### What Should Be Pinned
 
-The first thing to decide is what should be pinned. For this choice, you have two options:
+In order to decide what should be pinned you can follow the following steps.
 
-- Pin the certificate.
-- Pin the public key.
+1. Decide if you want to pin the root CA, intermediate CA or leaf certificate:
 
-If you choose public keys, you have two additional choices:
+    - Pinning the **root CA** is generally not recommended since it highly increases the risk because it implies also trusting all its intermediate CAs.
+    - Pinning a specific **intermediate CA** reduces the risk but the application will be also trusting any other certificates issues by that CA, not only the ones meant for your application.
+    - Pinning a **leaf certificate** is recommended but must include backup (e.g. intermediate CA). It provides 100% certainty that the app exclusively trusts the remote hosts it was designed to connect to.
+
+    For example, the application pins the remote endpoint leaf certificate but includes a backup pin for the intermediate CA. This increases the risk by trusting more certificate authorities but decreases the chances of bricking your app. If there's any issue with the leaf certificate, the app can always fall back to the intermediate CA until you release an app update.
+
+2. Choose if you want to pin the **whole certificate** or just its **public key**.
+
+3. If you chose the public key, you have two additional choices:
 
 - Pin the `subjectPublicKeyInfo`.
 - Pin one of the concrete types such as `RSAPublicKey` or `DSAPublicKey`.
@@ -46,29 +55,50 @@ If you choose public keys, you have two additional choices:
 
 The three choices are explained below in more detail. I would encourage you to pin the `subjectPublicKeyInfo` because it has the public parameters (such as `{e,n}` for an RSA public key) **and** contextual information such as an algorithm and OID. The context will help you keep your bearings at times, and the figure to the right shows the additional information available.
 
-### Certificate
+#### Certificate
 
 ![Certificate](../assets/Pinning_Cheat_Sheet_Certificate.png)
 
 The certificate is easiest to pin. You can fetch the certificate out of band for the website, have the IT folks email your company certificate to you, use `openssl s_client` to retrieve the certificate etc. At runtime, you retrieve the website or server's certificate in the callback. Within the callback, you compare the retrieved certificate with the certificate embedded within the program. If the comparison fails, then fail the method or function.
 
-There is a downside to pinning a certificate. If the site rotates its certificate on a regular basis, then your application would need to be updated regularly. For example, Google rotates its certificates, so you will need to update your application about once a month (if it depended on Google services). Even though Google rotates its certificates, the underlying public keys (within the certificate) remain static.
+**Benefits:**
 
-### Public Key
+- It might be easier to implement than the other methods, especially in laguages such as Cocoa/CocoaTouch and OpenSSL.
+
+**Downsides:**
+
+- If the site rotates its certificate on a regular basis, then your application would need to be updated regularly. For example, Google rotates its certificates, so you will need to update your application about once a month (if it depended on Google services).
+
+#### Public Key
 
 ![PublicKey](../assets/Pinning_Cheat_Sheet_PublicKey.png)
 
 Public key pinning is more flexible but a little trickier due to the extra steps necessary to extract the public key from a certificate. As with a certificate, the program checks the extracted public key with its embedded copy of the public key.
 
-There are two downsides to public key pinning. First, it's harder to work with keys (versus certificates) since you must extract the key from the certificate. Extraction is a minor inconvenience in Java and .Net, buts it's uncomfortable in Cocoa/CocoaTouch and OpenSSL. Second, the key is static and may violate key rotation policies.
+**Benefits:**
 
-### Hashing
+- It allows access to public key parameters (such as `{e,n}` for an RSA public key) and contextual information such as an algorithm and OID.
+- It's more flexible than certificate pinning. Even if the server rotates its certificates, the underlying public keys (within the certificate) remain static.
+
+**Downsides:**
+
+- It's harder to work with keys (versus certificates) since you must extract the key from the certificate. Extraction is a minor inconvenience in Java and .Net, but it's uncomfortable in Cocoa/CocoaTouch and OpenSSL.
+- The key is static and may violate key rotation policies.
+- It's not possible to anonymize the public keys.
+
+#### Hash
 
 While the three choices above used DER encoding, its also acceptable to use a hash of the information. In fact, the original sample programs were written using digested certificates and public keys. The samples were changed to allow a programmer to inspect the objects with tools like `dumpasn1` and other ASN.1 decoders.
 
-Hashing also provides three additional benefits. First, hashing allows you to anonymize a certificate or public key. This might be important if you application is concerned about leaking information during decompilation and re-engineering. Second, a digested certificate fingerprint is often available as a native API for many libraries, so its convenient to use.
+**Benefits:**
 
-Finally, an organization might want to supply a reserve (or back-up) identity in case the primary identity is compromised. Hashing ensures your adversaries do not see the reserved certificate or public key in advance of its use. In fact, Google's IETF draft *websec-key-pinning* uses the technique.
+- It's convenient to use. A digested certificate fingerprint is often available as a native API for many libraries.
+- Hashing allows you to anonymize a certificate or public key. This might be important if you application is concerned about leaking information during decompilation and re-engineering.
+- An organization might want to supply a reserve (or back-up) identity in case the primary identity is compromised. Hashing ensures your adversaries do not see the reserved certificate or public key in advance of its use. In fact, Google's IETF draft *websec-key-pinning* uses the technique.
+
+**Downsides:**
+
+- No access to public key parameters nor contextual information such as an algorithm and OID which might be needed in certain use cases.
 
 ## Examples of Pinning
 


### PR DESCRIPTION
- enhance outline.
- highlight Benefits and Downsides in Certificate/Public Key/Hash sections.

I was about to add this information to the MSTG but thought that it might be better here and we'd simply reference back here since it applies to _any application_ (not only mobile). In the MSTG we'll then keep only the Android/iOS specifics extending what you have here.

- add steps for "What Should Be Pinned" including first step about deciding for root CA, intermediate CA or leaf certificate.