### PR TITLE
Fix typo in Symfony Cheat Sheet

### DIFF
--- a/cheatsheets/Symfony_Cheat_Sheet.md
+++ b/cheatsheets/Symfony_Cheat_Sheet.md
@@ -392,7 +392,7 @@ composer require nelmio/cors-bundle
 For Symfony Flex users, the installation generates a basic configuration file in the `config/packages` directory automatically. Take a look at the example configuration for routes starting with */API* prefix.
 
 ```yaml
-# config/packages/nelimo_cors.yaml
+# config/packages/nelmio_cors.yaml
 nelmio_cors:
     defaults:
         origin_regex: true


### PR DESCRIPTION
Hi, I've fixed a typo in the Nelmio CORS Bundle configuration file name.