### PR TITLE
Update PR template to close linked issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,6 @@ Please make sure that for your contribution:
 
 If your PR is related to an issue, please finish your PR text with the following line:
 
-This PR covers issue #`<REPLACE WITH ISSUE NUMBER>`.
+This PR fixes issue #`<REPLACE WITH ISSUE NUMBER>`.
 
 Thank you again for your contribution :smiley:


### PR DESCRIPTION
I've noticed a large number of open issues where PRs were merged that resolved them but the original issues have remained open. It appears that this can be solved using [keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) if we simply change the text of the PR to say "fixes" or "resolves" instead of just "covers".