### PR TITLE
Improved JAXB Example

### DIFF
--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -388,9 +388,19 @@ documentBuilder.setEntityResolver(noop);
 Since a `javax.xml.bind.Unmarshaller` parses XML and does not support any flags for disabling XXE, it's imperative to parse the untrusted XML through a configurable secure parser first, generate a source object as a result, and pass the source object to the Unmarshaller. For example:
 
 ``` java
-//Disable XXE
 SAXParserFactory spf = SAXParserFactory.newInstance();
+
+//Option 1: This is the PRIMARY defense against XXE
 spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+spf.setXIncludeAware(false);
+
+//Option 2: If disabling doctypes is not possible
+spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+spf.setXIncludeAware(false);
 
 //Do unmarshall operation
 Source xmlSource = new SAXSource(spf.newSAXParser().getXMLReader(),


### PR DESCRIPTION
Hi there, 

I read through the last PR that changed the JAXB code snippet (https://github.com/OWASP/CheatSheetSeries/pull/1097) which undid some of my previous changes and don't agree with it 100%. I feel like this new PR here would improve the JAXB example, because:

1. Even if doctypes are completely disabled, XXE may be possible via `XIncludes`
2. I'm not sure if `FEATURE_SECURE_PROCESSING` would add a security benefit if `disallow-doctype-decl` is set to `true`. However, I don't see any harm. I went down the rabbit hole of `FEATURE_SECURE_PROCESSING` before, and I think I recall it does different things depending on the Java version and the parser it's used on.
3. I think it makes sense to suggest the alternative option when disabling doctypes is not possible

Thanks,
Florian