### PR TITLE
Clarify Apache Header always vs onsuccess behavior to prevent duplication (#2008)

### DIFF
--- a/cheatsheets/HTTP_Headers_Cheat_Sheet.md
+++ b/cheatsheets/HTTP_Headers_Cheat_Sheet.md
@@ -300,11 +300,20 @@ header("X-Frame-Options: DENY");
 
 ### Apache
 
-Below is an `.htaccess` sample configuration which sets the `X-Frame-Options` header in Apache. Note that without the `always` option, the header will only be sent for certain status codes, as described in [the Apache documentation](https://httpd.apache.org/docs/2.4/mod/mod_headers.html#header).
+Below is an `.htaccess` sample configuration which sets the `X-Frame-Options` header in Apache.
+
+As described in the [Apache documentation](https://httpd.apache.org/docs/2.4/mod/mod_headers.html#header), `Header set` (default `onsuccess`) and `Header always set` operate on separate internal header tables.
+
+In some cases, both header tables may be used, which can result in duplicate headers if the same header is configured in both contexts.
+
+If a header needs to be removed entirely, it should be unset in both contexts (`onsuccess` and `always`).
+
+To avoid duplication and ensure the header is sent on all responses, unset it first and then use `always set`:
 
 ```lang-bsh
 <IfModule mod_headers.c>
-Header always set X-Frame-Options "DENY"
+  Header unset X-Frame-Options
+  Header always set X-Frame-Options "DENY"
 </IfModule>
 ```
 


### PR DESCRIPTION
## Summary

This PR clarifies the behavior of `Header set` (default `onsuccess`) and `Header always set` in Apache `mod_headers`.

Previously, the section mentioned the `always` option but did not explain that it operates on a separate internal header table. On 2xx responses, both `onsuccess` and `always` directives may apply, which can result in duplicate headers if the same header is configured in both contexts.

This update:
- Adds a short clarification about the separation of header tables.
- Warns about potential header duplication.
- Recommends a safe configuration pattern using `Header unset` before `Header always set`.

The goal is to prevent misconfiguration while keeping the guidance concise and practical.

This PR fixes issue #2008.

---

## AI Tool Usage Disclosure

- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `ChatGPT (GPT-5.2)` and the prompt used was assistance in clarifying Apache mod_headers behavior and improving documentation wording.