### PR TITLE
REST Security Cheat Sheet - Removed Deprecated Feature-Policy and added Permissions-Policy 

### DIFF
--- a/cheatsheets/REST_Security_Cheat_Sheet.md
+++ b/cheatsheets/REST_Security_Cheat_Sheet.md
@@ -146,13 +146,13 @@ The following headers should be included in all API responses:
 | `X-Content-Type-Options: nosniff` | To prevent browsers from performing MIME sniffing, and inappropriately interpreting responses as HTML. |
 | `X-Frame-Options: DENY` | To protect against drag-and-drop style clickjacking attacks. |
 
-The headers below are only intended to provide additional security when responses are rendered as HTML. As such, if the API will __never__ return HTML in responses, then these headers may not be necessary. However, if there is any uncertainty about the function of the headers, or the types of information that the API returns (or may return in future), then it is recommended to include them as part of a defence-in-depth approach.
+The headers below are only intended to provide additional security when responses are rendered as HTML. As such, if the API will **never** return HTML in responses, then these headers may not be necessary. However, if there is any uncertainty about the function of the headers, or the types of information that the API returns (or may return in future), then it is recommended to include them as part of a defence-in-depth approach.
 
-| Header | Rationale |
-|--------|-----------|
-| `Content-Security-Policy: default-src 'none'` | The majority of CSP functionality only affects pages rendered as HTML. |
-| `Feature-Policy: 'none'` | Feature policies only affect pages rendered as HTML. |
-| `Referrer-Policy: no-referrer` | Non-HTML responses should not trigger additional requests. |
+| Header | Example | Rationale |
+|--------|-----------|-----------|
+| Content-Security-Policy | `Content-Security-Policy: default-src 'none'` | The majority of CSP functionality only affects pages rendered as HTML. |
+| Permissions-Policy | `Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()` | This header used to be named Feature-Policy. When browsers heed this header, it is used to control browser features via directives. The example disables features with an empty allowlist for a number of permitted [directive names](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy#directives). When you apply this header, verify that the directives are up-to-date and fit your needs. Please have a look at this [article](https://developer.chrome.com/en/docs/privacy-sandbox/permissions-policy) for a detailed explanation on how to control browser features. |
+| Referrer-Policy | `Referrer-Policy: no-referrer` | Non-HTML responses should not trigger additional requests. |
 
 ## CORS
 


### PR DESCRIPTION
Note: Feature-Policy / Permissions-Policy may not be a great fit for REST-APIs. However, didn't see any information that this header was deprecated. This is why i suggest to update this information.

Regarding the example given: "Permissions-Policy: 'none'" may be a catch-all, but i didn't quite get whether this actually works.
This is why this example contains the standard directives. If you happen to know, please cut it down to proper size!

Removed - Feature-Policy - The header was renamed to Permissions-Policy
Added - Permissions-Policy and notes what to keep in mind about this HTTP-Header 
See: https://www.w3.org/TR/permissions-policy/#introduction

Changed - Table for optional HTTP-Headers separated into | Header | Example | Rationale | 
from | Header | Rationale | with the intent to give more room to the example