### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -1,4 +1,8 @@
 name: Identify old issues and PR
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
**I will address all issues from CodeQL in the next week but I want to do this step by step and later harden our default config.**

Fix for [https://github.com/OWASP/CheatSheetSeries/security/code-scanning/1](https://github.com/OWASP/CheatSheetSeries/security/code-scanning/1)

To fix the problem, you must add a `permissions` block to the workflow. This block should be at the root level or within the relevant job. For minimal permissions, set `contents: read`. If `scripts/Identify_Old_Issue_And_PR.py` needs to write to issues or PRs, add `issues: write` and/or `pull-requests: write` as needed. Since the provided workflow does not clearly show it making changes to repo contents, but given its name ("Identify old issues and PR"), it is likely that it at least comments or closes issues/PRs, so `issues: write` and possibly `pull-requests: write` may be required. Place the permissions block at the root level for all jobs, just below `name:` and above `on:` for maximum coverage and clarity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
