### PR TITLE
Drone Security: fix typos

### DIFF
--- a/cheatsheets/Drone_Security_Cheat_Sheet.md
+++ b/cheatsheets/Drone_Security_Cheat_Sheet.md
@@ -126,7 +126,7 @@ The following table summaries the different attack vectors for a drone system.
 
 | Attack |  | Targets | | | | | Security Measures | |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Type | Nature | Privacy| Data Confidentiality | Integrity | Accessibility | Authentication|Non-Cryptographic | Cryptographic |
+| Type | Nature | Privacy| Data Confidentiality | Integrity | Accessibility | Authentication | Cryptographic | Non-Cryptographic |
 | Malware | Infection | x | x |x |x |x | Control access, system integrity solutions and multi-factor authentication | Hybrid lightweight Intrusion Detection System |
 | BackDoor Access | Infection |x|x|x| x|x | Multi-factor robust authentication scheme | Hybrid lightweight Intrusion Detection System, vulnerability assessment |
 | Social Engineering | Exploitation | x|x |- |- |x | N/A | Raising awareness, training operators |

--- a/cheatsheets/Drone_Security_Cheat_Sheet.md
+++ b/cheatsheets/Drone_Security_Cheat_Sheet.md
@@ -28,11 +28,11 @@ The communication between the drone and the GCS is vulnerable to interception an
 
 - **Insecure Communication Links** – Data transmitted between the drone and GCS can be intercepted if not properly encrypted. Use standard protocols for encryption of any data being sent over.
 
-- **Spoofing and Replay Attacks** – If the drone uses a GPS module then data spoofing and command replay attacks can also become a reality. Again encrpyted data transfer is the best way to go forward. There are many more methods, which have been discussed [here](https://www.okta.com/identity-101/gps-spoofing/)
+- **Spoofing and Replay Attacks** – If the drone uses a GPS module then data spoofing and command replay attacks can also become a reality. Again encrypted data transfer is the best way to go forward. There are many more methods, which have been discussed [here](https://www.okta.com/identity-101/gps-spoofing/)
 
 - **Wi-Fi Weaknesses** – Weak authentication or unprotected channels can allow unauthorized access. This is even possible through simple [microcontrollers like ESP8266](https://github.com/SpacehuhnTech/esp8266_deauther)!
 
-    - Use **802.11w MFP (Management Frame Protection)** to prevent Wi-Fi deauthentication attacks. Don't worry, if your Wi-Fi systems are up to date, then this is a default protocol now.
+    - Use **802.11w MFP (Management Frame Protection)** to prevent Wi-Fi deauthentication attacks. Don't worry, if your Wi-Fi systems are up-to-date, then this is a default protocol now.
 
 ### 2. Authentication & Access Control
 
@@ -50,7 +50,7 @@ Thus, it becomes very important to maintain their security as well. The possible
 
 ### 3. Physical Security
 
-If your drone is ever captured or lost, you should ensure that its not physically possible to steal data from it. This may happen under the following conditions:
+If your drone is ever captured or lost, you should ensure that it's not physically possible to steal data from it. This may happen under the following conditions:
 
 - **Insufficient Physical Security** – Unsecured USB ports or exposed hardware can lead to data theft or tampering.
 
@@ -86,7 +86,7 @@ Below are some protocols used by drone systems to communicate. This can be eithe
 
    - You must secure **heartbeat messages** to avoid [command injection vulnerabilities](https://owasp.org/www-community/attacks/Command_Injection). A heartbeat message is usually a single byte that is sent at a certain frequency to all other nodes, informing of the device's existence. The frequency is important here!
 
-   - Tools like **ArduPilot** and **PX4** support MAVLink 2.0 security enhancements. There are thoroughly tested softwares and hence recommended.
+   - Tools like **ArduPilot** and **PX4** support MAVLink 2.0 security enhancements. They have been thoroughly tested and are therefore recommended.
 
    - Utilize **end-to-end encryption**! Either through TLS or DTLS is fine and good.
 


### PR DESCRIPTION
Hi! Noticed a couple of typos in the Drone_Security_Cheat_Sheet, so created this PR to fix them.

Additionally, noticed that in the attack vector table, the Security Measures columns are probably flipped:
- Message authentication or digital signature, encrypted traffic/stream are examples of cryptographic measures, but they are in non-cryptographic column
- Traffic filtering, close unused TCP/FTP ports are in cryptographic measures column, but they are examples of non-cryptographic ones

Also, I considered reformatting the table in Markdown (align columns with whitespaces) to make it easier to read, but that would introduce more line changes, so I decided against it. Though, I'm happy to do it if you'd prefer!

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).
