### PR TITLE
add Docker Bench for Security to static tools

### DIFF
--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -244,6 +244,7 @@ To detect misconfigurations in Docker:
 
 - [inspec.io](https://www.inspec.io/docs/reference/resources/docker/)
 - [dev-sec.io](https://dev-sec.io/baselines/docker/)
+- [Docker Bench for Security](https://github.com/docker/docker-bench-security)
 
 ### RULE \#10 - Set the logging level to at least INFO
 


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

This PR:
- Adds [Docker Bench for Security](https://github.com/docker/docker-bench-security) to the list of static testing tools

