### PR TITLE
FIX: Broken URL in REST_Assessment_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/REST_Assessment_Cheat_Sheet.md
+++ b/cheatsheets/REST_Assessment_Cheat_Sheet.md
@@ -65,4 +65,4 @@ Lastly, when [fuzzing](https://owasp.org/www-community/Fuzzing), don't forget to
 ## Related Resources
 
 - [REST Security Cheat Sheet](REST_Security_Cheat_Sheet.md) - the other side of this cheat sheet
-- [RESTful services, web security blind spot](https://xiom.com/2016/10/31/restful-services-web-security-blind-spot/) - a presentation (including video) elaborating on most of the topics on this cheat sheet.
+- [YouTube: RESTful services, web security blind spot](https://www.youtube.com/watch?v=pWq4qGLAZHI) - a video presentation elaborating on most of the topics on this cheat sheet.


### PR DESCRIPTION
Replaced broken URL with the youtube video that was referenced in the now deleted blog post over at xiom.com.

https://web.archive.org/web/20200806132321/https://xiom.com/2016/10/31/restful-services-web-security-blind-spot/

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #<insert number here>.

Thank you again for your contribution :smiley:
