### PR TITLE
Replaced dead link in the Key Management Cheat Sheet

### DIFF
--- a/cheatsheets/Key_Management_Cheat_Sheet.md
+++ b/cheatsheets/Key_Management_Cheat_Sheet.md
@@ -252,5 +252,5 @@ Use only reputable crypto libraries that are well maintained and updated, as wel
 
 ## Documentation
 
-- [The definitive guide to encryption key management fundamentals](https://info.townsendsecurity.com/definitive-guide-to-encryption-key-management-fundamentals).
+- [The definitive guide to encryption key management fundamentals](https://downloads.townsendsecurity.com/ebooks/EKM-Definitive-Guide.pdf).
 - [Practical cryptography for developers](https://cryptobook.nakov.com/).


### PR DESCRIPTION
I noticed a dead link in the Key Management Cheat Sheet and replaced it with a live link on the same domain.
