### PR TITLE
Add additional events which we are removing from ASVS

### DIFF
--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -93,11 +93,22 @@ Where possible, always log:
 - Output validation failures e.g. database record set mismatch, invalid data encoding
 - Authentication successes and failures
 - Authorization (access control) failures
-- Session management failures e.g. cookie session identification value modification
+- Session management failures e.g. cookie session identification value modification or suspicious JWT validation failures
 - Application errors and system events e.g. syntax and runtime errors, connectivity problems, performance issues, third party service error messages, file system errors, file upload virus detection, configuration changes
 - Application and related systems start-ups and shut-downs, and logging initialization (starting, stopping or pausing)
-- Use of higher-risk functionality e.g. network connections, addition or deletion of users, changes to privileges, assigning users to tokens, adding or deleting tokens, use of systems administrative privileges, access by application administrators, all actions by users with administrative privileges, access to payment cardholder data, use of data encrypting keys, key changes, creation and deletion of system-level objects, data import and export including screen-based reports, submission of user-generated content - especially file uploads
+- Use of higher-risk functionality including:
+  - User administration actions such as addition or deletion of users, changes to privileges, assigning users to tokens, adding or deleting tokens
+  - Use of systems administrative privileges or access by application administrators including all actions by those users
+  - Access to sensitive data such as payment cardholder data,
+  - Encryption activities such as use or rotation of cryptographic keys
+  - Creation and deletion of system-level objects
+  - Data import and export including screen-based reports
+  - Submission and processing of user-generated content - especially file uploads
+  - Deserialization failures
+  - Network connections and associated failures such as backend TLS failures (including certificate validation failures), or requests with an unexpected HTTP verb
 - Legal and other opt-ins e.g. permissions for mobile phone capabilities, terms of use, terms & conditions, personal data usage consent, permission to receive marketing communications
+
+
 
 Optionally consider if the following events can be logged and whether it is desirable information:
 

--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -99,6 +99,7 @@ Where possible, always log:
 - Use of higher-risk functionality including:
     - User administration actions such as addition or deletion of users, changes to privileges, assigning users to tokens, adding or deleting tokens
     - Use of systems administrative privileges or access by application administrators including all actions by those users
+    - Use of default or shared accounts or a "break-glass" account.
     - Access to sensitive data such as payment cardholder data,
     - Encryption activities such as use or rotation of cryptographic keys
     - Creation and deletion of system-level objects

--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -107,6 +107,10 @@ Where possible, always log:
     - Deserialization failures
     - Network connections and associated failures such as backend TLS failures (including certificate validation failures), or requests with an unexpected HTTP verb
 - Legal and other opt-ins e.g. permissions for mobile phone capabilities, terms of use, terms & conditions, personal data usage consent, permission to receive marketing communications
+- Suspicous business logic activities such as:
+    - Attempts to perform a set actions out of order/bypass flow control
+    - Actions which don't make sense in the business context
+    - Attempts to exceed limitations for particular actions
 
 Optionally consider if the following events can be logged and whether it is desirable information:
 

--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -97,18 +97,16 @@ Where possible, always log:
 - Application errors and system events e.g. syntax and runtime errors, connectivity problems, performance issues, third party service error messages, file system errors, file upload virus detection, configuration changes
 - Application and related systems start-ups and shut-downs, and logging initialization (starting, stopping or pausing)
 - Use of higher-risk functionality including:
-  - User administration actions such as addition or deletion of users, changes to privileges, assigning users to tokens, adding or deleting tokens
-  - Use of systems administrative privileges or access by application administrators including all actions by those users
-  - Access to sensitive data such as payment cardholder data,
-  - Encryption activities such as use or rotation of cryptographic keys
-  - Creation and deletion of system-level objects
-  - Data import and export including screen-based reports
-  - Submission and processing of user-generated content - especially file uploads
-  - Deserialization failures
-  - Network connections and associated failures such as backend TLS failures (including certificate validation failures), or requests with an unexpected HTTP verb
+    - User administration actions such as addition or deletion of users, changes to privileges, assigning users to tokens, adding or deleting tokens
+    - Use of systems administrative privileges or access by application administrators including all actions by those users
+    - Access to sensitive data such as payment cardholder data,
+    - Encryption activities such as use or rotation of cryptographic keys
+    - Creation and deletion of system-level objects
+    - Data import and export including screen-based reports
+    - Submission and processing of user-generated content - especially file uploads
+    - Deserialization failures
+    - Network connections and associated failures such as backend TLS failures (including certificate validation failures), or requests with an unexpected HTTP verb
 - Legal and other opt-ins e.g. permissions for mobile phone capabilities, terms of use, terms & conditions, personal data usage consent, permission to receive marketing communications
-
-
 
 Optionally consider if the following events can be logged and whether it is desirable information:
 


### PR DESCRIPTION
We are looking to abstract out our logging requirements in ASVS. We want to make sure that the detail we are losing gets captured in this cheatsheet.

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series. 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [x] ~~In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).~~
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] ~~All your assets are stored in the **assets** folder.~~
- [x] ~~All the images used are in the **PNG** format.~~
- [ ] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

