### PR TITLE
Add reference for DRF CS

### DIFF
--- a/cheatsheets/Django_REST_Framework_Cheat_Sheet.md
+++ b/cheatsheets/Django_REST_Framework_Cheat_Sheet.md
@@ -199,5 +199,6 @@ PyCharm Security – [Pycharm-security](https://pycharm-security.readthedocs.io/
 
 ## Related Articles and References
 
+- [Django REST Framework (DRF) Secure Code Guidelines](https://openaccess.uoc.edu/handle/10609/147246)
 - [Django’s security policies](https://docs.djangoproject.com/en/4.1/internals/security/)
 - [Security in Django](https://docs.djangoproject.com/en/4.1/topics/security/)


### PR DESCRIPTION
Changes:
- Add 1 Reference for the Django REST Framework Cheat Sheet

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).


Thank you again for your contribution :smiley:
