### PR TITLE
SSRF Cheat Sheet - Updated link to new location of network segmentation impl article

### DIFF
--- a/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -257,7 +257,7 @@ In the schema below, a Firewall component is leveraged to limit the application'
 
 ![Case 1 for Network layer protection about flows that we want to prevent](../assets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet_Case1_NetworkLayer_PreventFlow.png)
 
-[Network segregation](https://www.mwrinfosecurity.com/our-thinking/making-the-case-for-network-segregation) (see this set of [implementation advice](https://www.cyber.gov.au/publications/network-segmentation-and-segregation)) can also be leveraged and **is highly recommended in order to block illegitimate calls directly at network level itself**.
+[Network segregation](https://www.mwrinfosecurity.com/our-thinking/making-the-case-for-network-segregation) (see this set of [implementation advice](https://www.cyber.gov.au/acsc/view-all-content/publications/implementing-network-segmentation-and-segregation) can also be leveraged and **is highly recommended in order to block illegitimate calls directly at network level itself**.
 
 ### Case 2 - Application can send requests to ANY external IP address or domain name
 
@@ -285,7 +285,7 @@ Taking into consideration the same assumption in the following [example](Server_
 
 ##### Application layer
 
-Like for the case [n°1](Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md#case-1---application-can-send-request-only-to-identified-and-trusted-applications), it is assumed that the `IP Address` or `domain name` is required to create the request that will be sent to the *TargetApplication*.
+Like for the case [n°1](Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md#case-1-application-can-send-request-only-to-identified-and-trusted-applications), it is assumed that the `IP Address` or `domain name` is required to create the request that will be sent to the *TargetApplication*.
 
 The first validation on the input data presented in the case [n°1](Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md#application-layer) on the 3 types of data will be the same for this case **BUT the second validation will differ**. Indeed, here we must use the block-list approach.
 


### PR DESCRIPTION
Updated link to "Implementing Network Segmentation and Segregation" article
It seems the article was moved. Previous link shows a HTTP 404 error. Link updated to new location of the article on the site

Updated anchor to Case 1
The anchor to chapter "Case 1 - Application can send request .." didn't seem to work. A Mismatch in the generated ID, d.h. redundant - are stripped from the h3 , but appear to kept in the a href.