### PR TITLE
enabling Edit button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,6 @@ site_description: Website with the collection of all the cheat sheets of the pro
 # Repository
 repo_name: OWASP/CheatSheetSeries
 repo_url: https://github.com/OWASP/CheatSheetSeries
-edit_uri: ""
 
 # Copyright
 copyright: ©Copyright 2021 - CheatSheets Series Team - This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a>.


### PR DESCRIPTION
It seems that specifying explicitly `edit_uri` in the configuration with a blank value `edit_uri: ""`, overrides the dynamic value computed from `repo_url` and so disables the _Edit button_.

cf. mkdocs et material theme doc

- https://www.mkdocs.org/user-guide/configuration/#edit_uri
- https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/?h=edit#edit-button

this would be nice to have the _Edit button_ on top of every page instead of having to open the github repository and look for the right page based on the URL of the page.

![image](https://user-images.githubusercontent.com/16578570/183132598-b2a79e3e-d8f7-473e-8ef0-f1e4da1ae0ad.png)

PS: unfortunately the github action CI https://github.com/OWASP/CheatSheetSeries/actions/runs/2805308503 just build the website base on the PR but doesn't deploy a staging preview
