### PR TITLE
Remove link to leapgraph that redirects to gambling website

### DIFF
--- a/cheatsheets/GraphQL_Cheat_Sheet.md
+++ b/cheatsheets/GraphQL_Cheat_Sheet.md
@@ -320,7 +320,6 @@ GraphQL APIs in production shouldn't return stack traces or be in debug mode. Do
 
 ### GraphQL Security Best Practices + Documentation
 
-- [GraphQL security best practices](https://leapgraph.com/graphql-api-security)
 - [Protecting GraphQL APIs from security threats - blog post](https://medium.com/swlh/protecting-your-graphql-api-from-security-vulnerabilities-e8afdfa6fbe4)
 - [https://nordicapis.com/security-points-to-consider-before-implementing-graphql/](https://nordicapis.com/security-points-to-consider-before-implementing-graphql/)
 - [Limiting resource usage to prevent DoS (timeouts, throttling, complexity management, depth limiting, etc.)](https://developer.github.com/v4/guides/resource-limitations/)


### PR DESCRIPTION
It appears that the leapgraph link now redirects to https://qqsuper99top.com/, a gambling website.

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as [TEXT](URL)
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
