### PR TITLE
Clarify that ProcessStartInfo.ArgumentList is not safe with untrusted data

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -308,7 +308,7 @@ DO NOT: Assume you can sanitize special characters without actually removing the
 
 DO NOT: Rely on methods without a security guarantee.
 
-e.g. .NET Core 2.2 and greater and .NET 5 and greater support [ProcessStartInfo.ArgumentList](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist) which performs some character escaping but it is not clear if this is guaranteed to be secure.
+e.g. .NET Core 2.2 and greater and .NET 5 and greater support [ProcessStartInfo.ArgumentList](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist) which performs some character escaping but the object includes [a disclaimer that it is not safe with untrusted input](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist#remarks).
 
 DO: Look at alternatives to passing raw untrusted arguments via command-line parameters such as encoding using Base64 (which would safely encode any special characters as well) and then decode the parameters in the receiving application.
 


### PR DESCRIPTION
I originally raised https://github.com/dotnet/dotnet-api-docs/issues/7697 which was eventually resolved (probably without refering to my issue 🙃) by https://github.com/dotnet/dotnet-api-docs/pull/8802.

Since this is now clear, I want to clarify the cheatsheet