### PR TITLE
Fix GH checkout action not fetching all branches

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
     - name: Setup Action
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # fetch all branches
     - name: Install dependencies
       run: sudo apt-get install -y unzip zip
     - name: Switch to offline website (gh-pages) branch


### PR DESCRIPTION
In #1260, we upgraded to the latest version of the GH checkout action (v4). This version appears to no longer fetch all branches by default, so we are getting an error when trying to switch to the gh-pages branch in order to build the website. This PR explicitly configures the checkout action to fetch all branches.