### PR TITLE
First Draft for JWT Best Practices Doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ news.xml
 package-lock.json
 yarn.lock
 venv
+/.idea

--- a/Index.md
+++ b/Index.md
@@ -1,158 +1,200 @@
-# Introduction
+# Index Alphabetical
 
-**64** cheat sheets available.
+**86** cheat sheets available.
 
 *Icons beside the cheat sheet name indicate in which language(s) code snippet(s) are provided.*
 
-[A](Index.md#a) [B](Index.md#b) [C](Index.md#c) [D](Index.md#d) [E](Index.md#e) [F](Index.md#f) [H](Index.md#h) [I](Index.md#i) [J](Index.md#j) [K](Index.md#k) [L](Index.md#l) [M](Index.md#m) [N](Index.md#n) [O](Index.md#o) [P](Index.md#p) [Q](Index.md#q) [R](Index.md#r) [S](Index.md#s) [T](Index.md#t) [U](Index.md#u) [V](Index.md#v) [W](Index.md#w) [X](Index.md#x)
+[A](Index.md#a) [B](Index.md#b) [C](Index.md#c) [D](Index.md#d) [E](Index.md#e) [F](Index.md#f) [G](Index.md#g) [H](Index.md#h) [I](Index.md#i) [J](Index.md#j) [K](Index.md#k) [L](Index.md#l) [M](Index.md#m) [N](Index.md#n) [O](Index.md#o) [P](Index.md#p) [Q](Index.md#q) [R](Index.md#r) [S](Index.md#s) [T](Index.md#t) [U](Index.md#u) [V](Index.md#v) [W](Index.md#w) [X](Index.md#x) 
 
 ## A
 
+[Authorization Cheat Sheet](cheatsheets/Authorization_Cheat_Sheet.md).
+
+[AJAX Security Cheat Sheet](cheatsheets/AJAX_Security_Cheat_Sheet.md). ![Json](assets/Index_Json.png) 
+
 [Access Control Cheat Sheet](cheatsheets/Access_Control_Cheat_Sheet.md).
-
-[Attack Surface Analysis Cheat Sheet](cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.md).
-
-[Authentication Cheat Sheet](cheatsheets/Authentication_Cheat_Sheet.md).
-
-[AJAX Security Cheat Sheet](cheatsheets/AJAX_Security_Cheat_Sheet.md). ![Json](assets/Index_Json.png)
 
 [Abuse Case Cheat Sheet](cheatsheets/Abuse_Case_Cheat_Sheet.md).
 
-[Authorization Testing Automation Cheat Sheet](cheatsheets/Authorization_Testing_Automation_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Xml](assets/Index_Xml.png)
+[Authorization Testing Automation Cheat Sheet](cheatsheets/Authorization_Testing_Automation_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Xml](assets/Index_Xml.png) 
+
+[Authentication Cheat Sheet](cheatsheets/Authentication_Cheat_Sheet.md).
+
+[Attack Surface Analysis Cheat Sheet](cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.md).
 
 ## B
 
-[Bean Validation Cheat Sheet](cheatsheets/Bean_Validation_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Xml](assets/Index_Xml.png)
+[Bean Validation Cheat Sheet](cheatsheets/Bean_Validation_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Xml](assets/Index_Xml.png) 
 
 ## C
 
-[Cross-Site Request Forgery Prevention Cheat Sheet](cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md). ![Html](assets/Index_Html.png)
-
-[Clickjacking Defense Cheat Sheet](cheatsheets/Clickjacking_Defense_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png)
-
-[Cross Site Scripting Prevention Cheat Sheet](cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Html](assets/Index_Html.png) ![Ruby](assets/Index_Ruby.png)
-
-[Choosing and Using Security Questions Cheat Sheet](cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md).
-
-[Content Security Policy Cheat Sheet](cheatsheets/Content_Security_Policy_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png)
+[Cryptographic Storage Cheat Sheet](cheatsheets/Cryptographic_Storage_Cheat_Sheet.md).
 
 [Credential Stuffing Prevention Cheat Sheet](cheatsheets/Credential_Stuffing_Prevention_Cheat_Sheet.md).
 
-[Cryptographic Storage Cheat Sheet](cheatsheets/Cryptographic_Storage_Cheat_Sheet.md).
+[Choosing and Using Security Questions Cheat Sheet](cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md).
+
+[C-Based Toolchain Hardening Cheat Sheet](cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md). ![C](assets/Index_C.png) ![Bash](assets/Index_Bash.png) 
+
+[Cross-Site Request Forgery Prevention Cheat Sheet](cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md). ![Html](assets/Index_Html.png) 
+
+[Content Security Policy Cheat Sheet](cheatsheets/Content_Security_Policy_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png) 
+
+[Clickjacking Defense Cheat Sheet](cheatsheets/Clickjacking_Defense_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png) 
+
+[Cross Site Scripting Prevention Cheat Sheet](cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md). ![Html](assets/Index_Html.png) 
 
 ## D
 
-[Deserialization Cheat Sheet](cheatsheets/Deserialization_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Python](assets/Index_Python.png)
-
-[Docker Security Cheat Sheet](cheatsheets/Docker_Security_Cheat_Sheet.md). ![Bash](assets/Index_Bash.png)
-
-[Database Security Cheat Sheet](cheatsheets/Database_Security_Cheat_Sheet.md).
-
-[DotNet Security Cheat Sheet](cheatsheets/DotNet_Security_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Csharp](assets/Index_Csharp.png) ![Html](assets/Index_Html.png) ![Xml](assets/Index_Xml.png) ![Sql](assets/Index_Sql.png)
-
-[DOM based XSS Prevention Cheat Sheet](cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png)
+[DOM based XSS Prevention Cheat Sheet](cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png) 
 
 [Denial of Service Cheat Sheet](cheatsheets/Denial_of_Service_Cheat_Sheet.md).
 
+[DotNet Security Cheat Sheet](cheatsheets/DotNet_Security_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Csharp](assets/Index_Csharp.png) ![Html](assets/Index_Html.png) ![Xml](assets/Index_Xml.png) ![Sql](assets/Index_Sql.png) 
+
+[Deserialization Cheat Sheet](cheatsheets/Deserialization_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Python](assets/Index_Python.png) 
+
+[Docker Security Cheat Sheet](cheatsheets/Docker_Security_Cheat_Sheet.md). ![Bash](assets/Index_Bash.png) 
+
+[Database Security Cheat Sheet](cheatsheets/Database_Security_Cheat_Sheet.md).
+
+[Django REST Framework Cheat Sheet](cheatsheets/Django_REST_Framework_Cheat_Sheet.md). ![Python](assets/Index_Python.png) 
+
+[DOM Clobbering Prevention Cheat Sheet](cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png) 
+
 ## E
 
-[Error Handling Cheat Sheet](cheatsheets/Error_Handling_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Xml](assets/Index_Xml.png)
+[Error Handling Cheat Sheet](cheatsheets/Error_Handling_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Xml](assets/Index_Xml.png) 
 
 ## F
 
+[Forgot Password Cheat Sheet](cheatsheets/Forgot_Password_Cheat_Sheet.md).
+
 [File Upload Cheat Sheet](cheatsheets/File_Upload_Cheat_Sheet.md).
 
-[Forgot Password Cheat Sheet](cheatsheets/Forgot_Password_Cheat_Sheet.md).
+## G
+
+[GraphQL Cheat Sheet](cheatsheets/GraphQL_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) 
 
 ## H
 
-[HTML5 Security Cheat Sheet](cheatsheets/HTML5_Security_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) ![Html](assets/Index_Html.png) ![Json](assets/Index_Json.png) ![Shell](assets/Index_Shell.png)
-
 [HTTP Strict Transport Security Cheat Sheet](cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.md).
+
+[HTTP Headers Cheat Sheet](cheatsheets/HTTP_Headers_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Xml](assets/Index_Xml.png) ![Php](assets/Index_Php.png) 
+
+[HTML5 Security Cheat Sheet](cheatsheets/HTML5_Security_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) ![Html](assets/Index_Html.png) ![Json](assets/Index_Json.png) ![Shell](assets/Index_Shell.png) 
 
 ## I
 
-[Injection Prevention Cheat Sheet](cheatsheets/Injection_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png)
+[Injection Prevention in Java Cheat Sheet](cheatsheets/Injection_Prevention_in_Java_Cheat_Sheet.md).
 
-[Injection Prevention in Java Cheat Sheet](cheatsheets/Injection_Prevention_in_Java_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Xml](assets/Index_Xml.png)
+[Injection Prevention Cheat Sheet](cheatsheets/Injection_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png) 
 
-[Input Validation Cheat Sheet](cheatsheets/Input_Validation_Cheat_Sheet.md). ![Java](assets/Index_Java.png)
+[Input Validation Cheat Sheet](cheatsheets/Input_Validation_Cheat_Sheet.md). ![Java](assets/Index_Java.png) 
 
-[Insecure Direct Object Reference Prevention Cheat Sheet](cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png)
+[Infrastructure as Code Security Cheat Sheet](cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.md).
+
+[Insecure Direct Object Reference Prevention Cheat Sheet](cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.md).
 
 ## J
 
-[JAAS Cheat Sheet](cheatsheets/JAAS_Cheat_Sheet.md). ![Java](assets/Index_Java.png)
+[JAAS Cheat Sheet](cheatsheets/JAAS_Cheat_Sheet.md). ![Java](assets/Index_Java.png) 
 
-[JSON Web Token for Java Cheat Sheet](cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) ![Json](assets/Index_Json.png) ![Sql](assets/Index_Sql.png)
+[JWT Cheat Sheet](cheatsheets/JWT_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) ![Json](assets/Index_Json.png) 
+
+[Java Security Cheat Sheet](cheatsheets/Java_Security_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Xml](assets/Index_Xml.png) 
+
+[JSON Web Token for Java Cheat Sheet](cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) ![Json](assets/Index_Json.png) ![Sql](assets/Index_Sql.png) 
 
 ## K
 
 [Key Management Cheat Sheet](cheatsheets/Key_Management_Cheat_Sheet.md).
 
+[Kubernetes Security Cheat Sheet](cheatsheets/Kubernetes_Security_Cheat_Sheet.md). ![Json](assets/Index_Json.png) ![Bash](assets/Index_Bash.png) 
+
 ## L
+
+[Logging Vocabulary Cheat Sheet](cheatsheets/Logging_Vocabulary_Cheat_Sheet.md).
+
+[LDAP Injection Prevention Cheat Sheet](cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md).
 
 [Logging Cheat Sheet](cheatsheets/Logging_Cheat_Sheet.md).
 
-[LDAP Injection Prevention Cheat Sheet](cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md).
+[Laravel Cheat Sheet](cheatsheets/Laravel_Cheat_Sheet.md). ![Html](assets/Index_Html.png) ![Php](assets/Index_Php.png) ![Sql](assets/Index_Sql.png) ![Bash](assets/Index_Bash.png) 
 
 ## M
 
 [Multifactor Authentication Cheat Sheet](cheatsheets/Multifactor_Authentication_Cheat_Sheet.md).
 
-[Mass Assignment Cheat Sheet](cheatsheets/Mass_Assignment_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) ![Html](assets/Index_Html.png) ![Php](assets/Index_Php.png)
-
 [Microservices based Security Arch Doc Cheat Sheet](cheatsheets/Microservices_based_Security_Arch_Doc_Cheat_Sheet.md).
+
+[Mass Assignment Cheat Sheet](cheatsheets/Mass_Assignment_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Java](assets/Index_Java.png) ![Html](assets/Index_Html.png) ![Php](assets/Index_Php.png) 
+
+[Microservices Security Cheat Sheet](cheatsheets/Microservices_Security_Cheat_Sheet.md).
 
 ## N
 
-[NodeJS Security Cheat Sheet](cheatsheets/Nodejs_Security_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png) ![Bash](assets/Index_Bash.png)
+[NPM Security Cheat Sheet](cheatsheets/NPM_Security_Cheat_Sheet.md).
+
+[NodeJS Docker Cheat Sheet](cheatsheets/NodeJS_Docker_Cheat_Sheet.md).
+
+[Nodejs Security Cheat Sheet](cheatsheets/Nodejs_Security_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Bash](assets/Index_Bash.png) 
+
+[Network Segmentation Cheat Sheet](cheatsheets/Network_Segmentation_Cheat_Sheet.md).
 
 ## O
 
-[OS Command Injection Defense Cheat Sheet](cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Shell](assets/Index_Shell.png)
+[OS Command Injection Defense Cheat Sheet](cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Php](assets/Index_Php.png) ![Shell](assets/Index_Shell.png) 
 
 ## P
 
 [Password Storage Cheat Sheet](cheatsheets/Password_Storage_Cheat_Sheet.md).
 
-[PHP Configuration Cheat Sheet](cheatsheets/PHP_Configuration_Cheat_Sheet.md).
-
 [Pinning Cheat Sheet](cheatsheets/Pinning_Cheat_Sheet.md).
+
+[Prototype Pollution Prevention Cheat Sheet](cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) 
+
+[PHP Configuration Cheat Sheet](cheatsheets/PHP_Configuration_Cheat_Sheet.md).
 
 ## Q
 
-[Query Parameterization Cheat Sheet](cheatsheets/Query_Parameterization_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Ruby](assets/Index_Ruby.png) ![Php](assets/Index_Php.png) ![Sql](assets/Index_Sql.png) ![Coldfusion](assets/Index_Coldfusion.png) ![Perl](assets/Index_Perl.png)
+[Query Parameterization Cheat Sheet](cheatsheets/Query_Parameterization_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Ruby](assets/Index_Ruby.png) ![Php](assets/Index_Php.png) ![Sql](assets/Index_Sql.png) ![Coldfusion](assets/Index_Coldfusion.png) ![Perl](assets/Index_Perl.png) 
 
 ## R
 
-[REST Security Cheat Sheet](cheatsheets/REST_Security_Cheat_Sheet.md).
-
 [REST Assessment Cheat Sheet](cheatsheets/REST_Assessment_Cheat_Sheet.md).
 
-[Ruby on Rails Cheat Sheet](cheatsheets/Ruby_on_Rails_Cheat_Sheet.md). ![Html](assets/Index_Html.png) ![Ruby](assets/Index_Ruby.png) ![Bash](assets/Index_Bash.png)
+[Ruby on Rails Cheat Sheet](cheatsheets/Ruby_on_Rails_Cheat_Sheet.md). ![Html](assets/Index_Html.png) ![Ruby](assets/Index_Ruby.png) ![Bash](assets/Index_Bash.png) 
+
+[REST Security Cheat Sheet](cheatsheets/REST_Security_Cheat_Sheet.md).
 
 ## S
 
-[Securing Cascading Style Sheets Cheat Sheet](cheatsheets/Securing_Cascading_Style_Sheets_Cheat_Sheet.md).
+[Server Side Request Forgery Prevention Cheat Sheet](cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Python](assets/Index_Python.png) ![Ruby](assets/Index_Ruby.png) ![Bash](assets/Index_Bash.png) 
 
-[SQL Injection Prevention Cheat Sheet](cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Php](assets/Index_Php.png) ![Sql](assets/Index_Sql.png) ![Vbnet](assets/Index_Vbnet.png)
+[Secure Product Design Cheat Sheet](cheatsheets/Secure_Product_Design_Cheat_Sheet.md).
 
-[Server Side Request Forgery Prevention Cheat Sheet](cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Python](assets/Index_Python.png) ![Ruby](assets/Index_Ruby.png) ![Bash](assets/Index_Bash.png)
+[Secure Cloud Architecture Cheat Sheet](cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.md).
+
+[SQL Injection Prevention Cheat Sheet](cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Php](assets/Index_Php.png) ![Sql](assets/Index_Sql.png) ![Vbnet](assets/Index_Vbnet.png) 
+
+[Session Management Cheat Sheet](cheatsheets/Session_Management_Cheat_Sheet.md).
+
+[Secrets Management Cheat Sheet](cheatsheets/Secrets_Management_Cheat_Sheet.md).
 
 [SAML Security Cheat Sheet](cheatsheets/SAML_Security_Cheat_Sheet.md).
 
-[Session Management Cheat Sheet](cheatsheets/Session_Management_Cheat_Sheet.md).
+[Securing Cascading Style Sheets Cheat Sheet](cheatsheets/Securing_Cascading_Style_Sheets_Cheat_Sheet.md).
 
 ## T
 
 [Transaction Authorization Cheat Sheet](cheatsheets/Transaction_Authorization_Cheat_Sheet.md).
 
+[Transport Layer Protection Cheat Sheet](cheatsheets/Transport_Layer_Protection_Cheat_Sheet.md). ![Bash](assets/Index_Bash.png) 
+
 [TLS Cipher String Cheat Sheet](cheatsheets/TLS_Cipher_String_Cheat_Sheet.md).
 
-[Transport Layer Protection Cheat Sheet](cheatsheets/Transport_Layer_Protection_Cheat_Sheet.md). ![Bash](assets/Index_Bash.png)
-
-[Third Party Javascript Management Cheat Sheet](cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png)
+[Third Party Javascript Management Cheat Sheet](cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png) 
 
 [Threat Modeling Cheat Sheet](cheatsheets/Threat_Modeling_Cheat_Sheet.md).
 
@@ -160,15 +202,15 @@
 
 [User Privacy Protection Cheat Sheet](cheatsheets/User_Privacy_Protection_Cheat_Sheet.md).
 
-[Unvalidated Redirects and Forwards Cheat Sheet](cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Ruby](assets/Index_Ruby.png) ![Php](assets/Index_Php.png)
+[Unvalidated Redirects and Forwards Cheat Sheet](cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Ruby](assets/Index_Ruby.png) ![Php](assets/Index_Php.png) 
 
 ## V
 
-[Virtual Patching Cheat Sheet](cheatsheets/Virtual_Patching_Cheat_Sheet.md). ![Html](assets/Index_Html.png)
-
 [Vulnerability Disclosure Cheat Sheet](cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md).
 
-[Vulnerable Dependency Management Cheat Sheet](cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md). ![Java](assets/Index_Java.png)
+[Virtual Patching Cheat Sheet](cheatsheets/Virtual_Patching_Cheat_Sheet.md). ![Html](assets/Index_Html.png) 
+
+[Vulnerable Dependency Management Cheat Sheet](cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md). ![Java](assets/Index_Java.png) 
 
 ## W
 
@@ -176,6 +218,10 @@
 
 ## X
 
-[XML External Entity Prevention Cheat Sheet](cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Cpp](assets/Index_Cpp.png) ![Php](assets/Index_Php.png)
+[XML Security Cheat Sheet](cheatsheets/XML_Security_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Xml](assets/Index_Xml.png) ![Bash](assets/Index_Bash.png) 
 
-[XML Security Cheat Sheet](cheatsheets/XML_Security_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Xml](assets/Index_Xml.png) ![Bash](assets/Index_Bash.png)
+[XML External Entity Prevention Cheat Sheet](cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md). ![Java](assets/Index_Java.png) ![Csharp](assets/Index_Csharp.png) ![Cpp](assets/Index_Cpp.png) ![Php](assets/Index_Php.png) 
+
+[XSS Filter Evasion Cheat Sheet](cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md). ![Html](assets/Index_Html.png) ![Php](assets/Index_Php.png) 
+
+[XS Leaks Cheat Sheet](cheatsheets/XS_Leaks_Cheat_Sheet.md). ![Javascript](assets/Index_Javascript.png) ![Html](assets/Index_Html.png) 

--- a/assets/JWTCSA/0-verification.md
+++ b/assets/JWTCSA/0-verification.md
@@ -1,0 +1,49 @@
+# Verification
+
+## `None` Examples
+
+### Java
+
+<!-- --8<-- [start:java] -->
+```
+// HMAC key - Block serialization and storage as String in JVM memory
+private transient byte[] keyHMAC = ...;
+
+...
+
+//Create a verification context for the token requesting
+//explicitly the use of the HMAC-256 hashing algorithm
+JWTVerifier verifier = JWT.require(Algorithm.HMAC256(keyHMAC)).build();
+
+//Verify the token, if the verification fail then a exception is thrown
+DecodedJWT decodedToken = verifier.verify(token);
+```
+<!-- --8<-- [end:java] -->
+
+### Python:pyjwt
+
+<!-- --8<-- [start:pyjwt] -->
+```
+try:
+    pyjwt.decode(encoded, key, algorithms=["HS256","ES256"])
+except Exception as error:
+    # handle exception here
+    raise error
+else:
+    continue
+```
+<!-- --8<-- [end:pyjwt] -->
+
+### NodeJS:Jose
+
+<!-- --8<-- [start:jose] -->
+```
+const { payload, protectedHeader } = await jose.jwtVerify(jwt, secret, {
+  algorithms: "HS256"
+})
+
+console.log(protectedHeader)
+console.log(payload)
+```
+<!-- --8<-- [end:jose] -->
+

--- a/cheatsheets/JWT_Cheat_Sheet.md
+++ b/cheatsheets/JWT_Cheat_Sheet.md
@@ -1,0 +1,200 @@
+# JWT Cheat Sheet
+
+## Introduction
+
+Many applications use **JSON Web Tokens** (JWT) to allow the client to indicate its identity for further exchange after 
+authentication and to securely transmit data.
+
+From [JWT.IO](https://jwt.io/introduction):
+
+> JSON Web Token (JWT) is an open standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) that defines a compact and 
+> self-contained way for securely transmitting information between parties as a JSON object. This information can be 
+> verified and trusted because it is digitally signed. JWTs can be signed using a secret (with the **HMAC** algorithm) 
+> or a public/private key pair using **RSA** or **ECDSA**.
+
+JSON Web Token is used to carry information related to the identity and characteristics (claims) of a client. This 
+information should signed by the server in order for it to detect whether it was tampered with after sending it to the 
+client. This will prevent an attacker from changing the identity or any characteristics (for example, changing the role 
+from simple user to admin or change the client login).
+
+This token is created during authentication (is provided in case of successful authentication) and is verified by the 
+server before any processing. It is used by an application to allow a client to present a token representing the user's 
+"identity card" to the server and allow the server to verify the validity and integrity of the token in a secure way, 
+all of this in a stateless and portable approach (portable in the way that client and server technologies can be 
+different including also the transport channel even if HTTP is the most often used).
+
+## Token Structure
+
+Token structure example taken from [JWT.IO](https://jwt.io/#debugger):
+
+`[Base64(HEADER)].[Base64(PAYLOAD)].[Base64(SIGNATURE)]`
+
+```text
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.
+eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.
+TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ
+```
+
+Chunk 1: **Header**
+
+```json
+{
+  "alg": "HS256",
+  "typ": "JWT"
+}
+```
+
+Chunk 2: **Payload**
+
+```json
+{
+  "sub": "1234567890",
+  "name": "John Doe",
+  "admin": true
+}
+```
+
+Chunk 3: **Signature**
+
+```javascript
+HMACSHA256( base64UrlEncode(header) + "." + base64UrlEncode(payload), KEY )
+```
+
+And example of this jwt can be found [here](https://jwt.io/) on JWT.io signed with a symmetric key called `test` (obviously
+weak).
+
+
+## Objective
+
+This cheatsheet provides tips to prevent common security issues when using JSON Web Tokens (JWT).
+
+## Consideration about Using JWT
+
+Even if a JWT token is "easy" to use and allow to expose services (mostly REST style) in a stateless way, it's not the 
+solution that fits for all applications because it comes with some caveats, like for example the question of the 
+storage of the token (tackled in this cheatsheet) and others. 
+
+If your application does not need to be fully stateless, you can consider using traditional session system provided by 
+all web frameworks and follow the advice from the dedicated [session management cheat sheet](Session_Management_Cheat_Sheet.md). 
+Especially for authenticating users, the use of tools like Oauth2 or OIDC backed by SAML has become an industry best
+practice, as it allows one SAML implementation/Server to integrate a large number of authentication best practices.
+Some of those tools use JWT's under the hood.
+
+## Issues
+
+### None Hashing Algorithm
+
+#### Symptom
+
+This attack, described [here](https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/), occurs 
+when an attacker alters the token and changes the hashing algorithm to indicate, through the *none* keyword, that the 
+integrity of the token has already been verified. As explained in the link above *some libraries treated tokens signed 
+with the none algorithm as a valid token with a verified signature*, so an attacker can alter the token claims and 
+the modified token will still be trusted by the application.
+
+#### How to Prevent
+
+First, use a JWT library that is not exposed to this vulnerability, or use a library that allows you to specify which
+algorithms are considered acceptable and do not include (or explicitly exclude) the `none` algorithm. For example in
+[`pyjwt.decode`](https://pyjwt.readthedocs.io/en/stable/api.html#jwt.decode) (python) you can explicitly state which
+signature(s) is acceptable. Most libraries have fixed this issue, but as a rule, if you're using a symmetric key you 
+should explicitly set which libraries are allowed.
+
+Second (and not shown) is to use an asymmetric key to sign your jwts. In general, it should be seen as a best practice
+to use an asymetrc key to sign jwts rather than a symmetric key.
+
+#### Implementation Example Symmetric Key
+
+=== "Java Example"
+
+    --8<-- "JWTCSA/0-verification.md:java"
+
+=== "Python Example (`pyjwt`)"
+
+    --8<-- "JWTCSA/0-verification.md:pyjwt"
+
+=== "Javascript Example (`jose`)"
+
+    --8<-- "JWTCSA/0-verification.md:jose"
+
+
+### Token Sidejacking
+
+#### Symptom
+
+This attack occurs when a token has been intercepted/stolen by an attacker and they use it to gain access to the system 
+using targeted user identity. In part, this attack really can't be mitigated "in platform" as JWTs are generically stateless
+by design. 
+
+#### How to Prevent
+
+If you're using a jwt as a session token in the context of a webapp you should follow the 
+[Session Management Cheat Sheet](Session Management Cheat Sheet). But a more generic fix might be to use JWTs in conjunction
+with OIDC/OAUTH2 and utilize the replay protections those meta libraries provide. However, if you're looking to implement
+a similar solution you can utilize a `nonce`.
+
+Additionally, depending on your application and security designs; it might make sense to have your JWT tokens valid for
+short periods of time; especially in a "service to service" context where the service can regenerate a token at any time.
+There may be a performance concern associated with signing a jwt token on each request; but modern CPUs should be able to
+generate tokens without much consideration for all but the most abnormal workloads. This wouldn't eliminate the problem
+of token sidejacking, but it would limit the amount of time a successful sidejacking could be utilized.
+
+/// details | Stateful Considerations
+    type: warning
+
+Using a nonce in a multi-node environment will require state to be shared between each node. Generally this is done with
+a database table or a tool like [redis](https://redis.io/). If you're application is designed to be stateless, or if it's
+a microservices type architecture this approach may not be ideal, or might be somewhat difficult to utilize.
+///
+
+So in this example you're server would return a jwt with the `nonce` claim (along with the normal `nbf`, 
+`iat`, `exp` time based claims).
+
+/// details | ToDo: Nonce Recommendation
+    type: ToDo
+
+Find the "right way" to implement a nonce. Finding conflicting information about how it should work (just server verify, 
+just client verify, both verify); protections for simultaneous api calls etc...
+///
+
+### No Built-In Token Revocation by the User
+
+#### Symptom
+
+This problem is inherent to JWT because a token only becomes invalid when it expires. The 
+[`jti`](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.7) component of the specification is supposed to allow for the
+ability for token revocation on the server side. Additionally, if a public certificate is used and the library supports it,
+a signing certificate should be able to be revoked  and that should invalidate the jwt token(s) signed with it.
+
+#### How to Prevent
+
+/// details | Stateful Considerations
+type: warning
+
+Using a `jti` in a multi-node environment will require token ids to be shared between each node. Generally this is done 
+with a database table or a tool like [redis](https://redis.io/). If you're application is designed to be stateless, or 
+if it's a micro-services type architecture this approach may not be ideal, or might be somewhat difficult to utilize.
+///
+
+Use a `jti`.
+
+Use a publicly signed certificate to sign jwts and check for certificate revocation on validation.
+
+### Validate Common Claims
+
+TODO
+
+### Implement Buisness Logic post Validation
+
+TODO
+
+## Further Reading
+
+- [{JWT}.{Attack}.Playbook](https://github.com/ticarpi/jwt_tool/wiki) - A project documents the known attacks and potential security vulnerabilities and misconfigurations of JSON Web Tokens.
+- [JWT Best Practices Internet Draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-jwt-bcp/)
+- [JWT.io Discussion Forum](https://community.auth0.com/c/jwt/8) (Hosted by [Auth0](https://auth0.com/))
+- [JWT Overview on Wikipedia](https://en.wikipedia.org/wiki/JSON_Web_Token)
+- [OpenID](https://openid.net/) - A larger framework to provide ways to connect JWT based authentication with other authentication
+  systems.
+- [JSON Web Encryption (JWE) RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516) - A JWT like specification that includes
+  payload encryption.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,9 +11,10 @@ copyright: ©Copyright 2021 - CheatSheets Series Team - This work is licensed un
 
 #Config
 docs_dir: cheatsheets/
-google_analytics:
-  - !!python/object/apply:os.getenv ["WORKFLOW_GOOGLE_ANALYTICS_KEY", "none"]
-  - auto
+extra:
+  analytics:
+    provider: google
+    property: !!python/object/apply:os.getenv ["WORKFLOW_GOOGLE_ANALYTICS_KEY", "none"]
 use_directory_urls: false
 plugins:
   - search:
@@ -56,6 +57,12 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences # Required by Pygments
   - pymdownx.inlinehilite
+  - pymdownx.blocks.details
+  - pymdownx.snippets:
+      base_path:
+        ../assets/
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.emoji:
       emoji_index: !!python/name:pymdownx.emoji.twemoji
       emoji_generator: !!python/name:pymdownx.emoji.to_svg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-requests
-feedgen
-wheel
-mkdocs
-mkdocs-material
-pymdown-extensions
-Pygments
+requests>=2.31.0
+feedgen>=0.9.0
+wheel>=0.41.1
+mkdocs>=1.5.2
+mkdocs-material>=9.1.21
+pymdown-extensions>=10.1
+pygments>=2.16.1


### PR DESCRIPTION
* Ignores .idea files (pycharm ide)
* Index updated by make generate-site
* Added assets/JWTCSA as a place for assets and snippets
* Added a JWT Cheat Sheet Doc
* Fixed google_analytics in mkdocs.yaml
* Added pymdownx plugins for:
	* Admonitions (`blocks.details`)
	* Code Snippets (`snippets`)
	* Tabbed Content (`tabbed`)
* Pinned modern minimum versions on requirements.txt

This PR covers issue #1176 .

Please do not merge yet. This is a work in progress at best.
