### PR TITLE
Enhance Readability of Control Plane and Node Component Descriptions

### DIFF
--- a/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
+++ b/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
@@ -30,7 +30,7 @@ When you deploy Kubernetes, you get a cluster. A Kubernetes cluster consists of 
 The control plane's components make global decisions about the cluster, as well as detecting and responding to cluster events. It consists of components such as kube-apiserver, etcd, kube-scheduler, kube-controller-manager and cloud-controller-manager.
 
 **Component:** kube-apiserver  
-**Description**: Exposes the Kubernetes API. The API server is the front end for the Kubernetes control plane.
+**Description:** Exposes the Kubernetes API. The API server is the front end for the Kubernetes control plane.
 
 **Component:** etcd  
 **Description:** A consistent and highly-available key-value store used as Kubernetes' backing store for all cluster data.
@@ -380,16 +380,16 @@ When you are configuring the security context for your pods, only grant the priv
 
 Security Context Settings:
 
-1. SecurityContext->runAsNonRoot
+1. Security Context Setting: SecurityContext->**runAsNonRoot**  
    Description: Indicates that containers should run as non-root user.
 
-2. Security Context Setting: SecurityContext->Capabilities
+2. Security Context Setting: SecurityContext->**Capabilities**  
    Description: Controls the Linux capabilities assigned to the container.
 
-3. Security Context Setting: SecurityContext->readOnlyRootFilesystem
+3. Security Context Setting: SecurityContext->**readOnlyRootFilesystem**  
    Description: Controls whether a container will be able to write into the root filesystem.
 
-4. Security Context Setting: PodSecurityContext->runAsNonRoot
+4. Security Context Setting: PodSecurityContext->**runAsNonRoot**  
    Description: Prevents running a container with 'root' user as part of the pod |
 
 #### Security context example: A pod definition that includes security context parameters

--- a/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
+++ b/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
@@ -29,20 +29,20 @@ When you deploy Kubernetes, you get a cluster. A Kubernetes cluster consists of 
 
 The control plane's components make global decisions about the cluster, as well as detecting and responding to cluster events. It consists of components such as kube-apiserver, etcd, kube-scheduler, kube-controller-manager and cloud-controller-manager.
 
-Component: kube-apiserver
-Description: Exposes the Kubernetes API. The API server is the front end for the Kubernetes control plane.
+**Component:** kube-apiserver  
+**Description**: Exposes the Kubernetes API. The API server is the front end for the Kubernetes control plane.
 
-Component: etcd
-Description: A consistent and highly-available key-value store used as Kubernetes' backing store for all cluster data.
+**Componen:** etcd  
+**Description:** A consistent and highly-available key-value store used as Kubernetes' backing store for all cluster data.
 
-Component: kube-scheduler
-Description: Watches for newly created Pods with no assigned node, and selects a node for them to run on.
+**Component:** kube-scheduler  
+**Description:** Watches for newly created Pods with no assigned node, and selects a node for them to run on.
 
-Component: kube-controller-manager
-Description: Runs controller processes. Logically, each controller is a separate process, but to reduce complexity, they are all compiled into a single binary and run in a single process.
+**Component:** kube-controller-manager  
+**Description:** Runs controller processes. Logically, each controller is a separate process, but to reduce complexity, they are all compiled into a single binary and run in a single process.
 
-Component: cloud-controller-manager
-Description: The cloud controller manager lets you link your cluster into your cloud provider's API, and separates out the components that interact with that cloud platform from components that just interact with your cluster.
+**Component:** cloud-controller-manager  
+**Description:** The cloud controller manager lets you link your cluster into your cloud provider's API, and separates out the components that interact with that cloud platform from components that just interact with your cluster.
 
 ### Node Components
 

--- a/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
+++ b/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
@@ -48,14 +48,14 @@ The control plane's components make global decisions about the cluster, as well 
 
 Node components run on every node, maintaining running pods and providing the Kubernetes runtime environment. It consists of components such as kubelet, kube-proxy and container runtime.
 
-Component: kubelet
-Description: An agent that runs on each node in the cluster. It makes sure that containers are running in a Pod.
+**Component:** kubelet  
+**Description:** An agent that runs on each node in the cluster. It makes sure that containers are running in a Pod.
 
-Component: kube-proxy
-Description: A network proxy that runs on each node in your cluster, implementing part of the Kubernetes Service concept.
+**Component:** kube-proxy  
+**Description:** A network proxy that runs on each node in your cluster, implementing part of the Kubernetes Service concept.
 
-Container: runtime
-Description: The container runtime is the software that is responsible for running containers |
+**Container:** runtime  
+**Description:** The container runtime is the software that is responsible for running containers |
 
 ## SECTION 1: Securing Kubernetes Hosts
 

--- a/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
+++ b/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
@@ -380,16 +380,16 @@ When you are configuring the security context for your pods, only grant the priv
 
 Security Context Settings:
 
-1. Security Context Setting: SecurityContext->**runAsNonRoot**  
+1. SecurityContext->**runAsNonRoot**  
    Description: Indicates that containers should run as non-root user.
 
-2. Security Context Setting: SecurityContext->**Capabilities**  
+2. SecurityContext->**Capabilities**  
    Description: Controls the Linux capabilities assigned to the container.
 
-3. Security Context Setting: SecurityContext->**readOnlyRootFilesystem**  
+3. SecurityContext->**readOnlyRootFilesystem**  
    Description: Controls whether a container will be able to write into the root filesystem.
 
-4. Security Context Setting: PodSecurityContext->**runAsNonRoot**  
+4. PodSecurityContext->**runAsNonRoot**  
    Description: Prevents running a container with 'root' user as part of the pod |
 
 #### Security context example: A pod definition that includes security context parameters
@@ -544,7 +544,7 @@ While users of Google Cloud Platform can benefit from automatic firewall rules, 
 The following is an example of a network policy that controls the network for “backend” pods, which only allows inbound network access from “frontend” pods:
 
 ```json
-POST /apis/net.alpha.kubernetes.io/v1alpha1/namespaces/tenant-a/networkpolicys
+POST /apis/net.alpha.kubernetes.io/v1alpha1/namespaces/tenant-a/networkpolicies
 {
   "kind": "NetworkPolicy",
   "metadata": {

--- a/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
+++ b/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
@@ -32,7 +32,7 @@ The control plane's components make global decisions about the cluster, as well 
 **Component:** kube-apiserver  
 **Description**: Exposes the Kubernetes API. The API server is the front end for the Kubernetes control plane.
 
-**Componen:** etcd  
+**Component:** etcd  
 **Description:** A consistent and highly-available key-value store used as Kubernetes' backing store for all cluster data.
 
 **Component:** kube-scheduler  

--- a/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
+++ b/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
@@ -544,7 +544,7 @@ While users of Google Cloud Platform can benefit from automatic firewall rules, 
 The following is an example of a network policy that controls the network for “backend” pods, which only allows inbound network access from “frontend” pods:
 
 ```json
-POST /apis/net.alpha.kubernetes.io/v1alpha1/namespaces/tenant-a/networkpolicies
+POST /apis/net.alpha.kubernetes.io/v1alpha1/namespaces/tenant-a/networkpolicys
 {
   "kind": "NetworkPolicy",
   "metadata": {


### PR DESCRIPTION
This pull request aims to improve the readability of the descriptions for control plane and node components in the Kubernetes Cheat Sheet. The following changes have been made:

* Added a new line between the component name and its description for better separation and clarity.
* Made component and description bold to highlight them distinctly from the key-value pairs.