### PR TITLE
Graphql Introspection as default config

### DIFF
--- a/cheatsheets/GraphQL_Cheat_Sheet.md
+++ b/cheatsheets/GraphQL_Cheat_Sheet.md
@@ -9,7 +9,7 @@ This Cheat Sheet provides guidance on the various areas that need to be consider
 - Apply proper [input validation](Input_Validation_Cheat_Sheet.md) checks on all incoming data.
 - Expensive queries will lead to [Denial of Service (DoS)](Denial_of_Service_Cheat_Sheet.md), so add checks to limit or prevent queries that are too expensive.
 - Ensure that the API has proper [access control](Access_Control_Cheat_Sheet.md) checks.
-- Disable insecure default configurations (_e.g._ introspection, GraphiQL, excessive errors, etc.).
+- Disable insecure default configurations (_e.g._ excessive errors, introspection, GraphiQL, etc.).
 
 ## Common Attacks
 
@@ -272,8 +272,9 @@ Limiting the number of operations that can be batched and run at once is another
 
 By default, most GraphQL implementations have some insecure default configurations which should be changed:
 
-- Disable or restrict Introspection and GraphiQL based on your needs; these should only be used for development purposes.
 - Don't return excessive error messages (_e.g._ disable stack traces and debug mode).
+- Disable or restrict Introspection and GraphiQL based on your needs.
+- Suggestion of mis-typed fields if the introspection is disabled
 
 #### Introspection + GraphiQL
 


### PR DESCRIPTION
small followup on  #934 
cc @mackowski 
didn't saw the previous paragraph stating unilaterally that it's unsecure.
Plus small addition about field correction


> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
