### PR TITLE
docs: fix truncated OpenID 2.0 migration URL in OIDC section

### DIFF
--- a/cheatsheets/Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Authentication_Cheat_Sheet.md
@@ -321,7 +321,7 @@ OAuth is an **authorization** framework for delegated access to APIs. See also: 
 - Prefer **well-maintained libraries/SDKs** and provider discovery/JWKS endpoints.
 - Use the **UserInfo** endpoint when additional claims beyond the ID Token are required.
 
-> **Avoid confusion:** **OpenID 2.0 ("OpenID")** was a separate, legacy authentication protocol that has been **superseded by OpenID Connect** and is considered obsolete. New systems should not implement OpenID 2.0. References: [OpenID Foundation — obsolete OpenID 2.0 libraries](https://openid.net/developers/libraries-for-obsolete-specifications/), [OpenID 2.0 → OIDC migration](https://openid.net/specs/ope)
+> **Avoid confusion:** **OpenID 2.0 ("OpenID")** was a separate, legacy authentication protocol that has been **superseded by OpenID Connect** and is considered obsolete. New systems should not implement OpenID 2.0. References: [OpenID Foundation — obsolete OpenID 2.0 libraries](https://openid.net/developers/libraries-for-obsolete-specifications/), [OpenID 2.0 → OIDC migration](https://openid.net/specs/openid-connect-migration-1_0.html)
 
 ### SAML
 


### PR DESCRIPTION
The link for [OpenID 2.0 → OIDC migration] pointed to a truncated URL
(`https://openid.net/specs/ope`) that results in a 404 error.

Updated to the correct Final Specification URL:
`https://openid.net/specs/openid-connect-migration-1_0.html`

- [x] All the markdown files do not raise any validation policy violation
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution

- [x] I have NOT used any AI tool to generate the contents of this PR.

Thank you again for your contribution :smiley: