### PR TITLE
remove SeaSponge from Threat Modeling Cheat Sheet

### DIFF
--- a/cheatsheets/Threat_Modeling_Cheat_Sheet.md
+++ b/cheatsheets/Threat_Modeling_Cheat_Sheet.md
@@ -159,10 +159,6 @@ The Poirot tool isolates and diagnoses defects through fault modeling and simula
 
 The Microsoft Threat Modeling Tool (TMT) helps find threats in the design phase of software projects. It is one of the longest lived threat modeling tools, having been introduced as Microsoft SDL in 2008, and is actively supported; [version 7.3](https://aka.ms/threatmodelingtool) was released March 2020. It runs only on Windows 10 Anniversary Update or later, and so is difficult to use on macOS or Linux.
 
-##### SeaSponge
-
-[SeaSponge](https://github.com/mozilla/seasponge) is an accessible web-based threat modeling tool. The tool provides an online [live Demo](http://mozilla.github.io/seasponge/#/).
-
 ### Define Data Flow over your DFD
 
 Define Data Flows over the organization Data Flow Diagram.


### PR DESCRIPTION
Removes the reference to SeaSponge as it is misleading

[Mozilla SeaSponge](https://github.com/mozilla/seasponge) does not seem to be active - the last significant commit was January 2016 and the repo has been archived since April 2018. Closes #1129 

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as [TEXT](URL)
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

This PR covers issue #1129 