### PR TITLE
Fix broken reference links in XS_Leaks_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/XS_Leaks_Cheat_Sheet.md
+++ b/cheatsheets/XS_Leaks_Cheat_Sheet.md
@@ -309,11 +309,11 @@ You can disable the cache mechanism if you accept the degraded performance relat
 ### XS Leaks
 
 - [XS Leaks Wiki](https://xsleaks.dev/)
-- [XS Leaks Attacks & Prevention](https://www.appsecmonkey.com/blog/xs-leaks)
+- [XS Leaks Attacks & Prevention](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/XS-Leaks)
 
 ### Fetch Metadata
 
-- [Fetch Metadata and Isolation Policies](https://www.appsecmonkey.com/blog/fetch-metadata)
+- [Fetch Metadata and Isolation Policies](https://xsleaks.dev/docs/defenses/isolation-policies/)
 - [Protect your resources from attacks with Fetch Metadata](https://web.dev/fetch-metadata/)
 
 ### Framing protection


### PR DESCRIPTION
**Description**

This PR fixes broken reference links in the XS Leaks Cheat Sheet.

Two reference links under the References section were no longer accessible and consistently resulted in a "site can't be reached" error.

Changes made:
-Replaced the broken "XS Leaks Attacks & Prevention" and  "Fetch Metadata and Isolation Policies" reference links with active and relevant resources.

This PR fixes issue #1994 .