### PR TITLE
Update XSS_Filter_Evasion_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md
+++ b/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md
@@ -58,7 +58,7 @@ This XSS method uses the relaxed rendering engine to create an XSS vector within
 If the system does not allow quotes of any kind, you can `eval()` a `fromCharCode` in JavaScript to create any XSS vector you need:
 
 ```html
-<a href="javascript:alert(String,fromCharCode(88,83,83))">Click Me!</a>
+<a href="javascript:alert(String.fromCharCode(88,83,83))">Click Me!</a>
 ```
 
 ### Default SRC Tag to Get Past Filters that Check SRC Domain


### PR DESCRIPTION
Should be a dot instead of a comma

# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [X] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [X] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [X] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [X] All your assets are stored in the **assets** folder.
- [X] All the images used are in the **PNG** format.
- [X] Any references to websites have been formatted as `[TEXT](URL)`
- [X] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective 
