### PR TITLE
[NodeJS Security Cheat Sheet] Update various helmet middlewares

### DIFF
--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -448,7 +448,9 @@ app.use(helmet.frameguard()); // default behavior (SAMEORIGIN)
 
 - **[X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection):** As described in the [XSS Prevention Cheat Sheet](Cross_Site_Scripting_Prevention_Cheat_Sheet.md#x-xss-protection-header), this header should be set to `0` to disable the XSS Auditor.
 
-> An [issue](https://github.com/helmetjs/x-xss-protection/issues/14) was created in the [helmetjs](https://github.com/helmetjs/) project to be able to set the header to `0`. Once it is updated, this section will be updated to inform the user to disable the XSS auditor properly using helmetjs.
+```JavaScript
+app.use(helmet.xssFilter()); // sets "X-XSS-Protection: 0"
+```
 
 - **[X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options):** Even if the server sets a valid `Content-Type` header in the response, browsers may try to sniff the MIME type of the requested resource. This header is a way to stop this behavior and tell the browser not to change MIME types specified in `Content-Type` header. It can be configured in the following way:
 

--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -475,17 +475,21 @@ For moderns browsers, it is recommended to implement a strong **Content-Security
 - **[Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy):** Content Security Policy is developed to reduce the risk of attacks like [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/) and [Clickjacking](https://owasp.org/www-community/attacks/Clickjacking). It allows content from a list that you decide. It has several directives each of which prohibits loading specific type of a content. You can refer to [Content Security Policy Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html) for detailed explanation of each directive and how to use it. You can implement these settings in your application as follows:
 
 ```JavaScript
-const csp = require('helmet-csp')
-app.use(csp({
-   directives: {
-       defaultSrc: ["'self'"],  // default value for all directives that are absent
-       scriptSrc: ["'self'"],   // helps prevent XSS attacks
-       frameAncestors: ["'none'"],  // helps prevent Clickjacking attacks
-       imgSrc: ["'self'", "'http://imgexample.com'"],
-       styleSrc: ["'none'"]
+app.use(
+  helmet.contentSecurityPolicy({
+    // the following directives will be merged into the default helmet CSP policy
+    directives: {
+      defaultSrc: ["'self'"],  // default value for all directives that are absent
+      scriptSrc: ["'self'"],   // helps prevent XSS attacks
+      frameAncestors: ["'none'"],  // helps prevent Clickjacking attacks
+      imgSrc: ["'self'", "'http://imgexample.com'"],
+      styleSrc: ["'none'"]
     }
-}))
+  })
+);
 ```
+
+As this middleware performs very little validation, it is recommended to rely on CSP checkers like [CSP Evaluator](https://csp-evaluator.withgoogle.com/) instead.
 
 - **[X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options):** Even if the server sets a valid `Content-Type` header in the response, browsers may try to sniff the MIME type of the requested resource. This header is a way to stop this behavior and tell the browser not to change MIME types specified in `Content-Type` header. It can be configured in the following way:
 

--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -432,7 +432,7 @@ app.use(session({
 #### Use appropriate security headers
 
 There are several [HTTP security headers](https://owasp.org/www-project-secure-headers/) that can help you prevent some common attack vectors.
-The [helmet](https://www.npmjs.com/package/helmet) package can help to set those headers :
+The [helmet](https://www.npmjs.com/package/helmet) package can help to set those headers:
 
 ```Javascript
 const express = require("express");
@@ -444,7 +444,7 @@ app.use(helmet()); // Add various HTTP headers
 ```
 
 The top-level `helmet` function is a wrapper around 14 smaller middlewares.
-Bellow is a list of HTTP security headers covered by `helmet` middlewares :
+Bellow is a list of HTTP security headers covered by `helmet` middlewares:
 
 - **[Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)**: [HTTP Strict Transport Security (HSTS)](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) dictates browsers that the application can only be accessed via HTTPS connections. In order to use it in your application, add the following codes:
 
@@ -491,7 +491,7 @@ app.use(csp({
 }))
 ```
 
-- **[Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) and [Pragma](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma):** Cache-Control header can be used to prevent browsers from caching the given responses. This should be done for pages that contain sensitive information about either the user or the application. However, disabling caching for pages that do not contain sensitive information may seriously affect the performance of the application. Therefore, caching should only be disabled for pages that return sensitive information. Appropriate caching controls and headers can be set easily using the [nocache](https://www.npmjs.com/package/nocache) package :
+- **[Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) and [Pragma](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma):** Cache-Control header can be used to prevent browsers from caching the given responses. This should be done for pages that contain sensitive information about either the user or the application. However, disabling caching for pages that do not contain sensitive information may seriously affect the performance of the application. Therefore, caching should only be disabled for pages that return sensitive information. Appropriate caching controls and headers can be set easily using the [nocache](https://www.npmjs.com/package/nocache) package:
 
 ```JavaScript
 const nocache = require("nocache");

--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -424,7 +424,7 @@ Generally, session information is sent using cookies in web applications. Howeve
 const session = require('express-session');
 app.use(session({
     secret: 'your-secret-key',
-    key: 'cookieName',
+    name: 'cookieName',
     cookie: { secure: true, httpOnly: true, path: '/user', sameSite: true}
 }));
 ```

--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -443,9 +443,7 @@ app.use(helmet.hsts("<max-age>", "<includeSubdomains>")); // custom configuratio
 - **[X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options):** determines if a page can be loaded via a `<frame>` or an `<iframe>` element. Allowing the page to be framed may result in [Clickjacking](https://owasp.org/www-community/attacks/Clickjacking) attacks. This header can be used with [helmet](https://www.npmjs.com/package/helmet) module as follows:
 
 ```JavaScript
-app.use(helmet.xframe()); // default behavior (DENY)
-helmet.xframe('sameorigin'); // SAMEORIGIN
-helmet.xframe('allow-from', 'http://alloweduri.com'); //ALLOW-FROM uri
+app.use(helmet.frameguard()); // default behavior (SAMEORIGIN)
 ```
 
 - **[X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection):** As described in the [XSS Prevention Cheat Sheet](Cross_Site_Scripting_Prevention_Cheat_Sheet.md#x-xss-protection-header), this header should be set to `0` to disable the XSS Auditor.

--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -14,7 +14,7 @@ This cheat sheet aims to provide a list of best practices to follow during devel
 
 ## Recommendations
 
-There are several different recommendations to enhance security of your Node.js applications. These are categorized as:
+There are several recommendations to enhance security of your Node.js applications. These are categorized as:
 
 - **Application Security**
 - **Error & Exception Handling**
@@ -206,10 +206,10 @@ In the above code, call to unlink the file and other file operations are within 
 
 #### Perform input validation
 
-Input validation is a crucial part of application security. Input validation failures can result in many different types of application attacks. These include SQL Injection, Cross-Site Scripting, Command Injection, Local/Remote File Inclusion, Denial of Service, Directory Traversal, LDAP Injection and many other injection attacks. In order to avoid these attacks, input to your application should be sanitized first. The best input validation technique is to use a list of accepted inputs. However, if this is not possible, input should be first checked against expected input scheme and dangerous inputs should be escaped. In order to ease input validation in Node.js applications, there are some modules like [validator](https://www.npmjs.com/package/validator) and [mongo-express-sanitize](https://www.npmjs.com/package/mongo-express-sanitize).
+Input validation is a crucial part of application security. Input validation failures can result in many types of application attacks. These include SQL Injection, Cross-Site Scripting, Command Injection, Local/Remote File Inclusion, Denial of Service, Directory Traversal, LDAP Injection and many other injection attacks. In order to avoid these attacks, input to your application should be sanitized first. The best input validation technique is to use a list of accepted inputs. However, if this is not possible, input should be first checked against expected input scheme and dangerous inputs should be escaped. In order to ease input validation in Node.js applications, there are some modules like [validator](https://www.npmjs.com/package/validator) and [mongo-express-sanitize](https://www.npmjs.com/package/mongo-express-sanitize).
 For detailed information on input validation, please refer to [Input Validation Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html).
 
-JavaScript is a dynamic language and depending on how the framework parses a URL, the data seen by the application code can take on many different forms. Here are some examples after parsing a query string in express.js:
+JavaScript is a dynamic language and depending on how the framework parses a URL, the data seen by the application code can take many forms. Here are some examples after parsing a query string in express.js:
 
 | URL | Content of request.query.foo in code |
 | --- | --- |
@@ -268,7 +268,7 @@ app.use(function(req, res, next) {
 #### Take precautions against brute-forcing
 
 [Brute-forcing](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#protect-against-automated-attacks
-) is a common threat to all web applications. Attackers can use brute-forcing as a password guessing attack to obtain account passwords. Therefore, application developers should take precautions against brute-force attacks especially in login pages.  Node.js has several modules available for this purpose. [Express-bouncer](https://libraries.io/npm/express-bouncer), [express-brute](https://libraries.io/npm/express-brute) and [rate-limiter](https://libraries.io/npm/rate-limiter) are just some examples. Based on your needs and requirements, you should choose one or more of these modules and use accordingly. [Express-bouncer](https://libraries.io/npm/express-bouncer) and [express-brute](https://libraries.io/npm/express-brute) modules work very similar and they both increase the delay with each failed request. They can both be arranged for a specific route. These modules can be used as follows:
+) is a common threat to all web applications. Attackers can use brute-forcing as a password guessing attack to obtain account passwords. Therefore, application developers should take precautions against brute-force attacks especially in login pages.  Node.js has several modules available for this purpose. [Express-bouncer](https://libraries.io/npm/express-bouncer), [express-brute](https://libraries.io/npm/express-brute) and [rate-limiter](https://libraries.io/npm/rate-limiter) are just some examples. Based on your needs and requirements, you should choose one or more of these modules and use accordingly. [Express-bouncer](https://libraries.io/npm/express-bouncer) and [express-brute](https://libraries.io/npm/express-brute) modules work similarly. They increase the delay for each failed request and can be arranged for a specific route. These modules can be used as follows:
 
 ```JavaScript
 const bouncer = require('express-bouncer');
@@ -323,7 +323,7 @@ app.get('/captcha', function (req, res) {
 
 #### Use Anti-CSRF tokens
 
-[Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf) aims to perform authorized actions on behalf of an authenticated user, while the user is unaware of this action. CSRF attacks are generally performed for state-changing requests like changing a password, adding users or placing orders. [Csurf](https://www.npmjs.com/package/csurf) is an express middleware that has been used to mitigate CSRF attacks. But a security hole in this package has been recently discovered. The team behind the package has not fixed the discovered vulnerability and they have marked the package as deprecated, recommending to use any other csrf protection package.
+[Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf) aims to perform authorized actions on behalf of an authenticated user, while the user is unaware of this action. CSRF attacks are generally performed for state-changing requests like changing a password, adding users or placing orders. [Csurf](https://www.npmjs.com/package/csurf) is an express middleware that has been used to mitigate CSRF attacks. But a security hole in this package has been recently discovered. The team behind the package has not fixed the discovered vulnerability and they have marked the package as deprecated, recommending using any other CSRF protection package.
 
 For detailed information on cross-site request forgery (CSRF) attacks and prevention methods, you can refer to [Cross-Site Request Forgery Prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
 
@@ -333,7 +333,7 @@ A web application should not contain any page that is not used by users, as it m
 
 #### Prevent HTTP Parameter Pollution
 
-[HTTP Parameter Pollution(HPP)](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.html) is an attack in which attackers send multiple HTTP parameters with the same name and this causes your application to interpret them in an unpredictable way. When multiple parameter values are sent, Express populates them in an array. In order to solve this issue, you can use [hpp](https://www.npmjs.com/package/hpp) module. When used, this module will ignore all values submitted for a parameter in `req.query` and/or `req.body` and just select the last parameter value submitted. You can use it as follows:
+[HTTP Parameter Pollution(HPP)](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution.html) is an attack in which attackers send multiple HTTP parameters with the same name and this causes your application to interpret them unpredictably. When multiple parameter values are sent, Express populates them in an array. In order to solve this issue, you can use [hpp](https://www.npmjs.com/package/hpp) module. When used, this module will ignore all values submitted for a parameter in `req.query` and/or `req.body` and just select the last parameter value submitted. You can use it as follows:
 
 ```JavaScript
 const hpp = require('hpp');
@@ -431,7 +431,7 @@ app.use(session({
 
 #### Use appropriate security headers
 
-There are several different [HTTP security headers](https://owasp.org/www-project-secure-headers/) that can help you prevent some common attack vectors.
+There are several [HTTP security headers](https://owasp.org/www-project-secure-headers/) that can help you prevent some common attack vectors.
 The [helmet](https://www.npmjs.com/package/helmet) package can help to set those headers :
 
 ```Javascript
@@ -443,7 +443,7 @@ const app = express();
 app.use(helmet()); // Add various HTTP headers
 ```
 
-The top-level `helmet` function is a wrapper around 14 smaller middlewares. 
+The top-level `helmet` function is a wrapper around 14 smaller middlewares.
 Bellow is a list of HTTP security headers covered by `helmet` middlewares :
 
 - **[Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)**: [HTTP Strict Transport Security (HSTS)](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) dictates browsers that the application can only be accessed via HTTPS connections. In order to use it in your application, add the following codes:
@@ -532,7 +532,7 @@ app.use(helmet.hidePoweredBy({ setTo: 'PHP 4.2.0' }));
 
 #### Keep your packages up-to-date
 
-Security of your application depends directly on how secure the third-party packages you use in your application are. Therefore, it is important to keep your packages up-to-date. It should be noted that [Using Components with Known Vulnerabilities](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities) is still in the OWASP Top 10. You can use [OWASP Dependency-Check](https://jeremylong.github.io/DependencyCheck/analyzers/nodejs.html) to see if any of the packages used in the project has a known vulnerability. Also you can use [Retire.js](https://github.com/retirejs/retire.js/) to check JavaScript libraries with known vulnerabilities.
+Security of your application depends directly on how secure the third-party packages you use in your application are. Therefore, it is important to keep your packages up-to-date. It should be noted that [Using Components with Known Vulnerabilities](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A9-Using_Components_with_Known_Vulnerabilities) is still in the OWASP Top 10. You can use [OWASP Dependency-Check](https://jeremylong.github.io/DependencyCheck/analyzers/nodejs.html) to see if any of the packages used in the project has a known vulnerability. Also, you can use [Retire.js](https://github.com/retirejs/retire.js/) to check JavaScript libraries with known vulnerabilities.
 
 Starting with version 6, `npm` introduced `audit`, which will warn about vulnerable packages:
 
@@ -564,7 +564,7 @@ The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, 
 
 #### Run security linters
 
-When developing code, keeping all security tips in mind can be really difficult. Also keeping all team members obey these rules is nearly impossible. This is why there are Static Analysis Security Testing (SAST) tools. These tools do not execute your code, but they simply look for patterns that can contain security risks. As JavaScript is a dynamic and loosely-typed language, linting tools are really essential in the software development life cycle. The linting rules should be reviewed periodically and the findings should be audited. Another advantage of these tools is the feature that you can add custom rules for patterns that you may see dangerous. [ESLint](https://eslint.org/) and [JSHint](http://jshint.com/) are commonly used SAST tools for JavaScript linting.
+When developing code, keeping all security tips in mind can be really difficult. Also, keeping all team members obey these rules is nearly impossible. This is why there are Static Analysis Security Testing (SAST) tools. These tools do not execute your code, but they simply look for patterns that can contain security risks. As JavaScript is a dynamic and loosely-typed language, linting tools are really essential in the software development life cycle. The linting rules should be reviewed periodically and the findings should be audited. Another advantage of these tools is the feature that you can add custom rules for patterns that you may see dangerous. [ESLint](https://eslint.org/) and [JSHint](http://jshint.com/) are commonly used SAST tools for JavaScript linting.
 
 #### Use strict mode
 

--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -464,17 +464,13 @@ app.use(
 app.use(helmet.frameguard()); // default behavior (SAMEORIGIN)
 ```
 
-- **[X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection):** As described in the [XSS Prevention Cheat Sheet](Cross_Site_Scripting_Prevention_Cheat_Sheet.md#x-xss-protection-header), this header should be set to `0` to disable the XSS Auditor.
+- **[X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection):** stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. This header has been deprecated by modern browsers and its use can introduce additional security issues on the client side. As such, it is recommended to set the header as **X-XSS-Protection: 0** in order to disable the XSS Auditor, and not allow it to take the default behavior of the browser handling the response.
 
 ```JavaScript
 app.use(helmet.xssFilter()); // sets "X-XSS-Protection: 0"
 ```
 
-- **[X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options):** Even if the server sets a valid `Content-Type` header in the response, browsers may try to sniff the MIME type of the requested resource. This header is a way to stop this behavior and tell the browser not to change MIME types specified in `Content-Type` header. It can be configured in the following way:
-
-```JavaScript
-app.use(helmet.noSniff());
-```
+For moderns browsers, it is recommended to implement a strong **Content-Security-Policy** policy, as detailed in the next section.
 
 - **[Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy):** Content Security Policy is developed to reduce the risk of attacks like [Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/) and [Clickjacking](https://owasp.org/www-community/attacks/Clickjacking). It allows content from a list that you decide. It has several directives each of which prohibits loading specific type of a content. You can refer to [Content Security Policy Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html) for detailed explanation of each directive and how to use it. You can implement these settings in your application as follows:
 
@@ -489,6 +485,12 @@ app.use(csp({
        styleSrc: ["'none'"]
     }
 }))
+```
+
+- **[X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options):** Even if the server sets a valid `Content-Type` header in the response, browsers may try to sniff the MIME type of the requested resource. This header is a way to stop this behavior and tell the browser not to change MIME types specified in `Content-Type` header. It can be configured in the following way:
+
+```JavaScript
+app.use(helmet.noSniff());
 ```
 
 - **[Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) and [Pragma](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma):** Cache-Control header can be used to prevent browsers from caching the given responses. This should be done for pages that contain sensitive information about either the user or the application. However, disabling caching for pages that do not contain sensitive information may seriously affect the performance of the application. Therefore, caching should only be disabled for pages that return sensitive information. Appropriate caching controls and headers can be set easily using the [nocache](https://www.npmjs.com/package/nocache) package:

--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -473,10 +473,12 @@ app.use(csp({
 }))
 ```
 
-- **[Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) and [Pragma](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma):** Cache-Control header can be used to prevent browsers from caching the given responses. This should be done for pages that contain sensitive information about either the user or the application. However, disabling caching for pages that do not contain sensitive information may seriously affect the performance of the application. Therefore, caching should only be disabled for pages that return sensitive information. Appropriate caching controls and headers can be used easily by the following code:
+- **[Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) and [Pragma](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma):** Cache-Control header can be used to prevent browsers from caching the given responses. This should be done for pages that contain sensitive information about either the user or the application. However, disabling caching for pages that do not contain sensitive information may seriously affect the performance of the application. Therefore, caching should only be disabled for pages that return sensitive information. Appropriate caching controls and headers can be set easily using the [nocache](https://www.npmjs.com/package/nocache) package :
 
 ```JavaScript
-app.use(helmet.noCache());
+const nocache = require("nocache");
+
+app.use(nocache());
 ```
 
 The above code sets Cache-Control, Surrogate-Control, Pragma and Expires headers accordingly.

--- a/cheatsheets/Nodejs_Security_Cheat_Sheet.md
+++ b/cheatsheets/Nodejs_Security_Cheat_Sheet.md
@@ -431,16 +431,34 @@ app.use(session({
 
 #### Use appropriate security headers
 
-There are several different [HTTP security headers](https://owasp.org/www-project-secure-headers/) that can help you prevent some common attack vectors. These are listed below:
+There are several different [HTTP security headers](https://owasp.org/www-project-secure-headers/) that can help you prevent some common attack vectors.
+The [helmet](https://www.npmjs.com/package/helmet) package can help to set those headers :
+
+```Javascript
+const express = require("express");
+const helmet = require("helmet");
+
+const app = express();
+
+app.use(helmet()); // Add various HTTP headers
+```
+
+The top-level `helmet` function is a wrapper around 14 smaller middlewares. 
+Bellow is a list of HTTP security headers covered by `helmet` middlewares :
 
 - **[Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)**: [HTTP Strict Transport Security (HSTS)](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) dictates browsers that the application can only be accessed via HTTPS connections. In order to use it in your application, add the following codes:
 
 ```JavaScript
 app.use(helmet.hsts()); // default configuration
-app.use(helmet.hsts("<max-age>", "<includeSubdomains>")); // custom configuration
+app.use(
+  helmet.hsts({
+    maxAge: 123456,
+    includeSubDomains: false,
+  })
+); // custom configuration
 ```
 
-- **[X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options):** determines if a page can be loaded via a `<frame>` or an `<iframe>` element. Allowing the page to be framed may result in [Clickjacking](https://owasp.org/www-community/attacks/Clickjacking) attacks. This header can be used with [helmet](https://www.npmjs.com/package/helmet) module as follows:
+- **[X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options):** determines if a page can be loaded via a `<frame>` or an `<iframe>` element. Allowing the page to be framed may result in [Clickjacking](https://owasp.org/www-community/attacks/Clickjacking) attacks.
 
 ```JavaScript
 app.use(helmet.frameguard()); // default behavior (SAMEORIGIN)


### PR DESCRIPTION
This PR update various helmet middlewares found in the **NodeJS Security Cheat Sheet**.

- Replace `express-session` cookie `key` attribute with `name`. Although the `key` attribute still works, [it was replaced by `name`](https://github.com/expressjs/session/blob/master/HISTORY.md#110--2014-05-12) and only the later is referenced in the documentation,
- Replace `helmet.xframe()` with `helmet.frameguard()` : [the xframe middleware is now called frameguard](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#050---2014-10-28) (xframe still works). Also, updated the example as [frameguard is now set to SAMEORIGIN by default](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#600---2022-08-26), and ALLOW-FROM is no more supported,
- Update the X-XSS-Protection section as it is now disabled by default by `helmet`. See : https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#changed-12,
- Replace `helmet.noCache()` with the `nocache` package. See : https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#removed-4,
- Add information and example about the top level `helmet()` function,
- Some small grammatical fixes.

Also, I saw that the section [Cross_Site_Scripting_Prevention_Cheat_Sheet.md#x-xss-protection-header](https://github.com/OWASP/CheatSheetSeries/blob/9d5dc5b52c07eb4af4dcfadd8803f06c8d55918b/cheatsheets/Nodejs_Security_Cheat_Sheet.md?plain=1#L451) no longer exists in the `Cross_Site_Scripting_Prevention_Cheat_Sheet.md` cheatsheet. Should the link be deleted or should it point to another section ?