### PR TITLE
chore: add Claude Code config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ news.xml
 package-lock.json
 yarn.lock
 venv
+# Claude Code
+CLAUDE.md
+.claude/


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` and `.claude/` to .gitignore so local editor config doesn't get committed to the repo