### PR TITLE
Improve guidance for passkey implementations in Authentication Cheat …

### DIFF
--- a/cheatsheets/Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Authentication_Cheat_Sheet.md
@@ -245,11 +245,11 @@ Error disclosure can also be used as a discrepancy factor, consult the [error ha
 
 There are a number of different types of automated attacks that attackers can use to try and compromise user accounts. The most common types are listed below:
 
-| Attack Type | Description |
-|-------------|-------------|
-| Brute Force | Testing multiple passwords from a dictionary or other source against a single account. |
-| Credential Stuffing | Testing username/password pairs obtained from the breach of another site. |
-| Password Spraying | Testing a single weak password against a large number of different accounts.|
+| Attack Type         | Description                                                                                      |
+|---------------------|--------------------------------------------------------------------------------------------------|
+| Brute Force         | Testing multiple passwords from a dictionary or other source against a single account.           |
+| Credential Stuffing | Testing username/password pairs obtained from the breach of another site.                        |
+| Password Spraying   | Testing a single weak password against a large number of different accounts.                     |
 
 Different protection mechanisms can be implemented to protect against these attacks. In many cases, these defenses do not provide complete protection, but when a number of them are implemented in a defense-in-depth approach, a reasonable level of protection can be achieved.
 
@@ -346,7 +346,6 @@ U2F augments password-based authentication using a hardware token (typically USB
 Developers implementing passkeys should rely on well-maintained WebAuthn libraries or platform APIs instead of attempting to implement authentication logic manually. Using mature libraries helps ensure correct handling of cryptographic operations, token validation, and browser compatibility across platforms.
 
 See also: [Web Authentication API (WebAuthn)](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API).
-
 
 ## Password Managers
 

--- a/cheatsheets/Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Authentication_Cheat_Sheet.md
@@ -341,11 +341,13 @@ UAF takes advantage of existing security technologies present on devices for aut
 
 U2F augments password-based authentication using a hardware token (typically USB) that stores cryptographic authentication keys and uses them for signing. The user can use the same token as a second factor for multiple applications. U2F works with web applications. It provides **protection against phishing** by using the URL of the website to look up the stored authentication key.
 
-**FIDO2**: FIDO2 and WebAuthn, encompassing previous standards (UAF/U2F), form the foundation of modern **Passkeys** technology. Passkeys enable users to securely log in using local user verification (such as biometrics or device PINs) and often supporting cloud synchronization across devices. This technology is widely supported by major platforms (Windows Hello/Mac Touch ID).
+**FIDO2**: FIDO2 and WebAuthn, encompassing previous standards (UAF/U2F), form the foundation of modern **Passkeys** technology. Passkeys enable users to securely log in using local user verification (such as biometrics or device PINs), often with credential synchronization across devices.
 
-Developers implementing passkeys should rely on well-maintained WebAuthn libraries or platform APIs instead of attempting to implement authentication logic manually. Using mature libraries helps ensure correct handling of cryptographic operations, token validation, and browser compatibility across platforms.
+#### Hardware-backed Key Storage
 
-See also: [Web Authentication API (WebAuthn)](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API).
+For platform passkeys, the private key is generated and stored by the operating system's secure key manager. Modern platforms typically provide hardware-backed protection for these keys, such as the Trusted Platform Module (TPM) on Windows, Secure Enclave on Apple devices, or the Android Keystore/StrongBox on Android.
+
+The private key is non-exportable and remains on the user’s device. During authentication, the platform security module signs a server challenge using this key. This hardware-backed protection of private keys is a core security property of passkeys and WebAuthn.
 
 ## Password Managers
 

--- a/cheatsheets/Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Authentication_Cheat_Sheet.md
@@ -341,7 +341,12 @@ UAF takes advantage of existing security technologies present on devices for aut
 
 U2F augments password-based authentication using a hardware token (typically USB) that stores cryptographic authentication keys and uses them for signing. The user can use the same token as a second factor for multiple applications. U2F works with web applications. It provides **protection against phishing** by using the URL of the website to look up the stored authentication key.
 
-**FIDO2**: FIDO2 and WebAuthn, encompassing previous standards (UAF/U2F), form the foundation of modern **Passkeys** technology. Passkeys enable users to securely log in using local user verification (such as biometrics or device PINs) and often supporting cloud synchronization across devices. This technology is widely supported by major platforms. (Windows Hello/Mac Touch ID)
+**FIDO2**: FIDO2 and WebAuthn, encompassing previous standards (UAF/U2F), form the foundation of modern **Passkeys** technology. Passkeys enable users to securely log in using local user verification (such as biometrics or device PINs) and often supporting cloud synchronization across devices. This technology is widely supported by major platforms (Windows Hello/Mac Touch ID).
+
+Developers implementing passkeys should rely on well-maintained WebAuthn libraries or platform APIs instead of attempting to implement authentication logic manually. Using mature libraries helps ensure correct handling of cryptographic operations, token validation, and browser compatibility across platforms.
+
+See also: [Web Authentication API (WebAuthn)](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API).
+
 
 ## Password Managers
 

--- a/cheatsheets/Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Authentication_Cheat_Sheet.md
@@ -345,9 +345,9 @@ U2F augments password-based authentication using a hardware token (typically USB
 
 #### Hardware-backed Key Storage
 
-For platform passkeys, the private key is generated and stored by the operating system's secure key manager. Modern platforms typically provide hardware-backed protection for these keys, such as the Trusted Platform Module (TPM) on Windows, Secure Enclave on Apple devices, or the Android Keystore/StrongBox on Android.
+For many authenticators, including common platform passkeys, the private key is generated and stored by the operating system's secure key manager. Depending on the platform and authenticator, keys may be protected using hardware-backed components such as the Trusted Platform Module (TPM) on Windows, Secure Enclave on Apple devices, or the Android Keystore/StrongBox on Android, or by other software-based mechanisms.
 
-The private key is non-exportable and remains on the user’s device. During authentication, the platform security module signs a server challenge using this key. This hardware-backed protection of private keys is a core security property of passkeys and WebAuthn.
+In typical implementations, the private key is intended to be non-exportable and bound to the authenticator, and the platform security module signs a server challenge using this key. However, some authenticators support credential synchronization or backup that may involve export or server-side storage, and not all implementations are hardware-backed. Relying parties should not assume that keys are hardware-backed and non-exportable unless this is verified (for example, via authenticator properties or attestation).
 
 ## Password Managers
 


### PR DESCRIPTION
# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the Cheat Sheet template.
- [x] All the markdown files do not raise any validation policy violation, see the policy.
- [x] All the markdown files follow these format rules.
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status here.

## Description

This PR improves the guidance in the **FIDO2 / Passkeys** section of the Authentication Cheat Sheet by recommending the use of well-maintained WebAuthn libraries or platform APIs instead of implementing authentication logic manually.

A reference link to the Web Authentication API (WebAuthn) documentation was also added to provide developers with an authoritative resource for implementing passkey-based authentication securely.

## AI Tool Usage Disclosure (required for all PRs)

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to assist with drafting and formatting this contribution. The contents were reviewed and validated before submission.

Thank you again for your contribution :smiley: