### PR TITLE
add recommendations on hardware backed security & attestation checks

### DIFF
--- a/cheatsheets/Mobile_Application_Security_Cheat_Sheet.md
+++ b/cheatsheets/Mobile_Application_Security_Cheat_Sheet.md
@@ -61,7 +61,7 @@ from the OWASP Mobile Top 10.
 
 - Perform authentication/authorization server-side and only load data on
 the device after successful authentication.
-- If storing data locally, encrypt it using a key derived from the user’s
+- If storing data locally, encrypt it using a key derived from the user's
 login credentials.
 - Do not store user passwords on the device; use device-specific tokens
 that can be revoked.
@@ -117,6 +117,9 @@ Keychain (iOS) or Keystore (Android).
 - Store private data on the device's internal storage.
 - Use platform APIs for encryption. Do not attempt to implement your own
   encryption algorithms.
+- Leverage hardware-based security features when available (e.g., Secure Enclave on iOS,
+  Strongbox on Android) for key storage and cryptographic operations
+  whenever available.
 
 ### 2. Data Leakage
 
@@ -204,6 +207,11 @@ examples of data that should not be logged.
 - Disable debugging.
 - Include code to validate integrity of application code.
 - Obfuscate the app binary.
+- Implement runtime anti-tampering controls:
+  - Check for signs of debugging, hooking, or code injection.
+  - Detect if the app is running in an emulator or rooted/jailbroken device.
+  - Verify app signatures at runtime.
+  - Apply appropriate responses to detected tampering (e.g., limiting functionality).
 
 ## Testing
 
@@ -248,11 +256,28 @@ examples of data that should not be logged.
 
 ### Android
 
-- Use Android’s ProGuard for code obfuscation.
+- Use Android's ProGuard for code obfuscation.
 - Avoid storing sensitive data in SharedPreferences. See the
   [Android docs](https://developer.android.com/topic/security/data)
   on working with data securely for more details.
 - Disable backup mode to prevent sensitive data being stored in backups.
+
+- Use Android Keystore with hardware backing (TEE or StrongBox) to securely store
+  cryptographic keys.
+  - **How**: Generate keys with hardware backing by specifying
+    `.setIsStrongBoxBacked(true)` in `KeyGenParameterSpec.Builder` when available (Android 9+).
+  - Verify hardware-backed storage via `KeyInfo.isInsideSecureHardware()`.
+  - Fall back to regular hardware-backed keystore if Strongbox isn't available.
+  - Configure key usage restrictions with `.setUserAuthenticationRequired(true)`
+    for sensitive operations.
+  - See [Hardware-backed Keystore documentation](https://developer.android.com/training/articles/keystore).
+
+- Implement Google's [Play Integrity API](https://developer.android.com/google/play/integrity) for device and app integrity checks.
+  - **How**: Obtain an integrity verdict from the device, validate server-side,
+    and take action if integrity checks fail.
+  - The SafetyNet Attestation API was was fully turned down in January 2025. All
+    developers must migrate to Play Integrity API.
+  - See [Play Integrity API documentation](https://developer.android.com/google/play/integrity/overview).
 
 ### iOS and iPadOS
 
@@ -345,6 +370,34 @@ between app and widgets.
 - Use ATS (App Transport Security) to enforce strong security policies for
 network communication.
 - Do not store sensitive data in `plist` files.
+
+- Use Apple's Secure Enclave for secure cryptographic key storage and
+  sensitive operations.
+  - **How**: Create keys using `SecKeyCreateRandomKey` with `kSecAttrTokenID`
+    set to `kSecAttrTokenIDSecureEnclave`.
+  - Keys created in the Secure Enclave never leave the secure hardware -
+    only the operations using those keys are performed there.
+  - For biometric operations, use `LAContext` with `evaluatePolicy` to
+    perform authentication directly through the Secure Enclave without
+    exposing biometric data to your application.
+  - Consider access control options like `kSecAccessControlBiometryAny` or
+    `kSecAccessControlUserPresence` to require user authentication before
+    key usage.
+  - See [Secure Enclave documentation](https://support.apple.com/guide/security/secure-enclave-sec59b0b31ff/web).
+
+- Use Apple's [App Attest API](https://developer.apple.com/documentation/devicecheck/establishing_your_app_s_integrity) (iOS 14+) to validate app integrity.
+  - **How**: Generate attestation keys and assertions with `DCAppAttestService`
+    and verify assertions server-side.
+  - Complement with Apple's [DeviceCheck API](https://developer.apple.com/documentation/devicecheck) for persistent device state tracking.
+  - See [App Attest documentation](https://developer.apple.com/documentation/devicecheck/dcappattestservice).
+
+## Advanced Hardware Security & Monitoring
+
+- Modern devices typically provide Trusted Execution Environments (TEE) or
+  secure hardware modules. Leverage these through standard OS APIs.
+- Consider additional runtime security measures (behavioral anomaly
+  detection, runtime monitoring) to complement built-in OS protections
+  in higher-risk scenarios.
 
 For further reading, visit the
 [OWASP Mobile Top 10 Project](https://owasp.org/www-project-mobile-top-10/).


### PR DESCRIPTION
This PR adds information about how to use hardware security features in both Android and iOS apps. These features help protect sensitive data better than software-only solutions.

References

- [Android Hardware-backed Keystore](https://developer.android.com/privacy-and-security/keystore)
- [Play Integrity API](https://developer.android.com/google/play/integrity)
- [Apple Secure Enclave](https://support.apple.com/guide/security/secure-enclave-sec59b0b31ff/web)
- [App Attest API](https://developer.apple.com/documentation/devicecheck/establishing-your-app-s-integrity)