### PR TITLE
Fixed "Multi-Factor Authentication CS" link

### DIFF
--- a/cheatsheets/Secrets_Management_CheatSheet.md
+++ b/cheatsheets/Secrets_Management_CheatSheet.md
@@ -90,7 +90,7 @@ Secrets follow a lifecycle. The stages of the lifecycle are as follows:
 
 New secrets must be securely generated and cryptographically robust enough for their purpose. Secrets must have the minimum privileges assigned to them to enable their requested use/role.
 
-You should transmit credentials securely, such that ideally, you don't send the password along with the username when requesting user accounts. Instead, you should send the password via a secure channel (e.g. mutually authenticated connection) or a side-channel such as push notification, SMS, email. Refer to the [Multi-Factor Authentication Cheat Sheet](cheat sheets/Multifactor_Authentication_Cheat_Sheet) to learn about the pros and cons of each channel.
+You should transmit credentials securely, such that ideally, you don't send the password along with the username when requesting user accounts. Instead, you should send the password via a secure channel (e.g. mutually authenticated connection) or a side-channel such as push notification, SMS, email. Refer to the [Multi-Factor Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Multifactor_Authentication_Cheat_Sheet) to learn about the pros and cons of each channel.
 
 Applications may not benefit from having multiple communication channels, so you must provision credentials securely.
 


### PR DESCRIPTION
The "**Multi-Factor Authentication Cheat Sheet**" link (inside the "Secrets Management CheatSheet", section 2.6.1 Creation) is pointing to:

- "/cheatsheets/cheat%20sheets/Multifactor_Authentication_Cheat_Sheet" 

while the correct address is: 

- "/cheatsheets/Multifactor_Authentication_Cheat_Sheet".