### PR TITLE
CI: Update Actions

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         node-version: 20.x
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install Python dependencies

--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build offline website
-    runs-on: ubuntu-20.04 #ubuntu-latest ubuntu latest have some bug, we need to use older one 
+    runs-on: ubuntu-24.04
     env:
       CI: true
       WORKFLOW_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
@@ -16,11 +16,11 @@ jobs:
     - name: Setup Action
       uses: actions/checkout@v4
     - name: Setup Node
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v4
       with:
-        node-version: 12.x
+        node-version: 20.x
     - name: Setup Python
-      uses: actions/setup-python@v2.2.1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install Python dependencies

--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
     - name: Setup Action
       uses: actions/checkout@v4
-    - name: Setup Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.x
     - name: SetUp python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Identify old issues and PR
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CI: true
     steps:
@@ -16,9 +16,9 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 12.x
+        node-version: 20.x
     - name: SetUp python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install python dependencies

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   link-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CI: true
     steps:
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 12.x
+        node-version: 20.x
     - name: Install dependencies
       run: npm install
     - name: Run link check

--- a/.github/workflows/md_lint_check.yml
+++ b/.github/workflows/md_lint_check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CI: true
     steps:
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 12.x
+        node-version: 20.x
     - name: Install dependencies
       run: npm install
     - name: Run linter

--- a/.github/workflows/publishing-check.yml
+++ b/.github/workflows/publishing-check.yml
@@ -5,16 +5,16 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build website
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CI: true
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install Python dependencies
         run: make install-python-requirements
       - name: Build website


### PR DESCRIPTION
- [x] The CI build of your PR pass, see the build status [here](https://github.com/tinyboxvk/CheatSheetSeries/actions).

- Bump Ubuntu runner to the latest LTS version 24.04
- Bump Nodejs to the latest LTS version 20 
  - Nodejs 12 EOL over 2 years ago
- Bump actions/setup-node to v4
  - Resolves GH actions nodejs deprecation warnings
- Bump actions/setup-python to v5
  - Resolves GH actions nodejs deprecation warnings
- Remove `Setup Node` from `identify-old-issues-and-pr.yml`
  - It's not required
