### PR TITLE
HTTP_Headers_Cheat_Sheet: Add missing comma in Permissions-Policy

### DIFF
--- a/cheatsheets/HTTP_Headers_Cheat_Sheet.md
+++ b/cheatsheets/HTTP_Headers_Cheat_Sheet.md
@@ -175,7 +175,7 @@ More information: [Permissions-Policy](https://developer.mozilla.org/en-US/docs/
 #### Recommendation
 
 Set it and disable all the features that your site does not need or allow them only to the authorized domains:
-> `Permissions-Policy: geolocation=() camera=(), microphone=()`
+> `Permissions-Policy: geolocation=(), camera=(), microphone=()`
 
 - *NOTE*: This example is disabling geolocation, camera, and microphone for all domains.
 


### PR DESCRIPTION
Missing comma in given Permissions-Policy leads to "Parse of permissions policy failed because of errors reported by structured header parser."

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy