### PR TITLE
Fix typo in REST_Security_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/REST_Security_Cheat_Sheet.md
+++ b/cheatsheets/REST_Security_Cheat_Sheet.md
@@ -176,7 +176,7 @@ RESTful web services should be careful to prevent leaking credentials. Passwords
 
 **NOT OK:**
 
-`https://example.com/controller/123/action?apiKey=a53f435643de32` because API Key is into the URL.
+`https://example.com/controller/123/action?apiKey=a53f435643de32` because API Key is in the URL.
 
 ## HTTP Return Code
 

--- a/cheatsheets/REST_Security_Cheat_Sheet.md
+++ b/cheatsheets/REST_Security_Cheat_Sheet.md
@@ -176,7 +176,7 @@ RESTful web services should be careful to prevent leaking credentials. Passwords
 
 **NOT OK:**
 
-`https://example.com/controller/123/action?apiKey=a53f435643de32` because API Key is in the URL.
+`https://example.com/controller/123/action?apiKey=a53f435643de32` because the apiKey is in the URL.
 
 ## HTTP Return Code
 


### PR DESCRIPTION

- [X] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [X] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [X] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [X] All your assets are stored in the **assets** folder.
- [X] All the images used are in the **PNG** format.
- [X] Any references to websites have been formatted as `[TEXT](URL)`
- [X] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [X] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).
