### PR TITLE
Fix missing closing parenthesis in Java code example in Input_Validation_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -105,7 +105,7 @@ private static final Pattern zipPattern = Pattern.compile("^\d{5}(-\d{4})?
 public void doPost( HttpServletRequest request, HttpServletResponse response) {
   try {
       String zipCode = request.getParameter( "zip" );
-      if ( !zipPattern.matcher( zipCode ).matches()  {
+      if ( !zipPattern.matcher( zipCode ).matches() ) {
           throw new YourValidationException( "Improper zipcode format." );
       }
       // do what you want here, after its been validated ..


### PR DESCRIPTION
The missing parenthesis has been added after matches()

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
