### PR TITLE
Add AI tool usage disclosure to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,13 @@ If your PR is related to an issue, please finish your PR text with the following
 
 This PR fixes issue #`<REPLACE WITH ISSUE NUMBER>`.
 
+## AI Tool Usage Disclosure (required for all PRs)
+
+Please select one of the following options:
+
+- [ ] I have NOT used any AI tool to generate the contents of this PR.
+- [ ] I have used AI tools to generate the contents of this PR. I have verified
+    the contents and I affirm the results. The LLM used is `[llm name and version]`
+    and the prompt used is `[your prompt here]`. [Feel free to add more details if needed]
+
 Thank you again for your contribution :smiley:


### PR DESCRIPTION
Due to the recent increase in AI tool usage and the corresponding increase in low quality PRs across the Open Source world, this PR adds a new section to the PR template which asks submitters to indicate if and how they've used UI in the generation of their PRs. This will allow the reviewers to have more clarity in their reviews (hopefully decreasing maintainer burnout) and will also preserve the information necessary to recreate the content if desired. Having the prompts for historical purposes will also allow future users to learn how to prompt LLMs to get the content they desire.
This is not an anti-AI move - I used GH Copilot while writing this PR. AI tools can be wonderful, but we believe they should be used transparently.