### PR TITLE
Update GH Actions versions; Pin Ubuntu version

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -8,19 +8,19 @@ on:
 jobs:
   build:
     name: Build offline website
-    runs-on: ubuntu-20.04 #ubuntu-latest ubuntu lastes have some bug, we need to use older one 
+    runs-on: ubuntu-22.04
     env:
       CI: true
       WORKFLOW_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v3
       with:
         node-version: 12.x
     - name: Setup Python
-      uses: actions/setup-python@v2.2.1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install Python dependencies
@@ -34,19 +34,19 @@ jobs:
     - name: Test bundle
       run: zip -T bundle.zip
     - name: Upload bundle as artifact
-      uses: actions/upload-artifact@v2.2.2
+      uses: actions/upload-artifact@v3
       with:
         name: Bundle
         path: bundle.zip
   deploy:
     name: Deploy offline website
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Install dependencies
       run: sudo apt-get install -y unzip zip
     - name: Switch to offline website (gh-pages) branch
@@ -56,7 +56,7 @@ jobs:
         shopt -s extglob
         rm -rdfv !("CNAME"|"robots.txt"|"_config.yml")
     - name: Download new build from artifact
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name: Bundle
     - name: Replace bundle with new build

--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -7,18 +7,18 @@ on:
 jobs:
   build:
     name: Identify old issues and PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v3
       with:
         node-version: 12.x
     - name: SetUp python
-      uses: actions/setup-python@v2.2.1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install python dependencies

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v3
       with:
         node-version: 12.x
     - name: Install dependencies

--- a/.github/workflows/md_lint_check.yml
+++ b/.github/workflows/md_lint_check.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v3
       with:
         node-version: 12.x
     - name: Install dependencies

--- a/.github/workflows/publishing-check.yml
+++ b/.github/workflows/publishing-check.yml
@@ -5,16 +5,16 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build website
-    runs-on: ubuntu-20.04 #ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CI: true
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.9.5'
+          python-version: '3.9'
       - name: Install Python dependencies
         run: make install-python-requirements
       - name: Build website


### PR DESCRIPTION
This is an attempt to fix the Python setup errors that were occurring in the GitHub actions due to a Python version not being available in a new version of Ubuntu. This PR fixes that and additionally updates the versions of all the GitHub actions and pins the latest available Ubuntu version (22.04).