### PR TITLE
[NodeJS Security Cheat Sheet] Fix express deprecated res.send

### DIFF
--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -258,7 +258,7 @@ const app = express();
 app.use(function(req, res, next) {
     if (toobusy()) {
         // log if you see necessary
-        res.send(503, "Server Too Busy");
+        res.status(503).send("Server Too Busy");
     } else {
     next();
     }
@@ -275,7 +275,7 @@ const bouncer = require('express-bouncer');
 bouncer.whitelist.push('127.0.0.1'); // allow an IP address
 // give a custom error message
 bouncer.blocked = function (req, res, next, remaining) {
-    res.send(429, "Too many requests have been made. Please wait " + remaining/1000 + " seconds.");
+    res.status(429).send("Too many requests have been made. Please wait " + remaining/1000 + " seconds.");
 };
 // route to protect
 app.post("/login", bouncer.block, function(req, res) {


### PR DESCRIPTION
This PR fix the warning ``express deprecated res.send(status, body): Use res.status(status).send(body)``
occurring when using some code snippets from the NodeJS Security Cheat Sheet with Express 4.x.

This syntax will be [no longer supported in Express 5.x](https://expressjs.com/en/guide/migrating-5.html#res.send.body).

---

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
