### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   link-check:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-24.04
     env:
       CI: true


### PR DESCRIPTION
Fix for [https://github.com/OWASP/CheatSheetSeries/security/code-scanning/3](https://github.com/OWASP/CheatSheetSeries/security/code-scanning/3)

To fix this problem, we need to add a `permissions` block to restrict GITHUB_TOKEN permissions to the minimum needed by the job. In this workflow, commenting on pull requests requires `pull-requests: write`. All other steps like checking out the repo, setting up Node, installing dependencies, and running checks only require `contents: read`. Therefore, we should add a `permissions:` block at the job level (under `link-check:`) specifying:
- `contents: read` (for all steps needing repo read-access)
- `pull-requests: write` (for the action commenting on PRs)

No other permission is needed, so this strictly limits the token per the principle of least privilege. 