### PR TITLE
Update links in Threat Modeling cheat sheet

### DIFF
--- a/cheatsheets/Threat_Modeling_Cheat_Sheet.md
+++ b/cheatsheets/Threat_Modeling_Cheat_Sheet.md
@@ -34,7 +34,7 @@ Proper threat modeling requires participants to think creatively and critically 
 
 ### Improved Visibility of Target of Evaluation (TOE)
 
-Threat modeling requires a deep understanding of the system being evaluated. To properly threat model, one must understand data flows, trust boundaries, and other characteristics of the system. Thus, [Stiliyana Simeonova](https://securityintelligence.com/threat-modeling-in-the-enterprise-part-1-understanding-the-basics/) asserts that improved visibility into a system and its interactions is one advantage of threat modeling.
+Threat modeling requires a deep understanding of the system being evaluated. To properly threat model, one must understand data flows, trust boundaries, and other characteristics of the system. Thus improved visibility into a system and its interactions is one advantage of threat modeling.
 
 ## Addressing Each Question
 
@@ -80,10 +80,10 @@ STRIDE is a mature and popular threat modeling technique and mnemonic originally
 
 | Threat Category             | Violates          | Examples                                                                                                    |
 | --------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------- |
-| **S**poofing                | Authenticity      | An attacker steals the authentication token of a legitimate user and uses it to impersonate the user.       |
+| **S**poofing                | Authentication    | An attacker steals the authentication token of a legitimate user and uses it to impersonate the user.       |
 | **T**ampering               | Integrity         | An attacker abuses the application to perform unintended updates to a database.                             |
-| **R**epudiation             | Non-repudiability | An attacker manipulates logs to cover their actions.                                                        |
-| **I**nformation Disclosure  | Confidentiality   | An attacker extracts data from a database containing user account info.                                      |
+| **R**epudiation             | Accounting        | An attacker manipulates logs to cover their actions.                                                        |
+| **I**nformation Disclosure  | Confidentiality   | An attacker extracts data from a database containing user account info.                                     |
 | **D**enial of Service       | Availability      | An attacker locks a legitimate user out of their account by performing many failed authentication attempts. |
 | **E**levation of Privileges | Authorization     | An attacker tampers with a JWT to change their role.                                                        |
 


### PR DESCRIPTION
This pull request corrects these broken links.
- new link for Threat Modeling project
- remove links to content no longer in existence:
  - OWASP Cloud Security Project
  - MS Cloud Security Threat Modeling
  - Threat modeling in the enterprise part 1 Understanding the basics

This PR fixes #1912 

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

The STRIDE table was also updated for wording in line with CIA and AAA triads

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

## AI Tool Usage Disclosure

- [x] I have NOT used any AI tool to generate the contents of this PR.
- [ ] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `[llm name and version]`
    and the prompt used is `[your prompt here]`. [Feel free to add more details if needed]
