### PR TITLE
Implement #1373: Document Relaxed `__Secure-` Cookie Prefix

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -292,8 +292,10 @@ Usually, a minor percentage of traffic does fall under above categories ([1-2%](
 
 #### Using Cookies with Host Prefixes to Identify Origins
 
-While the `SameSite` attribute guards against malicious actors *reading* cookies,
-they may still try to inject or overwrite otherwise secured cookies.
+While the `SameSite` and `Secure` attributes mentioned earlier restrict the sending of already set cookies
+and `HttpOnly` restricts the reading of a set cookie,
+an attacker may still try to inject or overwrite otherwise secured cookies
+(cf. [session fixation attacks](http://www.acrossecurity.com/papers/session_fixation.pdf)).
 Using `Cookie Prefixes` for cookies with CSRF tokens extends security protections against this kind of attacks as well.
 If cookies have `__Host-` prefixes e.g. `Set-Cookie: __Host-token=RANDOM; path=/; Secure` then each cookie:
 

--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -292,11 +292,26 @@ Usually, a minor percentage of traffic does fall under above categories ([1-2%](
 
 #### Using Cookies with Host Prefixes to Identify Origins
 
-Another solution for this problem is using `Cookie Prefixes` for cookies with CSRF tokens. If cookies have `__Host-` prefixes e.g. `Set-Cookie: __Host-token=RANDOM; path=/; Secure` then each cookie:
+While the `SameSite` attribute guards against malicious actors *reading* cookies,
+they may still try to inject or overwrite otherwise secured cookies.
+Using `Cookie Prefixes` for cookies with CSRF tokens extends security protections against this kind of attacks as well.
+If cookies have `__Host-` prefixes e.g. `Set-Cookie: __Host-token=RANDOM; path=/; Secure` then each cookie:
 
-- Cannot be (over)written from another subdomain.
+- Cannot be (over)written from another subdomain and
+- cannot have a `Domain` attribute.
 - Must have the path of `/`.
 - Must be marked as Secure (i.e, cannot be sent over unencrypted HTTP).
+
+In addition to the `__Host-` prefix, the weaker `__Secure-` prefix is also supported by browser vendors.
+It relaxes the restrictions on domain overwrites, i.e., they
+
+- Can have `Domain` attributes and
+- can be overwritten by subdomains.
+- Can have a `Path` other than `/`.
+
+This relaxed variant can be used as an alternative to the "domain locked" `__Host-` prefix,
+if authenticated users would need to visit different (sub-)domains.
+In all other cases, using the `__Host-` prefix in addition to the `SameSite` attribute is recommended.
 
 As of July 2020 cookie prefixes [are supported by all major browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Browser_compatibility).
 


### PR DESCRIPTION
Also clarifies what `__Host-` and prefixes in general intends to guard against, what kind of problems implementers may encounter and encourage usage together with `SameSite`.

---

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

This PR covers issue #1373.