### PR TITLE
Fix typo in XSS cheatsheet

### DIFF
--- a/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md
@@ -215,7 +215,7 @@ Context: HTML Body
 Code: `<span>UNTRUSTED DATA </span>`
 Sample Defense: HTML Entity Encoding (rule \#1)
 
-Data Type: Strong
+Data Type: String
 Context: Safe HTML Attributes
 Code: `<input type="text" name="fname" value="UNTRUSTED DATA ">`
 Sample Defense: Aggressive HTML Entity Encoding (rule \#2), Only place untrusted data into a list of safe attributes (listed below), Strictly validate unsafe attributes such as background, ID and name.


### PR DESCRIPTION
- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).
