### PR TITLE
Clarify IdP-initiated SSO section: specify login CSRF, remove MITM re… #1876

### DIFF
--- a/cheatsheets/SAML_Security_Cheat_Sheet.md
+++ b/cheatsheets/SAML_Security_Cheat_Sheet.md
@@ -93,7 +93,7 @@ Need an architectural diagram? The [SAML technical overview](https://www.oasis-o
 
 ## Unsolicited Response (ie. IdP Initiated SSO) Considerations for Service Providers
 
-Unsolicited Response is inherently less secure by design due to the lack of **login [CSRF](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#possible-csrf-vulnerabilities-in-login-forms)** protection. This limitation arises because the Service Provider (SP) has no opportunity to create a pre-login session or verify that the authentication request was intentionally initiated by the user.  
+Unsolicited Response is inherently less secure by design due to the lack of **login [CSRF](Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md#possible-csrf-vulnerabilities-in-login-forms)** protection. This limitation arises because the Service Provider (SP) has no opportunity to create a pre-login session or verify that the authentication request was intentionally initiated by the user.  
 
 While this design does not make IdP-initiated SSO uniquely vulnerable to Man-in-the-Middle (MITM) attacks—those risks apply equally to SP-initiated flows if transport security is compromised—it does remove an important layer of login intent validation.  
 


### PR DESCRIPTION
### Summary
This PR improves the "IdP Initiated SAML SSO" section of the SAML Security Cheat Sheet.

- Removes an external reference incorrectly claiming IdP-initiated SSO is uniquely vulnerable to MITM.
- Clarifies that the main design limitation is the lack of **login CSRF protection**, since the SP cannot establish a pre-login state to bind the response.

### Rationale
This aligns the cheat sheet with accurate security reasoning while keeping the focus on real, design-based risks rather than general TLS issues.


Covers: #1876 
