### PR TITLE
Update URL to contributing guidelines

### DIFF
--- a/Preface.md
+++ b/Preface.md
@@ -24,5 +24,5 @@ Project links:
 
 - [Homepage](https://owasp.org/www-project-cheat-sheets/)
 - [GitHub repository](https://github.com/OWASP/CheatSheetSeries)
-- [How to contribute?](CONTRIBUTING.md)
+- [How to contribute?](https://github.com/OWASP/CheatSheetSeries/blob/master/CONTRIBUTING.md)
 - [Logo](https://github.com/OWASP/owasp-swag/tree/master/projects/cheat-sheet-series)


### PR DESCRIPTION
## Problem

The "How to contribute?" link on https://cheatsheetseries.owasp.org/ is 404'ing. This PR updates the URL to the contributing file in the repo.

## AI Tool Usage Disclosure (required for all PRs)

Please select one of the following options:

- [x] I have NOT used any AI tool to generate the contents of this PR.
- [ ] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `[llm name and version]`
    and the prompt used is `[your prompt here]`. [Feel free to add more details if needed]
