### PR TITLE
Improve JAXB example/recommendation with 'disallow-doctype-decl' feat…

### DIFF
--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -333,11 +333,7 @@ Since a `javax.xml.bind.Unmarshaller` parses XML and does not support any flags 
 ``` java
 //Disable XXE
 SAXParserFactory spf = SAXParserFactory.newInstance();
-spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-spf.setXIncludeAware(false);
+spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 
 //Do unmarshall operation
 Source xmlSource = new SAXSource(spf.newSAXParser().getXMLReader(),


### PR DESCRIPTION
Improvement suggestion for protecting against XXE when using JAXB.

This PR covers issue #1094.