### PR TITLE
Remove link to the now removed ASVS 4.0 index

### DIFF
--- a/IndexASVS.md
+++ b/IndexASVS.md
@@ -105,7 +105,7 @@
 
 The objective of this index is to help an OWASP [Application Security Verification Standard](https://owasp.org/www-project-application-security-verification-standard/) (ASVS) user clearly identify which cheat sheets are useful for each section during his or her usage of the ASVS.
 
-This index is based on the version 5.0.x of the ASVS. For ASVS 4.0.x, please go to the [DEPRECATED: ASVS 4.0 Index](IndexASVS4.m).
+This index is based on the version 5.0.x of the ASVS.
 
 ## V1: Encoding and Sanitization
 


### PR DESCRIPTION
Remove link to the now removed ASVS 4.0 index

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [x] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).


## AI Tool Usage Disclosure (required for all PRs)

Please select one of the following options:

- [x] I have NOT used any AI tool to generate the contents of this PR.
- [ ] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `[llm name and version]`
    and the prompt used is `[your prompt here]`. [Feel free to add more details if needed]

Thank you again for your contribution :smiley:
