### PR TITLE
Fix a typo

### DIFF
--- a/cheatsheets/XML_Security_Cheat_Sheet.md
+++ b/cheatsheets/XML_Security_Cheat_Sheet.md
@@ -146,9 +146,9 @@ Defining the correct data type for numbers can be more complex since there are m
 XML Schema numeric data types can include different ranges of numbers. They could include:
 
 - **negativeInteger**: Only negative numbers
-- **nonNegativeInteger**: Negative numbers and the zero value
+- **nonNegativeInteger**: Positive numbers and the zero value
 - **positiveInteger**: Only positive numbers
-- **nonPositiveInteger**: Positive numbers and the zero value
+- **nonPositiveInteger**: Negative numbers and the zero value
 
 The following sample document defines an `id` for a product, a `price`, and a `quantity` value that is under the control of an attacker:
 


### PR DESCRIPTION
non-negative integers are all integers that are _not_ negative, so it's the positive numbers and zero. 

I think this is the place in the standards that confirms this: https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#nonNegativeInteger

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
