### PR TITLE
Update XStream to correct version

### DIFF
--- a/cheatsheets/Deserialization_Cheat_Sheet.md
+++ b/cheatsheets/Deserialization_Cheat_Sheet.md
@@ -67,7 +67,7 @@ Be aware of the following Java API uses for potential serialization vulnerabilit
 
 1. `XMLdecoder` with external user defined parameters
 
-2. `XStream` with `fromXML` method (xstream version <= v1.46 is vulnerable to the serialization issue)
+2. `XStream` with `fromXML` method (xstream version <= v1.4.6 is vulnerable to the serialization issue)
 
 3. `ObjectInputStream` with `readObject`
 


### PR DESCRIPTION
The vulnerable XStream version is v1.4.6 not  v1.46.

Hopefully this will save someone else from going down a rabbit hole :)

https://x-stream.github.io/changes.html

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
