### PR TITLE
Add Cache-Control guidance for secure handling of sensitive content

### DIFF
--- a/cheatsheets/HTTP_Headers_Cheat_Sheet.md
+++ b/cheatsheets/HTTP_Headers_Cheat_Sheet.md
@@ -75,21 +75,22 @@ Although it is recommended to always set the `Content-Type` header correctly, it
 - *NOTE:* the `charset` attribute is necessary to prevent XSS in **HTML** pages
 - *NOTE*: the `Content-Type` can be any of the possible [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
 
-## Cache-Control
+### Cache-Control
 
 The `Cache-Control` header defines how responses are cached by browsers and intermediate caches.
 
-### Recommendation
+#### Recommendation
 
-- Use `no-store` for sensitive data to prevent any caching.
-- Use `private` to ensure responses are cached only in the user's browser and not in shared caches.
+- Use `no-store` for sensitive data to prevent any form of caching.
+- Use `private` to allow caching only in non-shared (user-specific) caches and to prevent storage in shared caches (note that private caches may still persist the response).
 - Avoid relying on default caching behavior for sensitive or protected content.
+- Be aware that `no-cache` does not prevent caching; it allows caches to store responses. It requires revalidation with the origin server before reuse.
 
-These directives help reduce the risk of sensitive data being stored or exposed through caching.
+These directives help reduce the risk of sensitive data being stored or exposed through caching, but use `no-store` when storage of sensitive data must be strictly prevented.
 
 ### References
 
-- http://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+- [MDN - Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
 
 ### Set-Cookie
 


### PR DESCRIPTION
This PR adds a new section for the Cache-Control header in the HTTP Headers cheat sheet.

It includes guidance on using no-store and private directives when handling sensitive or user-specific data, along with a reference to Mozilla documentation.

The goal is to improve clarity around caching-related security risks and make the cheat sheet more complete.

Closes #2086