### PR TITLE
Update markdown lint to allow collapsible sections

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -5,5 +5,6 @@
     "MD013": false,
     "MD024": { "siblings_only": true},
     "MD029": false,
+    "MD033": { "allowed_elements": "details, summary"},
     "MD040": false
 }


### PR DESCRIPTION
This change will stop the markdown linter complaining about the HTML used to create collapsible sections as were demonstrated in PR #1149