### PR TITLE
Update recommendation about safe strings in Django templates

### DIFF
--- a/cheatsheets/Django_Security_Cheat_Sheet.md
+++ b/cheatsheets/Django_Security_Cheat_Sheet.md
@@ -151,7 +151,8 @@ Include the `django.middleware.clickjacking.XFrameOptionsMiddleware` module in t
 The recommendations in this section are in addition to XSS recommendations already mentioned previously.
 
 - Use the built-in template system to render templates in Django. Refer to Django's [Automatic HTML escaping](https://docs.djangoproject.com/en/3.2/ref/templates/language/#automatic-html-escaping) documentation to learn more.
-- Avoid using the `safe` filter (or `mark_safe` function) for disabling Django's automatic template escaping. Use the [`json_script`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#json-script) template filter for passing data to JavaScript in Django templates.
+- Try to avoid using the `safe` filter (or `mark_safe` function) to disable Django's automatic template escaping. If you do need to use it, make sure the input is from a trusted source. Extra caution is required when handling user-controlled inputs.
+- Use the [`json_script`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#json-script) template filter for passing data to JavaScript in Django templates.
 - Refer to Django's [Cross Site Scripting (XSS) protection](https://docs.djangoproject.com/en/3.2/topics/security/#cross-site-scripting-xss-protection) documentation to learn more.
 
 ## HTTPS

--- a/cheatsheets/Django_Security_Cheat_Sheet.md
+++ b/cheatsheets/Django_Security_Cheat_Sheet.md
@@ -151,7 +151,7 @@ Include the `django.middleware.clickjacking.XFrameOptionsMiddleware` module in t
 The recommendations in this section are in addition to XSS recommendations already mentioned previously.
 
 - Use the built-in template system to render templates in Django. Refer to Django's [Automatic HTML escaping](https://docs.djangoproject.com/en/3.2/ref/templates/language/#automatic-html-escaping) documentation to learn more.
-- Avoid using `safe`, `mark_safe`, or `json_script` filters for disabling Django's automatic template escaping. The equivalent function in Python is the `make_safe()` function. Refer to the [json_script](https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#json-script0) template filter documentation to learn more.
+- Avoid using the `safe` filter (or `mark_safe` function) for disabling Django's automatic template escaping. Use the [`json_script`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#json-script) template filter for passing data to JavaScript in Django templates.
 - Refer to Django's [Cross Site Scripting (XSS) protection](https://docs.djangoproject.com/en/3.2/topics/security/#cross-site-scripting-xss-protection) documentation to learn more.
 
 ## HTTPS


### PR DESCRIPTION
The function [`mark_safe`](https://docs.djangoproject.com/en/5.2/ref/utils/#django.utils.safestring.mark_safe) is not a template filter. It's a utility function which marks a string as safe. But it was highlighted as a filter.

Previous suggestions had recommended not using `json_script`, but I think it's actually a good idea to recommend using this filter for passing data to JavaScript, precisely because it helps prevent XSS attacks.

According to the Django's documentation of json_script ([link](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#json-script)): 

> Safely outputs a Python object as JSON, wrapped in a <script> tag, ready for use with JavaScript.

So it's a safe way for passing data to JavaScript in Django templates and effectively mitigates XSS if used properly.