### PR TITLE
Fix #943 - security.txt URI within Vulnerability Disclosure Cheat Sheet

### DIFF
--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -70,7 +70,7 @@ The first step in reporting a vulnerability is finding the appropriate person to
 Where there is no clear disclosure policy, the following areas may provide contact details:
 
 - Bug bounty programs such as [BugCrowd](https://bugcrowd.com/programs),  [HackerOne](https://hackerone.com/directory/programs), [huntr.dev](https://huntr.dev/bounties) or [Open Bug Bounty](https://www.openbugbounty.org).
-- A [security.txt](https://securitytxt.org) file on the website at `/security.txt` or `/.well-known/security.txt`.
+- A [security.txt](https://securitytxt.org) file on the website at `/.well-known/security.txt` as per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html#name-location-of-the-securitytxt).
 - An existing issue tracking system.
 - Generic email addresses such as `security@` or `abuse@`.
 - The generic "Contact Us" page on the website.
@@ -188,7 +188,7 @@ The most important step in the process is providing a way for security researche
 - A dedicated security contact on the "Contact Us" page.
 - Dedicated instructions for reporting security issues on a bug tracker.
 - The common `security@` email address.
-- A [security.txt](https://securitytxt.org) file on the website at `/security.txt` or `/.well-known/security.txt`.
+- A [security.txt](https://securitytxt.org) file on the website at `/.well-known/security.txt` as per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html#name-location-of-the-securitytxt).
 - Using third party [bug bounty](#bug-bounty-programs) program.
 
 It is also important to ensure that frontline staff (such as those who monitor the main contact address, web chat and phone lines) are aware of how to handle reports of security issues, and who to escalate these reports to within the organisation.


### PR DESCRIPTION
- [X] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [X] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [X] Any references to websites have been formatted as [TEXT](URL)
- [X] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [X] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

This PR covers issue #943.
