### PR TITLE
Update Fetch Metadata positioning

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -13,7 +13,7 @@ In short, the following principles should be followed to defend against CSRF:
 **IMPORTANT: Remember that Cross-Site Scripting (XSS) can defeat all CSRF mitigation techniques!** While Cross-Site Scripting (XSS) vulnerabilities can bypass CSRF protections, CSRF tokens are still essential for web applications that rely on cookies for authentication. Consider the client and authentication method to determine the best approach for CSRF protection in your application.
 
 - **See the OWASP [XSS Prevention Cheat Sheet](Cross_Site_Scripting_Prevention_Cheat_Sheet.md) for detailed guidance on how to prevent XSS flaws.**
-- **First, check if your framework has [built-in CSRF protection](#use-built-in-or-existing-csrf-implementations-for-csrf-protection) and use it**
+- **First, check if your framework has [built-in CSRF protection](#built-in-or-existing-csrf-implementations-for-csrf-protection) and use it**
 - **If the framework does not have built-in CSRF protection, add [CSRF tokens](#token-based-mitigation) to all state-changing requests (requests that cause actions on the site) and validate them on the backend.**
 - **If your software targets only modern browsers, you may rely on [Fetch Metadata headers](#fetch-metadata-headers) together with the fallback options described below to block cross-site state-changing requests.**
 - **Stateful software should use the [synchronizer token pattern](#synchronizer-token-pattern)**


### PR DESCRIPTION
As agreed in https://github.com/OWASP/CheatSheetSeries/issues/1803 :
- Updated Fetch Metadata positioning
- Extended core guidance to mention Fetch Metadata request headers (Sec-Fetch-*) as an alternative to CSRF tokens for state-changing requests.
- Added clarification that developers can use CSRF tokens or Fetch Metadata depending on project needs and client compatibility.



- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

## AI Tool Usage Disclosure (required for all PRs)

Please select one of the following options:

- [x] I have NOT used any AI tool to generate the contents of this PR.
- [ ] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `[llm name and version]`
    and the prompt used is `[your prompt here]`. [Feel free to add more details if needed]

This PR fixes issue #1803.
