### PR TITLE
Removed Encrypted CSRF Cookie

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -73,16 +73,9 @@ The Naive Double Submit Cookie method is a good initial step to counter CSRF att
 
 #### Signed Double Submit Cookie
 
-The _Signed Double Submit Cookie_ involves a secret key known only to the server. This ensures that an attacker cannot create and inject their own, known, CSRF token into the victim's authenticated session. There are two common methods for signing tokens:
-
-- Encrypt the cookie that contains the CSRF token
-- Generate the CSRF Token using HMAC
+The _Signed Double Submit Cookie_ involves a secret key known only to the server. This ensures that an attacker cannot create and inject their own, known, CSRF token into the victim's authenticated session. Tokens can be secured by hashing or encrypting them, with HMAC algorithm being a popular choice due to its fast speed and easy implementation.
 
 In both cases, it is recommended to bind the CSRF token with the users current session to even further enhance security.
-
-##### Encrypted CSRF Cookie
-
-Include the CSRF token in an encrypted cookie - other than the authentication cookie (since they are often shared within subdomains) - and then at the server side match it (after decrypting the encrypted cookie) with the token in hidden form field or request header for AJAX calls. This works because a sub domain has no way to overwrite a properly crafted encrypted cookie without the necessary information such as encryption key.
 
 ##### HMAC CSRF Token
 


### PR DESCRIPTION
In [PR#1139](https://github.com/OWASP/CheatSheetSeries/pull/1139), I placed the existing text for [encrypting cookies](https://github.com/OWASP/CheatSheetSeries/blob/fec62f2c3626384dde40b5694215b3579ebe9979/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md?plain=1#L66) into its [own subsection](https://github.com/OWASP/CheatSheetSeries/blob/12674b64da927c2613e96d1414c6fe5f2d747de5/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md?plain=1#L83), under "Double Submit Cookie" pattern.

I, personally, believe that this was a mistake. 
The Cookie itself is not encrypted, but the value inside. It's no different from the [HMAC CSRF Token](https://github.com/OWASP/CheatSheetSeries/blob/12674b64da927c2613e96d1414c6fe5f2d747de5/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md?plain=1#L87) pattern, except that we encrypt the token instead of hashing it. The original text was confusing and made me believe that this was a different pattern.
Moreover, this new "Encrypted CSRF Cookie" section may no create more confusion with an older but similarly named token pattern ["Encryption based Token Pattern"](https://web.archive.org/web/20190207042021/https://owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Encryption_based_Token_Pattern).

I therefore removed the whole section and updated the enclosing section to reflect that signing the token can be done by encrypting or hashing the token.