### PR TITLE
Convert HTTP links to HTTPS in CONTRIBUTOR-V1.md

### DIFF
--- a/CONTRIBUTOR-V1.md
+++ b/CONTRIBUTOR-V1.md
@@ -88,7 +88,7 @@ Sorting applied on the name is an alphabetical one.
 - Dominique Righetto - [dominique.righetto@owasp.org](mailto:dominique.righetto@owasp.org)
 - Eric Sheridan - [eric.sheridan@owasp.org](mailto:eric.sheridan@owasp.org)
 - Paul Petefish
-- [Manideep Konakandla (Amazon Application Security Team)](http://www.manideepk.com)
+- [Manideep Konakandla (Amazon Application Security Team)](https://www.manideepk.com)
 
 ## [Cross Site Scripting Prevention Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/tree/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md)
 
@@ -299,7 +299,7 @@ Sorting applied on the name is an alphabetical one.
 
 - Gunnar Peterson
 - James McGovern
-- [Brad Broulik](http://bradbroulik.blogspot.dk/2010/01/bulletproof-sso-with-saml-20.html)
+- [Brad Broulik](https://bradbroulik.blogspot.com/2010/01/bulletproof-sso-with-saml-20.html)
 - [Paweł Krawczyk](https://ipsec.pl/)
 
 ## [SQL Injection Prevention Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/tree/master/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md)


### PR DESCRIPTION
## Summary
Convert HTTP links to HTTPS for improved security in the CONTRIBUTOR-V1.md file.

This addresses the contributing guidelines requirement: **"Always use HTTPS links where possible"**

## Changes Made
- Line 91: Updated Manideep Konakandla profile link from `http://` to `https://`
- Line 302: Updated Brad Broulik blog link from `http://bradbroulik.blogspot.dk/...` to `https://bradbroulik.blogspot.com/...`
  - **Note**: The original HTTP .dk link redirects to the HTTPS .com version, so this update eliminates the redirect chain

## Verification
- Both HTTPS links verified to return 200 OK status
- No functionality broken - links work correctly
- Follows OWASP security-first principles
- Aligns with project contributing guidelines

## Testing
```bash
# Both links tested and working
curl -I https://www.manideepk.com          # 200 OK
curl -I https://bradbroulik.blogspot.com/2010/01/bulletproof-sso-with-saml-20.html  # 200 OK
```