### PR TITLE
Update deprecated dependencies (uuid, request, har-validator) for #71

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
   "bugs": {
     "url": "https://github.com/OWASP/CheatSheetSeries/issues"
   },
-  "homepage": "https://github.com/OWASP/CheatSheetSeries#readme"
+  "homepage": "https://github.com/OWASP/CheatSheetSeries#readme",
+  "dependencies": {
+    "axios": "^1.5.0",
+    "uuid": "^9.0.0"
+  }
 }


### PR DESCRIPTION
This PR addresses issue [#71](https://github.com/OWASP/CheatSheetSeries/issues/71)
 by updating and cleaning up deprecated dependencies in the project.

**Changes made:**
- Upgraded `uuid `to version 9+ to replace the deprecated 3.4.0.
- Removed request and replaced it with `axios `(^1.5.0) for HTTP requests.
- Removed `har-validator` since it is no longer maintained.