### PR TITLE
Fixing a wrong link to OpenCRE

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -104,7 +104,7 @@ hmac = hmac("SHA256", secret, message) // Generate the HMAC hash
 csrfToken = hmac + "." + message // Combine HMAC hash with message to generate the token. The plain message is required to later authenticate it against its HMAC hash
 
 // Store the CSRF Token in a cookie
-response.setCookie("csrf_token=" + csrfToken + "; Secure) // Set Cookie without HttpOnly flag
+response.setCookie("csrf_token=" + csrfToken + "; Secure") // Set Cookie without HttpOnly flag
 ```
 
 ### Naive Double-Submit Cookie Pattern (DISCOURAGED)


### PR DESCRIPTION
The current link to OpenCRE does a search for the word 'secret' leading to some wrong topics. It is better to link to the official CRE topic of secrets, which has a future-proof 6-digit ID.
Thanks,