### PR TITLE
Fix lxml build error by installing system dependencies

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+    - name: Install system dependencies for lxml
+      run: sudo apt-get update && sudo apt-get install -y libxml2-dev libxslt1-dev
     - name: Install Python dependencies
       run: make install-python-requirements
     - name: Run build script


### PR DESCRIPTION
## Problem
The GitHub Actions workflow was failing when trying to build `lxml==5.3.0` from source with the error:
```
Error: Please make sure the libxml2 and libxslt development packages are installed.
```

## Solution
Added a step to install the required system development libraries (`libxml2-dev` and `libxslt1-dev`) before installing Python dependencies. These packages are required for building lxml from source.

## Changes
- `.github/workflows/build-and-deploy-website.yml`: Added system dependencies installation step

## Testing
This fix addresses the specific build error that was preventing the workflow from completing successfully.