### PR TITLE
Improve Log4j configuration examples

### DIFF
--- a/cheatsheets/Java_Security_Cheat_Sheet.md
+++ b/cheatsheets/Java_Security_Cheat_Sheet.md
@@ -462,21 +462,31 @@ for more information.
 
 #### Example using Logback
 
-The recommended logging policy for a production environment is sending logs to a network socket using the structured
+The recommended logging policy for a production environment is using the structured
 [JsonEncoder](https://logback.qos.ch/manual/encoders.html#JsonEncoder)
 introduced in
-[Logback 1.3.8](https://logback.qos.ch/news.html#1.3.8):
+[Logback 1.3.8](https://logback.qos.ch/news.html#1.3.8).
+In the example below, Logback is configured to roll on 10 log files of 5 MiB each:
 
 ``` xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE configuration>
 <configuration>
   <import class="ch.qos.logback.classic.encoder.JsonEncoder"/>
-  <import class="ch.qos.logback.classic.net.SocketAppender"/>
+  <import class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy"/>
+  <import class="ch.qos.logback.core.rolling.RollingFileAppender"/>
+  <import class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy"/>
 
-  <appender name="SOCKET" class="SocketAppender">
-    <remoteHost>localhost</remoteHost>
-    <port>12345</port>
+  <appender name="RollingFile" class="RollingFileAppender">
+    <file>app.log</file>
+    <rollingPolicy class="FixedWindowRollingPolicy">
+      <fileNamePattern>app-%i.log</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>10</maxIndex>
+    </rollingPolicy>
+    <triggeringPolicy class="SizeBasedTriggeringPolicy">
+      <maxFileSize>5MB</maxFileSize>
+    </triggeringPolicy>
     <encoder class="JsonEncoder"/>
   </appender>
 


### PR DESCRIPTION
The current Log4j 2 configuration examples misses some sources of `CRLF` injection:

- the message of an exception might contain line feeds: the [`%xEx` converter pattern](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html#converter-exception-extended) is implicitly added unless [`alwaysWriteExceptions`](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html#plugin-attr-alwaysWriteExceptions) is set to `false`.
- the name of a [custom level](https://logging.apache.org/log4j/2.x/manual/customloglevels.html#DefiningLevelsInCode) can also contain line feeds.

In general every part of a log event, with the exclusion of the timestamp, is susceptible to `CRLF` injection: thread names, logger names, etc. While it is very unlikely that a logger name will contain user data, it is a possibility that should not be excluded.

This PR modifies the Log4j examples in the cheat sheet by:

1. Adding an example of [JSON Template Layout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html) usage. Since this is a [structured layout](https://logging.apache.org/log4j/2.x/manual/layouts.html#structured-logging), it prevents `CRLF` injection out of the box.
2. Modifying the Pattern Layout example to encode the **entire** log event, not just the log message. This makes the log events less readable by humans, but guarantees that each log event is on a **single** line.