### PR TITLE
Remove references to unsupported or outdated third-party security tools

### DIFF
--- a/cheatsheets/Laravel_Cheat_Sheet.md
+++ b/cheatsheets/Laravel_Cheat_Sheet.md
@@ -6,8 +6,6 @@ This *Cheatsheet* intends to provide security tips to developers building Larave
 
 The Laravel Framework provides in-built security features and is meant to be secure by default. However, it also provides additional flexibility for complex use cases. This means that developers unfamiliar with the inner workings of Laravel may fall into the trap of using complex features in a way that is not secure. This guide is meant to educate developers to avoid common pitfalls and develop Laravel applications in a secure manner.
 
-You may also refer the [Enlightn Security Documentation](https://www.laravel-enlightn.com/docs/security/), which highlights common vulnerabilities and good practices on securing Laravel applications.
-
 ## The Basics
 
 - Make sure your app is not in debug mode while in production. To turn off debug mode, set your `APP_DEBUG` environment variable to `false`:
@@ -26,7 +24,7 @@ php artisan key:generate
 
 - Set safe file and directory permissions on your Laravel application. In general, all Laravel directories should be setup with a max permission level of `775` and non-executable files with a max permission level of `664`. Executable files such as Artisan or deployment scripts should be provided with a max permission level of `775`.
 
-- Make sure your application does not have vulnerable dependencies. You can check this using the [Enlightn Security Checker](https://github.com/enlightn/security-checker).
+- Make sure your application does not have vulnerable dependencies.
 
 ## Cookie Security and Session Management
 
@@ -510,17 +508,9 @@ You should consider adding the following security headers to your web server or 
 
 For more information, refer the [OWASP secure headers project](https://owasp.org/www-project-secure-headers/).
 
-## Tools
-
-You should consider using [Enlightn](https://www.laravel-enlightn.com/), a static and dynamic analysis tool for Laravel applications that has over 45 automated security checks to identify potential security issues. There is both an open source version and a commercial version of Enlightn available. Enlightn includes an extensive 45 page documentation on security vulnerabilities and a great way to learn more on Laravel security is to just review its [documentation](https://www.laravel-enlightn.com/docs/security/).
-
-You should also use the [Enlightn Security Checker](https://github.com/enlightn/security-checker) or the [Local PHP Security Checker](https://github.com/fabpot/local-php-security-checker). Both of them are open source packages, licensed under the MIT and AGPL licenses respectively, that scan your PHP dependencies for known vulnerabilities using the [Security Advisories Database](https://github.com/FriendsOfPHP/security-advisories).
-
 ## References
 
 - [Laravel Documentation on Authentication](https://laravel.com/docs/authentication)
 - [Laravel Documentation on Authorization](https://laravel.com/docs/authorization)
 - [Laravel Documentation on CSRF](https://laravel.com/docs/csrf)
 - [Laravel Documentation on Validation](https://laravel.com/docs/validation)
-- [Enlightn SAST and DAST Tool](https://www.laravel-enlightn.com/)
-- [Laravel Enlightn Security Documentation](https://www.laravel-enlightn.com/docs/security/)

--- a/cheatsheets/Symfony_Cheat_Sheet.md
+++ b/cheatsheets/Symfony_Cheat_Sheet.md
@@ -371,12 +371,6 @@ To use Security Checker run the following command using [Symfony CLI](https://gi
 symfony check:security
 ```
 
-You should also consider similar tools:
-
-- [Local PHP Security Checker](https://github.com/fabpot/local-php-security-checker)
-
-- [Enlightn Security Checker](https://github.com/enlightn/security-checker)
-
 ### Cross-Origin Resource Sharing (CORS)
 
 CORS is a security feature implemented in web browsers to control how web applications in one domain can request and interact with resources hosted on other domains.


### PR DESCRIPTION
## Description

This Pull Request removes references to third-party security tools that are no longer supported or maintained from the relevant cheat sheets.

The following tools have been removed due to a lack of ongoing support and maintenance:

- [Local PHP Security Checker](https://github.com/fabpot/local-php-security-checker) 
- [Enlightn Security Checker](https://github.com/enlightn/enlightn)

The objective is to keep the OWASP Cheat Sheet Series accurate, up to date, and aligned with currently supported security tooling.

## AI Tool Usage Disclosure (required for all PRs)
Please select one of the following options: 
- [x] I have NOT used any AI tool to generate the contents of this PR.
- [ ] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is [llm name and version] and the prompt used is [your prompt here]. [Feel free to add more details if needed] 

 Thank you again for your contribution :smiley: