### PR TITLE
CI/CD Security Cheatsheet | fix typo "o" --> "of" && "enviornment" --> "environment"

### DIFF
--- a/cheatsheets/CI_CD_Security_Cheat_Sheet.md
+++ b/cheatsheets/CI_CD_Security_Cheat_Sheet.md
@@ -50,7 +50,7 @@ CI/CD environments allow for code to be pushed to a repository and then deployed
 
 ### Pipeline and Execution Enviornment
 
-In addition to SCM systems, it is imperative that the automation servers responsible for running the pipelines are also configured securely. Examples o these technologies include Travis, TeamCity, Jenkins, and CircleCI. While the exact hardening process will vary according to the specific platform used, some general best practices include:
+In addition to SCM systems, it is imperative that the automation servers responsible for running the pipelines are also configured securely. Examples of these technologies include Travis, TeamCity, Jenkins, and CircleCI. While the exact hardening process will vary according to the specific platform used, some general best practices include:
 
 - Perform builds in appropriately isolated nodes (see Jenkins example [here](https://www.jenkins.io/doc/book/security/controller-isolation/))
 - Ensure communication between the SCM and CI/CD platform is secured using widely accepted protocols such as TLS 1.2 or greater.


### PR DESCRIPTION
**Checklist:** 
- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

Basically just came across these two typos in the CI/CD security cheatsheet page. I scanned the rest of the page and couldn't find any further issues.

Cheers!
