### PR TITLE
Update .NET Random function

### DIFF
--- a/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
+++ b/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
@@ -84,7 +84,7 @@ The table below shows the recommended algorithms for each language, as well as i
 | C        | `random()`, `rand()` | [getrandom(2)](http://man7.org/linux/man-pages/man2/getrandom.2.html) |
 | Java     | `java.util.Random()` | [java.security.SecureRandom](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) |
 | PHP      | `rand()`, `mt_rand()`, `array_rand()`, `uniqid()` | [random_bytes()](https://www.php.net/manual/en/function.random-bytes.php), [random_int()](https://www.php.net/manual/en/function.random-int.php) in PHP 7 or [openssl_random_pseudo_bytes()](https://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php) in PHP 5 |
-| .NET/C#  | `Random()` | [RNGCryptoServiceProvider](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.rngcryptoserviceprovider?view=netframework-4.8) |
+| .NET/C#  | `Random()` | [RandomNumberGenerator](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator?view=net-6.0) |
 | Objective-C | `arc4random()` (Uses RC4 Cipher) | [SecRandomCopyBytes](https://developer.apple.com/documentation/security/1399291-secrandomcopybytes?language=objc) |
 | Python   | `random()` | [secrets()](https://docs.python.org/3/library/secrets.html#module-secrets) |
 | Ruby     | `Random` | [SecureRandom](https://ruby-doc.org/stdlib-2.5.1/libdoc/securerandom/rdoc/SecureRandom.html) |

--- a/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
+++ b/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md
@@ -59,8 +59,6 @@ Where available, authenticated modes should always be used. These provide guaran
 
 If GCM or CCM are not available, then [CTR](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_%28CTR%29) mode or [CBC](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_%28CBC%29) mode should be used. As these do not provide any guarantees about the authenticity of the data, separate authentication should be implemented, such as using the [Encrypt-then-MAC](https://en.wikipedia.org/wiki/Authenticated_encryption#Encrypt-then-MAC_%28EtM%29) technique. Care needs to be taken when using this method with [variable length messages](https://en.wikipedia.org/wiki/CBC-MAC#Security_with_fixed_and_variable-length_messages)
 
-If random access to the encrypted data is required then [XTS](https://en.wikipedia.org/wiki/Disk_encryption_theory#XTS) mode should be used. This is typically used for disk encryption, so it unlikely to be used by a web application.
-
 [ECB](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#ECB) should not be used outside of very specific circumstances.
 
 ### Random Padding


### PR DESCRIPTION
This PR covers two thirds of issue #901

- Replace `RNGCryptoServiceProvider` with `RandomNumberGenerator` in the .NET section, because `RNGCryptoServiceProvider` is obsolete. The original issue (#901) suggested keeping both but since this is a cheat sheet I think for brevity we should jettison the old one. I'm open to input on this.

- Remove XTS section because it's too specialized to be useful in a cheat sheet.

I did not address the third point - discussing nonce generation and exhaustion, because I don't have expertise there. It may be a good idea to open a new issue to make tracking that easier.