### PR TITLE
Add HMAC validation pseudocode.

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -107,11 +107,11 @@ csrfToken = hmac + "." + randomValue // Add the `randomValue` to the HMAC hash t
 response.setCookie("csrf_token=" + csrfToken + "; Secure") // Set Cookie without HttpOnly flag
 ```
 
-And the following code demonstrates validation of the CSRF token that is sent back from the client:
+Below is an example in psuedo-code that demonstrates validation of the CSRF token once it is sent back from the client:
 
 ```code
 // Get the CSRF token from the request
-csrfToken = request.getParameter("csrf_token") // From form field or header
+csrfToken = request.getParameter("csrf_token") // From form field, cookie, or header
 
 // Split the token to get the randomValue
 const tokenParts = csrfToken.split(".");

--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -114,7 +114,9 @@ And the following code demonstrates validation of the CSRF token that is sent ba
 csrfToken = request.getParameter("csrf_token") // From form field or header
 
 // Split the token to get the randomValue
-const [hmacFromRequest, randomValue] = csrfToken.split(".");
+const tokenParts = csrfToken.split(".");
+const hmacFromRequest = tokenParts[0];
+const randomValue = tokenParts[1];
 
 // Recreate the HMAC with the current session and the randomValue from the request
 secret = readEnvironmentVariable("CSRF_SECRET") // HMAC secret key


### PR DESCRIPTION
I thought the "Pseudo-Code For Implementing HMAC CSRF Tokens" section could use an example of how to validate the CSRF token once returned by the client to the server. This PR adds the pseudocode for that.

Checklist:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).
