### PR TITLE
Fix bad closing code fence for X-Robots-Tag in HTTP Headers cheatsheet

### DIFF
--- a/cheatsheets/HTTP_Headers_Cheat_Sheet.md
+++ b/cheatsheets/HTTP_Headers_Cheat_Sheet.md
@@ -241,12 +241,12 @@ MvcHandler.DisableMvcResponseHeader = true;
 
 ### X-Robots-Tag
 
-The HTTP `X-Robots-Tag` response header controls how search engines and other automated crawlers index and display resources such as PDFs, images, and other non-HTML content.  
+The HTTP `X-Robots-Tag` response header controls how search engines and other automated crawlers index and display resources such as PDFs, images, and other non-HTML content.
 It functions similarly to the `<meta name="robots">` tag, but is applied via the HTTP response header, allowing greater flexibility (e.g., for non-HTML files or server-wide rules).
 
 ```none
 X-Robots-Tag: noindex, nofollow
-````
+```
 
 - **Note:** Only compliant crawlers respect these directives, and they must still make an HTTP request to read the headers before deciding how to handle the content.
 


### PR DESCRIPTION
This fixes the bad rendering currently on https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-robots-tag

I have NOT used any AI tool to generate the contents of this PR.
