### PR TITLE
Correct a typo in the event name for 'malicious_direct_reference' in the logging vocabulary cheatsheet.

### DIFF
--- a/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
@@ -730,7 +730,7 @@ CRITICAL
 {
     "datetime": "2019-01-01 00:00:00,000",
     "appid": "foobar.netportal_auth",
-    "event": "malicious_direct:joebob1, Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+    "event": "malicious_direct_reference:joebob1, Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
     "level": "CRITICAL",
     "description": "User joebob1 attempted to access an object to which they are not authorized",
     ...


### PR DESCRIPTION
The event was incorrectly named 'malicious_direct' in the example.

# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR fixes issue #1118.

Thank you again for your contribution :smiley:

I wanted to fix #1118 but it looks that the malicious_direct_reference event was already marked as CRITICAL, which aligns with suggestion from @jmanico . I've updated the example to use the correct event name, malicious_direct_reference, for consistency.