### PR TITLE
docs(django): Remove unsupported setting

### DIFF
--- a/cheatsheets/Django_Security_Cheat_Sheet.md
+++ b/cheatsheets/Django_Security_Cheat_Sheet.md
@@ -114,12 +114,11 @@ The `SECRET_KEY` parameter in settings.py is used for cryptographic signing and 
 Include the `django.middleware.security.SecurityMiddleware` module in the `MIDDLEWARE` setting in your project's `settings.py` to add security-related headers to your responses. This module is used to set the following parameters:
 
 - `SECURE_CONTENT_TYPE_NOSNIFF`: Set this key to `True`. Protects against MIME type sniffing attacks by enabling the header `X-Content-Type-Options: nosniff`.
-- `SECURE_BROWSER_XSS_FILTER`: Set this key to `True`. Enables the browser’s XSS filter by setting the header `X-XSS-Protection: 1; mode=block`.
 - `SECURE_HSTS_SECONDS`: Ensures the site is only accessible via HTTPS.
 
 Include the `django.middleware.clickjacking.XFrameOptionsMiddleware` module in the `MIDDLEWARE` setting in your project's `settings.py` (This module should be listed after the `django.middleware.security.SecurityMiddleware` module as ordering is important). This module is used to set the following parameters:
 
-- `X_FRAME_OPTIONS`: Set this key to to 'DENY' or 'SAMEORIGIN'. This setting adds the `X-Frame-Options` header to all HTTP responses. This protects against clickjacking attacks.
+- `X_FRAME_OPTIONS`: Set this key to 'DENY' or 'SAMEORIGIN'. This setting adds the `X-Frame-Options` header to all HTTP responses. This protects against clickjacking attacks.
 
 ## Cookies
 


### PR DESCRIPTION
## Description
This PR introduces a patch to the [Django CheatSheet Series](https://cheatsheetseries.owasp.org/cheatsheets/Django_Security_Cheat_Sheet.html) to remove the header setting, `SECURE_BROWSER_XSS_FILTER`. This security setting is no longer set by Django's `SecurityMiddleware` from `v4.0` (see release [notes](https://docs.djangoproject.com/en/4.2/releases/4.0/#securitymiddleware-no-longer-sets-the-x-xss-protection-header)).

Given the latest two Django LTS releases, `4.2` and `5.2` do not support `SECURE_BROWSER_XSS_FILTER` and MDN considers it _non-standard_ and _deprecated_ for modern browsers, the feature has been excluded from the cheat sheet.

> ⚠ MDN additionally warns against known vulnerabilities exposed to sites using `X-XSS-Protection` in certain contexts.

### Decisions
> This section outlines notable considerations for maintainers/contributors.

The alternative to `X-XSS-Protection` is `Content-Security-Policy`. In contrast, it has modern browser support and is the recommended feature to guard against [cross-site scripting](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting) attacks.

The following recommendations can be made to include `CSP` in the Django Cheat Sheet:

- **Define a `CSP` setting in the [Headers](https://cheatsheetseries.owasp.org/cheatsheets/Django_Security_Cheat_Sheet.html#headers) section, effectively replacing `SECURE_BROWSER_XSS_FILTER`**

```
# Tell browser, by default, to load resources only from the current domain.
CONTENT_SECURITY_POLICY = {
    "DIRECTIVES": {
        "default-src": [SELF],
        # ...
    },
}
```

> ℹ This is not as trivial given that Django doesn't have built-in CSP support. Therefore, third-party package [`django-csp`](https://django-csp.readthedocs.io/en/latest/index.html) by Mozilla must be installed and set up.

- **Update the [Cross Site Scripting (XSS)](https://cheatsheetseries.owasp.org/cheatsheets/Django_Security_Cheat_Sheet.html#cross-site-scripting-xss) section to reflect this change**

> "The recommendations in this section are in addition to XSS recommendations already mentioned previously."

The above note refers to the previous recommendations in the Cheat Sheet's **Headers** section to use unsupported `SECURE_BROWSER_XSS_FILTER`. This should be updated to reference `Content-Security-Policy`.

I'm happy to follow up with these additional changes given a maintainer's go-ahead.

## Resources
- MDN `X-XSS-Protection` [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
- MDN `Content-Security-Policy` [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
- GitHub [repository](https://github.com/mozilla/django-csp) for `django-csp`
- Offical [docs](https://django-csp.readthedocs.io/en/latest/index.html) for `django-csp`
- Getting Started [guide](https://www.laac.dev/blog/content-security-policy-using-django/) on `django-csp` by Steven Pate

## Additional
Please make sure that for your contribution:
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., is the defensive code proposed really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).