### PR TITLE
Fix typos in multiple cheat sheets

### DIFF
--- a/cheatsheets/Password_Storage_Cheat_Sheet.md
+++ b/cheatsheets/Password_Storage_Cheat_Sheet.md
@@ -38,7 +38,7 @@ However, there are some situations where an attacker can "crack" the hashes in s
 - Calculating the hash
 - Comparing the hash you calculated to the hash of the victim. If they match, you have correctly "cracked" the hash and now know the plaintext value of their password.
 
-Usually, the attacker will repeat this process wth a list of large number of potential candidate passwords, such as:
+Usually, the attacker will repeat this process with a list of large number of potential candidate passwords, such as:
 
 - Lists of passwords obtained from other compromised sites
 - Brute force (trying every possible candidate)

--- a/cheatsheets/REST_Assessment_Cheat_Sheet.md
+++ b/cheatsheets/REST_Assessment_Cheat_Sheet.md
@@ -22,7 +22,7 @@ RESTful web services (often called simply REST) are a light weight variant of We
     - No application utilizes all the available functions and parameters exposed by the service
     - Those used are often activated dynamically by client side code and not as links in pages.
     - The client application is often not a web application and does not allow inspection of the activating link or even relevant code.
-- The parameters are none standard making it hard to determine what is just part of the URL or a constant header and what is a parameter worth [fuzzing](https://owasp.org/www-community/Fuzzing).
+- The parameters are non-standard making it hard to determine what is just part of the URL or a constant header and what is a parameter worth [fuzzing](https://owasp.org/www-community/Fuzzing).
 - As a machine interface the number of parameters used can be very large, for example a JSON structure may include dozens of parameters. [fuzzing](https://owasp.org/www-community/Fuzzing) each one significantly lengthen the time required for testing.
 - Custom authentication mechanisms require reverse engineering and make popular tools not useful as they cannot track a login session.
 

--- a/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md
@@ -112,7 +112,7 @@ Though stored procedures are not always safe from SQL injection, developers can 
 
 #### Safe Approach to Stored Procedures
 
-If stored procedures are needed, the safest approach to using them requires the developer to build SQL statements with parameters that are automatically parameterized, unless the developer does something largely out of the norm. The difference between prepared statements and stored procedures is that the SQL code for a stored procedure is defined and stored in the database itself, and then called from the application. Since prepared statements and safe stored procedures are equally effecitve in preventing SQL injection so your organization should choose which approach makes the most sense for you.
+If stored procedures are needed, the safest approach to using them requires the developer to build SQL statements with parameters that are automatically parameterized, unless the developer does something largely out of the norm. The difference between prepared statements and stored procedures is that the SQL code for a stored procedure is defined and stored in the database itself, and then called from the application. Since prepared statements and safe stored procedures are equally effective in preventing SQL injection so your organization should choose which approach makes the most sense for you.
 
 #### When Stored Procedures Can Increase Risk
 


### PR DESCRIPTION
- Change "none standard" to "non-standard"
- Change "wth" to "with"
- Change "effecitve" to "effective"
