### PR TITLE
docs: use HTTPS for DMalloc reference

### DIFF
--- a/cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md
+++ b/cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md
@@ -656,4 +656,3 @@ Finally, for runtime hardening, Microsoft provides **Windows Defender Exploit Gu
 Additionally, the [Process Mitigation Management Tool](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-exploit-guard/customize-exploit-protection) (`ProcessMitigations` module) allows administrators to configure exploit mitigation policies via PowerShell and Group Policy.
 
 ![Windows2](exploit-protection-guard.png)
-  


### PR DESCRIPTION
This updates the DMalloc library reference in the C-Based Toolchain Hardening Cheat Sheet to use HTTPS.

No content or example changes are introduced.

Fixes #1964

