### PR TITLE
document custom request headers as a standalone CSRF protection

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -71,7 +71,7 @@ A simpler alternative to an encrypted cookie is to HMAC the token with a secret 
 
 Both the synchronizer token and the double submit cookie are used to prevent forgery of form data, but they can be tricky to implement and degrade usability. Many modern web applications do not use `<form>` tags. A user-friendly defense that is particularly well suited for AJAX or API endpoints is the use of a **custom request header**. No token is needed for this approach.
 
-In this pattern, the client appends a custom header to requests that require CSRF protection. The header can be any arbitrary key/value pair, as long as it does not conflict with existing headers.
+In this pattern, the client appends a custom header to requests that require CSRF protection. The header can be any arbitrary key-value pair, as long as it does not conflict with existing headers.
 
 ```
 X-YOURSITE-CSRF-PROTECTION=1


### PR DESCRIPTION
This change updates the CSRF Prevention Cheat Sheet to document custom request headers as a standalone CSRF protection for APIs, rather than as a "defense in depth" protection. The goal is to clarify that in some cases, custom request headers are on their own a sufficient defense against CSRF, without requiring a token. It also goes into more detail about what CORS configuration is appropriate for this defense.

This PR covers issue #1010 