### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/md_lint_check.yml
+++ b/.github/workflows/md_lint_check.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     env:
       CI: true


### PR DESCRIPTION
Fix for [https://github.com/OWASP/CheatSheetSeries/security/code-scanning/2](https://github.com/OWASP/CheatSheetSeries/security/code-scanning/2)

To fix the issue, I explicitly added a `permissions` block to the job definition. 
Here, since there is only one job, adding it at the job level is sufficient. The linter job only needs to read the contents of the repository (no need to write to contents, pull-requests, etc.), so `contents: read` is the minimal permissions set required. Added the following block under `lint:` and above `runs-on:` in `.github/workflows/md_lint_check.yml`:

```yaml
permissions:
  contents: read
```
