### PR TITLE
Docs: Clarify SlidingExpiration guidance

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -49,6 +49,8 @@ CookieHttpOnly = true,
 
 Reduce the time period a session can be stolen in by reducing session timeout and removing sliding expiration:
 
+The decision to use sliding expiration depends on your application's threat model. Setting `SlidingExpiration` to `false` is the most secure option as it ensures that a session has a fixed lifetime (absolute timeout), reducing the risk of a hijacked session being kept alive indefinitely. However, for some applications, enabling sliding expiration (`true`) may be preferred for user experience, as it keeps the session alive as long as the user is active. This convenience comes at the cost of increased risk if a session is compromised.
+
 ```csharp
 ExpireTimeSpan = TimeSpan.FromMinutes(60),
 SlidingExpiration = false
@@ -775,8 +777,9 @@ e.g
 services.ConfigureApplicationCookie(options =>
 {
  options.Cookie.HttpOnly = true;
- options.Cookie.Expiration = TimeSpan.FromHours(1)
- options.SlidingExpiration = true;
+ options.ExpireTimeSpan = TimeSpan.FromMinutes(60);
+ // See the discussion in A01 for trade-offs on using sliding expiration.
+ options.SlidingExpiration = false;
 });
 ```
 

--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -49,7 +49,7 @@ CookieHttpOnly = true,
 
 Reduce the time period a session can be stolen in by reducing session timeout and removing sliding expiration:
 
-The decision to use sliding expiration depends on your application's threat model. Setting `SlidingExpiration` to `false` is the most secure option as it ensures that a session has a fixed lifetime (absolute timeout), reducing the risk of a hijacked session being kept alive indefinitely. However, for some applications, enabling sliding expiration (`true`) may be preferred for user experience, as it keeps the session alive as long as the user is active. This convenience comes at the cost of increased risk if a session is compromised.
+The decision to use sliding expiration depends on your application's threat model. Setting `SlidingExpiration` to `false` enforces an absolute session lifetime, which limits how long a stolen session can be reused, at the cost of reduced usability for long-lived interactive sessions. For some applications, enabling sliding expiration (`true`) may be preferred for user experience, as it keeps the session alive as long as the user is active. This convenience comes with increased risk if a session is compromised.
 
 ```csharp
 ExpireTimeSpan = TimeSpan.FromMinutes(60),


### PR DESCRIPTION
Resolves #1325

The DotNet Security Cheat Sheet had conflicting advice regarding the `SlidingExpiration` cookie setting.

This commit:
- Adds a paragraph to section A01 explaining the security trade-offs between enabling and disabling `SlidingExpiration`, advising that the choice depends on the application's threat model.
- Updates the code example in section A07 to be consistent with the more secure recommendation (`SlidingExpiration = false`).
- Corrects a property name in the A07 code example from `options.Cookie.Expiration` to `options.ExpireTimeSpan`.

# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

If your PR is related to an issue, please finish your PR text with the following line:

This PR fixes issue #1325.

## AI Tool Usage Disclosure (required for all PRs)

Please select one of the following options:

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `jules`
    and the prompt is described below. 

Conversation with Jules
```
mackowski: Check the issue #1325 with all comments. Can you try to implement the changes? I do not want PR for now, just branch with proposal.

jules: After reviewing the GitHub issue and the relevant cheat sheets, I have a clear understanding of the task. The core of the issue is an inconsistency in the DotNet_Security_Cheat_Sheet.md file regarding the SlidingExpiration setting for session cookies.

Here's my analysis:

The Inconsistency: The "A01 Broken Access Control" section advises disabling sliding expiration (SlidingExpiration = false) to enforce a fixed session lifetime. However, the code example in the "A07 Identification and Authentication Failures" section enables it (SlidingExpiration = true).
Security Best Practice: The Session_Management_Cheat_Sheet.md explains that while sliding expiration (an idle timeout) is useful, it allows an attacker who has hijacked a session to keep it active indefinitely. Disabling it enforces an absolute timeout, which is a stronger security posture against session hijacking.
Proposed Solution: I intend to make the cheat sheet consistent by adopting the more secure recommendation. I will modify the code example in section A07 to set SlidingExpiration = false. I will also add a brief note to explain the reasoning behind this recommendation, which will address the question raised in the GitHub issue.
Before I create a plan and start modifying the files, I want to confirm my approach with you. Please answer the following questions:

My plan is to resolve the inconsistency by recommending the more secure option of disabling sliding expiration (SlidingExpiration = false) throughout the document. This involves changing the code example in section A07. Does this align with your expectations?
To help developers understand the "why," I'll add a short note explaining that disabling sliding expiration prevents hijacked sessions from being kept alive indefinitely. Is this addition okay with you?
The current file recommends a session timeout of 60 minutes. I will use this value consistently in the updated code example. Is this acceptable, or do you have a different value in mind?

mackowski: This plan is fine but I would like to add a short paragraph that will explain that using SlidingExpiration depends on threat model and briefly explain that

jules: 
1. Modify cheatsheets/DotNet_Security_Cheat_Sheet.md to explain session timeout trade-offs. In the "A01 Broken Access Control" section, I will add a paragraph explaining that the choice of using SlidingExpiration depends on the application's threat model. I will detail the security implications of setting it to true (better UX, but a hijacked session can be kept alive) versus false (more secure, fixed timeout).
2. Update the code example in section A01. I will ensure the code example in the "A01 Broken Access Control" section reflects the secure recommendation of SlidingExpiration = false and adds context about the threat model.
3. Correct and update the code example in section A07. In the "A07 Identification and Authentication Failures" section, I will correct the property name from options.Cookie.Expiration to options.ExpireTimeSpan. I will also set SlidingExpiration to false to align with the primary recommendation and add a comment to reference the explanation in A01.
4. Complete pre commit steps. Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
5. Submit the change. Once the changes are verified, I will create a branch and submit the changes with a descriptive commit message.

mackowski: plan approved
```

Thank you again for your contribution :smiley:
