### PR TITLE
Small grammar fix in Cryptographic Storage Cheat Sheet

### DIFF
--- a/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
+++ b/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
@@ -10,7 +10,7 @@ Passwords should not be stored using reversible encryption - secure password has
 
 The first step in designing any application is to consider the overall architecture of the system, as this will have a huge impact on the technical implementation.
 
-This process should begin with considering the [threat model](Threat_Modeling_Cheat_Sheet.md) of the application (i.e, who you trying to protect that data against).
+This process should begin with considering the [threat model](Threat_Modeling_Cheat_Sheet.md) of the application (i.e, who you are trying to protect that data against).
 
 The use of dedicated secret or key management systems can provide an additional layer of security protection, as well as making the management of secrets significantly easier - however it comes at the cost of additional complexity and administrative overhead - so may not be feasible for all applications. Note that many cloud environments provide these services, so these should be taken advantage of where possible.
 


### PR DESCRIPTION
I'm guessing "you are" is the intended phrasing. Unless it's supposed to be in question form, if so, I can update it to be "are you"

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

