### PR TITLE
Remove 'shame' to 'developers' language

### DIFF
--- a/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md
@@ -7,8 +7,6 @@ This article is focused on providing clear, simple, actionable guidance for prev
 1. the significant prevalence of SQL Injection vulnerabilities, and
 2. the attractiveness of the target (i.e., the database typically contains all the interesting/critical data for your application).
 
-It's somewhat shameful that there are so many successful SQL Injection attacks occurring, because it is EXTREMELY simple to avoid SQL Injection vulnerabilities in your code.
-
 SQL Injection flaws are introduced when software developers create dynamic database queries constructed with string concatenation which includes user supplied input. To avoid SQL injection flaws is simple. Developers need to either: a) stop writing dynamic queries with string concatenation; and/or b) prevent user supplied input which contains malicious SQL from affecting the logic of the executed query.
 
 This article provides a set of simple techniques for preventing SQL Injection vulnerabilities by avoiding these two problems. These techniques can be used with practically any kind of programming language with any type of database. There are other types of databases, like XML databases, which can have similar problems (e.g., XPath and XQuery injection) and these techniques can be used to protect them as well.


### PR DESCRIPTION
The way this part is written its shaming developers, the language does not help at all. It's the fact libraries still allow for exposing raw SQL queries we shouldn't be shaming developers for that.


