### PR TITLE
Update NPM Security Cheat Sheet

### DIFF
--- a/cheatsheets/NPM_Security_Cheat_Sheet.md
+++ b/cheatsheets/NPM_Security_Cheat_Sheet.md
@@ -161,7 +161,7 @@ Ensure you are following this npm security best practice by protecting and minim
 
 Typosquatting is an attack that relies on mistakes made by users, such as typos. With typosquatting, bad actors publish malicious modules to the npm registry with names that look much like existing popular modules. These malicious packages exploit common typing errors or visual similarities to trick developers into installing them instead of the legitimate packages they intended to use.
 
-We have been tracking tens of malicious packages in the npm ecosystem; similar attacks have been seen on the PyPi Python registry as well. Some of the most notable incidents include [cross-env](https://snyk.io/vuln/npm:crossenv:20170802), [event-stream](https://snyk.io/vuln/SNYK-JS-EVENTSTREAM-72638), and [eslint-scope](https://snyk.io/vuln/npm:eslint-scope:20180712).
+The Snyk security team has tracked tens of malicious packages in the npm ecosystem that used typosquatting to trick users into installing them; similar attacks have been observed on the PyPi Python registry as well. Some of the most notable incidents include [cross-env](https://snyk.io/vuln/npm:crossenv:20170802), [event-stream](https://snyk.io/vuln/SNYK-JS-EVENTSTREAM-72638), and [eslint-scope](https://snyk.io/vuln/npm:eslint-scope:20180712).
 
 One of the main targets for typosquatting attacks are user credentials, since any package has access to environment variables via the global variable `process.env`. Other examples include the event-stream case, where attackers targeted developers in the hopes of [injecting malicious code](https://snyk.io/blog/a-post-mortem-of-the-malicious-event-stream-backdoor) into an application's source code.
 


### PR DESCRIPTION
This PR fixes issue #1853 

1. Updated Section 3 to add a suggestion to disable lifecycle scripts by default and use an allowlist, with an example.
2. Updated Section 10 to make it all about typosquatting and slopsquatting. Removed the details about the rules npm uses for naming conventions, which didn't seem to add much useful information and distracted from the main point of the section (happy to bring it back if you think it's useful).
3. Added Section 11 about trusted publishing.
4. Some light cleanup and formatting.

## AI Tool Usage Disclosure (required for all PRs)

Please select one of the following options:

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `gpt-5`
    and the prompt used is `summarize the official trusted publishing documentation`

Thank you again for your contribution :smiley:
