### PR TITLE
fixed docker cheat sheet typo "simple" changed to "simply"

### DIFF
--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -38,7 +38,7 @@ Configuring the container to use an unprivileged user is the best way to prevent
 docker run -u 4000 alpine
 ```
 
-2. During build time. Simple add user in Dockerfile and use it. For example:
+2. During build time. Simply add user in Dockerfile and use it. For example:
 
 ```dockerfile
 FROM alpine


### PR DESCRIPTION
# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.
*I was only able to find one typo in the cheatsheet

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #`<No specific issue number, I just found a typo.>`.

Thank you again for your contribution :smiley:
