### PR TITLE
Add Encoding vs Escaping entry to Security Definitions Cheat Sheet

### DIFF
--- a/cheatsheets/Security_Definitions_Cheat_Sheet.md
+++ b/cheatsheets/Security_Definitions_Cheat_Sheet.md
@@ -1,29 +1,35 @@
 # Security Definitions Cheat Sheet
 
-## Encoding vs Escaping
+## Encoding vs Escaping (and Sanitization)
 
 **Baseline Definition:**  
-- **Encoding**: Transforming data into another format using a publicly available scheme (e.g., Base64, URL encoding).  
-- **Escaping**: Adding special characters to data so that it is treated as plain text, not as executable code (e.g., HTML entity escaping).  
-- Sources: [OWASP](https://owasp.org), [CNCF Glossary](https://glossary.cncf.io)
+- **Encoding (Output Encoding):** Converting data into a safe representation for a specific output context (e.g., `<` → `&lt;` in HTML). Often referred to as *output encoding* in OWASP materials.  
+- **Escaping:** Adding a special character before a control character so it is treated as data, not code (e.g., escaping quotes in SQL or JSON). In practice, escaping and output encoding are sometimes used interchangeably.  
+- **Sanitization:** Modifying or stripping unsafe input to enforce a security policy (e.g., removing `<script>` tags).  
 
 **Why it Matters in Security:**  
-- Misunderstanding these terms can cause developers to use the wrong defense mechanism.  
-- Encoding does **not** protect against injection attacks, while escaping is often critical for preventing XSS.  
+- Misunderstanding these terms can cause developers to use the wrong defense.  
+- **Encoding/escaping** are critical for preventing injection attacks (XSS, SQLi, etc.), but **encoding alone** (like Base64) is not a security control.  
+- **Sanitization** can reduce attack surface but is not foolproof—it should complement, not replace, contextual encoding/escaping.  
 
 **Real-World Example:**  
-- Developer Base64-encodes untrusted input and assumes it is “safe,” but the input is still executable after decoding → leading to SQL injection or XSS.  
-- Proper HTML escaping (`&lt;script&gt;`) prevents execution in the browser.  
+- Developer Base64-encodes untrusted input, assuming it is “safe,” but the value is still dangerous after decoding → possible SQL injection or XSS.  
+- Proper HTML output encoding: `&lt;script&gt;alert(1)&lt;/script&gt;` renders harmless text.  
+- Sanitization (e.g., stripping `<script>` tags) may preserve content but risks over- or under-filtering.  
 
 **Best Practices:**  
-- Use escaping when injecting untrusted data into a language/markup (HTML, SQL, XML).  
-- Use encoding only for safely transmitting data (e.g., sending binary over text).  
-- Do **not** confuse encoding with security controls.  
+- Always apply **contextual output encoding/escaping** (HTML, JavaScript, CSS, URL, etc.).  
+- Use well-tested libraries: [OWASP Java Encoder](https://owasp.org/www-project-java-encoder/), [OWASP ESAPI](https://owasp.org/www-project-esapi/).  
+- Use **sanitization** only when you must allow some user HTML (e.g., [OWASP Java HTML Sanitizer](https://owasp.org/www-project-java-html-sanitizer/)).  
+- Never confuse **transport encoding** (Base64, URL encoding) with **security encoding**.  
 
 **Snippet Example (XSS Prevention):**
-```html
-<!-- Unsafe -->
-<div>Welcome, <%= userInput %></div>
+```java
+// Unsafe
+out.println("Welcome, " + userInput);
 
-<!-- Safe (escaped) -->
-<div>Welcome, <%= HtmlUtils.htmlEscape(userInput) %></div>
+// Safe (HTML encoded)
+out.println("Welcome, " + Encode.forHtml(userInput));
+
+// Safe (JavaScript encoded)
+out.println("var msg = '" + Encode.forJavaScript(userInput) + "';");

--- a/cheatsheets/Security_Definitions_Cheat_Sheet.md
+++ b/cheatsheets/Security_Definitions_Cheat_Sheet.md
@@ -3,27 +3,42 @@
 ## Encoding vs Escaping (and Sanitization)
 
 **Baseline Definition:**  
-- **Encoding (Output Encoding):** Converting data into a safe representation for a specific output context (e.g., `<` → `&lt;` in HTML). Often referred to as *output encoding* in OWASP materials.  
-- **Escaping:** Adding a special character before a control character so it is treated as data, not code (e.g., escaping quotes in SQL or JSON). In practice, escaping and output encoding are sometimes used interchangeably.  
+
+- **Encoding (Output Encoding):** Converting data into a safe representation for a specific output context  
+  (e.g., `<` → `&lt;` in HTML). Often referred to as *output encoding* in OWASP materials.  
+
+- **Escaping:** Adding a special character before a control character so it is treated as data, not code  
+  (e.g., escaping quotes in SQL or JSON). In practice, escaping and output encoding are sometimes used  
+  interchangeably.  
+
 - **Sanitization:** Modifying or stripping unsafe input to enforce a security policy (e.g., removing `<script>` tags).  
 
 **Why it Matters in Security:**  
+
 - Misunderstanding these terms can cause developers to use the wrong defense.  
-- **Encoding/escaping** are critical for preventing injection attacks (XSS, SQLi, etc.), but **encoding alone** (like Base64) is not a security control.  
-- **Sanitization** can reduce attack surface but is not foolproof—it should complement, not replace, contextual encoding/escaping.  
+- **Encoding/escaping** are critical for preventing injection attacks (XSS, SQLi, etc.), but **encoding alone**  
+  (like Base64) is not a security control.  
+- **Sanitization** can reduce attack surface but is not foolproof—it should complement, not replace,  
+  contextual encoding/escaping.  
 
 **Real-World Example:**  
-- Developer Base64-encodes untrusted input, assuming it is “safe,” but the value is still dangerous after decoding → possible SQL injection or XSS.  
+
+- Developer Base64-encodes untrusted input, assuming it is “safe,” but the value is still dangerous after decoding →  
+  possible SQL injection or XSS.  
 - Proper HTML output encoding: `&lt;script&gt;alert(1)&lt;/script&gt;` renders harmless text.  
 - Sanitization (e.g., stripping `<script>` tags) may preserve content but risks over- or under-filtering.  
 
 **Best Practices:**  
+
 - Always apply **contextual output encoding/escaping** (HTML, JavaScript, CSS, URL, etc.).  
-- Use well-tested libraries: [OWASP Java Encoder](https://owasp.org/www-project-java-encoder/), [OWASP ESAPI](https://owasp.org/www-project-esapi/).  
-- Use **sanitization** only when you must allow some user HTML (e.g., [OWASP Java HTML Sanitizer](https://owasp.org/www-project-java-html-sanitizer/)).  
+- Use well-tested libraries: [OWASP Java Encoder](https://owasp.org/www-project-java-encoder/),  
+  [OWASP ESAPI](https://owasp.org/www-project-esapi/).  
+- Use **sanitization** only when you must allow some user HTML  
+  (e.g., [OWASP Java HTML Sanitizer](https://owasp.org/www-project-java-html-sanitizer/)).  
 - Never confuse **transport encoding** (Base64, URL encoding) with **security encoding**.  
 
 **Snippet Example (XSS Prevention):**
+
 ```java
 // Unsafe
 out.println("Welcome, " + userInput);

--- a/cheatsheets/Security_Definitions_Cheat_Sheet.md
+++ b/cheatsheets/Security_Definitions_Cheat_Sheet.md
@@ -1,0 +1,29 @@
+# Security Definitions Cheat Sheet
+
+## Encoding vs Escaping
+
+**Baseline Definition:**  
+- **Encoding**: Transforming data into another format using a publicly available scheme (e.g., Base64, URL encoding).  
+- **Escaping**: Adding special characters to data so that it is treated as plain text, not as executable code (e.g., HTML entity escaping).  
+- Sources: [OWASP](https://owasp.org), [CNCF Glossary](https://glossary.cncf.io)
+
+**Why it Matters in Security:**  
+- Misunderstanding these terms can cause developers to use the wrong defense mechanism.  
+- Encoding does **not** protect against injection attacks, while escaping is often critical for preventing XSS.  
+
+**Real-World Example:**  
+- Developer Base64-encodes untrusted input and assumes it is “safe,” but the input is still executable after decoding → leading to SQL injection or XSS.  
+- Proper HTML escaping (`&lt;script&gt;`) prevents execution in the browser.  
+
+**Best Practices:**  
+- Use escaping when injecting untrusted data into a language/markup (HTML, SQL, XML).  
+- Use encoding only for safely transmitting data (e.g., sending binary over text).  
+- Do **not** confuse encoding with security controls.  
+
+**Snippet Example (XSS Prevention):**
+```html
+<!-- Unsafe -->
+<div>Welcome, <%= userInput %></div>
+
+<!-- Safe (escaped) -->
+<div>Welcome, <%= HtmlUtils.htmlEscape(userInput) %></div>


### PR DESCRIPTION
This PR introduces the first draft entry ("Encoding vs Escaping") for the new Security Definitions Cheat Sheet (#1741).

Format includes:
- Baseline definition with external references
- Why it matters in security
- Real-world example
- Best practices
- Small code snippet

Once structure is validated, I’ll add more terms (e.g., Encryption vs Signature) in separate PRs as discussed.
