### PR TITLE
Enhance SAXBuilder's XXE fix by disabling external DTDs

### DIFF
--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -408,6 +408,7 @@ Alternatively, if DTDs can't be completely disabled, disable external entities a
 SAXBuilder builder = new SAXBuilder();
 builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
 builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 builder.setExpandEntities(false);
 Document doc = builder.build(new File(fileName));
 ```


### PR DESCRIPTION
Problem
The current fix for preventing XXE vulnerabilities in SAXBuilder only disables external entities. However, ​external DTDs remain enabled, leaving a potential security risk for SSRF attacks through DTD resolution.

![image](https://github.com/user-attachments/assets/85bb0ff4-f1bc-464d-9480-9f8d8918db6d)
