### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publishing-check.yml
+++ b/.github/workflows/publishing-check.yml
@@ -2,6 +2,9 @@ name: Build website
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build website


### PR DESCRIPTION
Fix for [https://github.com/OWASP/CheatSheetSeries/security/code-scanning/5](https://github.com/OWASP/CheatSheetSeries/security/code-scanning/5)

To fix this, explicitly define a minimal `permissions:` block so that the `GITHUB_TOKEN` used in this workflow is restricted to read-only repository contents. Since the single job `build` only clones the repo and runs local build commands, it does not need any write permissions or access to issues, pull requests, or other scopes.

The best fix, without changing existing functionality, is to add a workflow-level `permissions:` block (applies to all jobs) right below the `on:` section. Set `contents: read`, which is sufficient for `actions/checkout@v4` and does not grant write access. No other scopes appear necessary from the provided code.

Concretely, in `.github/workflows/publishing-check.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 3 (`on: [push, pull_request]`). No imports or additional methods are needed, as this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
