### PR TITLE
Test collapsibles

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -465,7 +465,7 @@ This code snippet has been tested with jQuery version 3.3.1.
 
 ---
 
-Collapsible Test:
+Collapsible Test 1:
 
 !!! info end "Lorem ipsum"
 
@@ -474,3 +474,22 @@ Collapsible Test:
     Curabitur feugiat, tortor non consequat
     finibus, justo purus auctor massa, nec
     semper lorem quam in massa.
+
+Collapsible Test 2:
+
+<details>
+  <summary>Click me</summary>
+  
+  ### Heading
+  1. Foo
+  2. Bar
+     * Baz
+     * Qux
+
+  ### Some Code
+  ```js
+  function logSomething(something) {
+    console.log('Something', something);
+  }
+  ```
+</details>

--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -461,3 +461,16 @@ This code snippet has been tested with jQuery version 3.3.1.
 - For Java: OWASP [CSRF Guard](https://owasp.org/www-project-csrfguard/) or [Spring Security](https://docs.spring.io/spring-security/site/docs/5.5.x-SNAPSHOT/reference/html5/#csrf)
 - For PHP and Apache: [CSRFProtector Project](https://owasp.org/www-project-csrfprotector/)
 - For AngularJS: [Cross-Site Request Forgery (XSRF) Protection](https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection)
+
+
+---
+
+Collapsible Test:
+
+!!! info end "Lorem ipsum"
+
+    Lorem ipsum dolor sit amet, consectetur
+    adipiscing elit. Nulla et euismod nulla.
+    Curabitur feugiat, tortor non consequat
+    finibus, justo purus auctor massa, nec
+    semper lorem quam in massa.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,3 +61,6 @@ markdown_extensions:
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
   - toc:
       permalink: true
+  - admonition
+  - pymdownx.details # Required for admonition
+  - pymdownx.superfences # Required for admonition


### PR DESCRIPTION
Regarding #1101, we've been discussing adding Collapsibles to OWASP to add additional information without increasing the size of the cheatsheet.

After some research, there seems 2 approaches here:
1. it seems that MKDocs, the framework of the cheatsheet, supports this but requires additional configuration. (See: https://squidfunk.github.io/mkdocs-material/reference/admonitions/)
2. With HTML https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab

I added test collapsibles at the end of the CSRF cheatsheet page to see how they render. We can remove this instantly afterward. I'd like to know if they render OK before I invest time in #1143 or #1101.

