### PR TITLE
Fix HTTPS REST reference in REST Security Cheat Sheet

### DIFF
--- a/cheatsheets/REST_Security_Cheat_Sheet.md
+++ b/cheatsheets/REST_Security_Cheat_Sheet.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-[REST](http://en.wikipedia.org/wiki/Representational_state_transfer) (or **RE**presentational **S**tate **T**ransfer) is an architectural style first described in [Roy Fielding](https://en.wikipedia.org/wiki/Roy_Fielding)'s Ph.D. dissertation on [Architectural Styles and the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm).
+[REST](https://en.wikipedia.org/wiki/REST) (or **RE**presentational **S**tate **T**ransfer) is an architectural style first described in [Roy Fielding](https://en.wikipedia.org/wiki/Roy_Fielding)'s Ph.D. dissertation on [Architectural Styles and the Design of Network-based Software Architectures](https://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm).
 
 It evolved as Fielding wrote the HTTP/1.1 and URI specs and has been proven to be well-suited for developing distributed hypermedia applications. While REST is more widely applicable, it is most commonly used within the context of communicating with services via HTTP.
 


### PR DESCRIPTION
Summary
Fixes an outdated HTTP reference by linking directly to the HTTPS REST Wikipedia page.

Scope
Documentation maintenance only; no content or guidance changes.

Files Changed
- cheatsheets/REST_Security_Cheat_Sheet.md

Use of AI
No AI-generated content.
