### PR TITLE
Fix: Converted hardcoded GitHub links to relative paths (#1703)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.
 
 Please make sure that for your contribution:
 
-- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](https://github.com/OWASP/CheatSheetSeries/blob/master/templates/New_CheatSheet.md).
+- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
 - [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
-- [ ] All the markdown files follow these [format rules](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md#markdown).
+- [ ] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
 - [ ] All your assets are stored in the **assets** folder.
 - [ ] All the images used are in the **PNG** format.
 - [ ] Any references to websites have been formatted as `[TEXT](URL)`

--- a/Preface.md
+++ b/Preface.md
@@ -24,5 +24,5 @@ Project links:
 
 - [Homepage](https://owasp.org/www-project-cheat-sheets/)
 - [GitHub repository](https://github.com/OWASP/CheatSheetSeries)
-- [How to contribute?](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md)
+- [How to contribute?](CONTRIBUTING.md)
 - [Logo](https://github.com/OWASP/owasp-swag/tree/master/projects/cheat-sheet-series)

--- a/cheatsheets/Microservices_Security_Cheat_Sheet.md
+++ b/cheatsheets/Microservices_Security_Cheat_Sheet.md
@@ -171,7 +171,7 @@ High-level recommendations to logging subsystem architecture with its rationales
 For a comprehensive overview of events that should be logged and possible data format, please see the [OWASP Logging Cheat Sheet](Logging_Cheat_Sheet.md#which-events-to-log) and [Application Logging Vocabulary Cheat Sheet](Logging_Vocabulary_Cheat_Sheet.md)
 
 ## References
-cls
+
 - [NIST Special Publication 800-204](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204.pdf) “Security Strategies for Microservices-based Application Systems”
 - [NIST Special Publication 800-204A](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf) “Building Secure Microservices-based Applications Using Service-Mesh Architecture”
 - [Microservices Security in Action](https://www.manning.com/books/microservices-security-in-action), Prabath Siriwardena and Nuwan Dias, 2020, Manning

--- a/cheatsheets/Microservices_Security_Cheat_Sheet.md
+++ b/cheatsheets/Microservices_Security_Cheat_Sheet.md
@@ -162,16 +162,16 @@ High-level recommendations to logging subsystem architecture with its rationales
     - this allows mitigating threats such as: microservice spoofing, logging/transport system spoofing, network traffic injection, sniffing network traffic
 5. Message broker shall enforce access control policy to mitigate unauthorized access and implement the principle of least privileges:
     - this allows mitigating the threat of microservice elevation of privileges
-6. Logging agent shall filter/sanitize output log messages to make sure that sensitive data (e.g., PII, passwords, API keys) is never sent to the central logging subsystem (data minimization principle). For a comprehensive overview of items that should be excluded from logging, please see the [OWASP Logging Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Logging_Cheat_Sheet.md#data-to-exclude).
+6. Logging agent shall filter/sanitize output log messages to make sure that sensitive data (e.g., PII, passwords, API keys) is never sent to the central logging subsystem (data minimization principle). For a comprehensive overview of items that should be excluded from logging, please see the [OWASP Logging Cheat Sheet](Logging_Cheat_Sheet.md#data-to-exclude).
 7. Microservices shall generate a correlation ID that uniquely identifies every call chain and helps group log messages to investigate them. The logging agent shall include a correlation ID in every log message.
 8. The logging agent shall periodically provide health and status data to indicate its availability or non-availability.
 9. The logging agent shall publish log messages in a structured logs format (e.g., JSON, CSV).
 10. The logging agent shall append log messages with context data, e.g., platform context (hostname, container name), runtime context (class name, filename).
 
-For a comprehensive overview of events that should be logged and possible data format, please see the [OWASP Logging Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Logging_Cheat_Sheet.md#which-events-to-log) and [Application Logging Vocabulary Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md)
+For a comprehensive overview of events that should be logged and possible data format, please see the [OWASP Logging Cheat Sheet](Logging_Cheat_Sheet.md#which-events-to-log) and [Application Logging Vocabulary Cheat Sheet](Logging_Vocabulary_Cheat_Sheet.md)
 
 ## References
-
+cls
 - [NIST Special Publication 800-204](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204.pdf) “Security Strategies for Microservices-based Application Systems”
 - [NIST Special Publication 800-204A](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-204A.pdf) “Building Secure Microservices-based Applications Using Service-Mesh Architecture”
 - [Microservices Security in Action](https://www.manning.com/books/microservices-security-in-action), Prabath Siriwardena and Nuwan Dias, 2020, Manning


### PR DESCRIPTION
This PR addresses issue #1703 by replacing hardcoded GitHub links with relative links across relevant cheat sheets.


