### PR TITLE
Fix incorrect use of false positives/negatives in Cookie Theft Mitigation (Fixes #1631)

### DIFF
--- a/cheatsheets/Cookie_Theft_Mitigation_Cheat_Sheet.md
+++ b/cheatsheets/Cookie_Theft_Mitigation_Cheat_Sheet.md
@@ -29,9 +29,9 @@ Of course, it is difficult to make a judgment based on simple comparison alone. 
 
 Suppose that a session cookie that has been granted access in a certain country is used from another country. This could be an attack, or it could simply be that the user has traveled.
 
-In other words, it is not possible to say with certainty that it is an attack just because the IP-Geo has changed. This means that there are **False Negatives** (it seems to be an attack, but it is not) in this detection method.
+In other words, it is not possible to say with certainty that it is an attack just because the IP-Geo has changed. This means that there are **False Positives** (it seems to be an attack, but it is not) in this detection method.
 
-At the same time, even if the IP-Geo does not change, there is also the possibility that the attacker is attacking from within the same country. This means that this detection method has a **False positives** (it seems not to be an attack, but it is).
+At the same time, even if the IP-Geo does not change, there is also the possibility that the attacker is attacking from within the same country. This means that this detection method has a **False Negatives** (it seems not to be an attack, but it is).
 
 ### Cookie Theft Detection
 


### PR DESCRIPTION
This PR addresses a factual inconsistency in the Cookie Theft Mitigation Cheat Sheet, where the terms "False Positives" and "False Negatives" were incorrectly used in reversed contexts. The changes correct the logic to align with standard cybersecurity definitions, improving both accuracy and clarity for readers.

These corrections are limited, non-invasive, and focused on editorial accuracy as outlined in [Issue #1631](https://github.com/OWASP/CheatSheetSeries/issues/1631).

Looking forward to your review. Thanks for maintaining such a great resource!

 **Checklist for OWASP PRs**
# Forked the repository

# Created a feature branch

# Made a focused, clearly scoped change

 #Commit message is clear and descriptive

 #PR title includes the issue number in this format: Fixes #1631

 #Description explains the change and its purpose

 #Spelling/grammar is accurate

 #No extra formatting or markdown issues introduced

