### PR TITLE
Update Clickjacking_Defense_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/Clickjacking_Defense_Cheat_Sheet.md
+++ b/cheatsheets/Clickjacking_Defense_Cheat_Sheet.md
@@ -38,7 +38,6 @@ See the following documentation for further details and more complex examples:
 
 ### Limitations
 
-- **Browser support:** CSP frame-ancestors is not supported by all the major browsers yet.
 - **X-Frame-Options takes priority:** [Section "Relation to X-Frame-Options" of the CSP Spec](https://w3c.github.io/webappsec/specs/content-security-policy/#frame-ancestors-and-frame-options) says: "*If a resource is delivered with an policy that includes a directive named frame-ancestors and whose disposition is "enforce", then the X-Frame-Options header MUST be ignored*", but Chrome 40 & Firefox 35 ignore the frame-ancestors directive and follow the X-Frame-Options header instead.
 
 ### Browser Support


### PR DESCRIPTION
i've removed a reference that stated several browsers didn't support frame-ancestors.

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
