### PR TITLE
REST Cheat Sheet: Prevent out-of-order API execution

### DIFF
--- a/cheatsheets/REST_Security_Cheat_Sheet.md
+++ b/cheatsheets/REST_Security_Cheat_Sheet.md
@@ -124,7 +124,6 @@ without completing payment.
 - Are tokens reusable across workflow steps?
 - Are invalid state transitions consistently rejected?
 
-
 ## Input validation
 
 - Do not trust input parameters/objects.


### PR DESCRIPTION
Summary
Adds a short, prevention-focused section to the REST Security Cheat Sheet covering risks and mitigations related to out-of-order API execution in multi-step workflows.

Details
The update explains how workflow abuse can occur when APIs are invoked out of sequence, why frontend-only enforcement is insufficient, and outlines practical server-side prevention patterns along with a brief validation checklist. The content is scoped to REST APIs and avoids architectural design guidance.

Audience
Developers building REST APIs.

Files Changed

REST_Security_Cheat_Sheet.md

Use of AI
AI was used to assist with wording and structure. All content was reviewed and edited manually.