### PR TITLE
Improve clarity of logged security events

### DIFF
--- a/cheatsheets/Logging_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Cheat_Sheet.md
@@ -96,10 +96,6 @@ Where possible, always log:
 - Input validation failures e.g. protocol violations, unacceptable encodings, invalid parameter names and values
     - A specific event for failures to validate a value against a discrete and finite list of valid values (e.g. a country from a dropdown). This is a high security event as it can only be attack activity. For example `input_validation_fail[:field,userid]`.
 - Output validation failures e.g. database record set mismatch, invalid data encoding
-These events help developers detect suspicious behavior and investigate security incidents early.
-
-Authentication successes and failures (for example, successful logins and invalid password attempts)
-Authorization (access control) failures (such as attempts to access restricted resources without permission)
 
 - Session management failures e.g. cookie session identification value modification or suspicious JWT validation failures
 - Application errors and system events e.g. syntax and runtime errors, connectivity problems, performance issues, third party service error messages, file system errors, file upload virus detection, configuration changes


### PR DESCRIPTION
This pull request improves clarity in the Logging Cheat Sheet by adding simple examples to existing security event recommendations, making them easier for developers to understand.

- Single-file documentation change
- No new sections added
