### PR TITLE
Fix inconsistent indentation in `.textlintrc`

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,22 +1,22 @@
 {
-    "filters": {
-        "comments": true,
-        "whitelist": {
-            "allow": [
-                "XSL stylesheet",
-                "OS X 10.9",
-                "Argon2**id**",
-                "Network IDS"
-            ]
-        }
-    },
+	"filters": {
+		"comments": true,
+		"whitelist": {
+			"allow": [
+				"XSL stylesheet",
+				"OS X 10.9",
+				"Argon2**id**",
+				"Network IDS"
+			]
+		}
+	},
 	"rules": {
 		"terminology": {
 			// Load default terms (see terms.json in the repository)
 			"defaultTerms": false,
 			// Syntax elements to skip. Overrides the default
 			"skip": [
-                "Link",
+				"Link",
 				"Blockquote"
 			],
 			// List of terms
@@ -125,10 +125,10 @@
 					"wi[- ]?fi",
 					"Wi-Fi"
 				],
-                [
-                    "CVE['’]?s",
-                    "CVEs"
-                ],
+				[
+						"CVE['’]?s",
+						"CVEs"
+				],
 
 				// Words and phrases
 				"ID",


### PR DESCRIPTION
In `.textlintrc`, there was a mix of tabs and spaces for indentation. I did not find a project level code style for indentation at this time, so since most of the lines in the file were tabs I converted the handful of lines that used spaces to tabs.


# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR covers issue #`<REPLACE WITH ISSUE NUMBER>`.

Thank you again for your contribution :smiley:
