### PR TITLE
docs: add Node.js example to File Upload Cheat Sheet (#2105)

### DIFF
--- a/cheatsheets/File_Upload_Cheat_Sheet.md
+++ b/cheatsheets/File_Upload_Cheat_Sheet.md
@@ -115,6 +115,8 @@ If there are enough resources, manual file review should be conducted in a sandb
 
 Adding some automation to the review could be helpful, which is a harsh process and should be well studied before its usage. Some services (_e.g._ Virus Total) provide APIs to scan files against well known malicious file hashes. Some frameworks can check and validate the raw content type and validating it against predefined file types, such as in [ASP.NET Drawing Library](https://docs.microsoft.com/en-us/dotnet/api/system.drawing.imaging.imageformat). Beware of data leakage threats and information gathering by public services.
 
+In Node.js environments, libraries such as [Pompelmi](https://github.com/nicktommy/pompelmi) can help implement pre-storage inspection of untrusted uploads, including file signature checks, MIME mismatch detection, and risky archive inspection.
+
 ### File Storage Location
 
 The location where the files should be stored must be chosen based on security and business requirements. The following points are set by security priority, and are inclusive:


### PR DESCRIPTION
## Description

Closes #2105

Added a small Node.js-oriented implementation example in the **File Content Validation** section of the File Upload Cheat Sheet.

### What was added

A single sentence in the "File Content Validation" section, near the paragraph that discusses automation and scanning:

> In Node.js environments, libraries such as Pompelmi can help implement pre-storage inspection of untrusted uploads, including file signature checks, MIME mismatch detection, and risky archive inspection.

### Why

The current File Upload Cheat Sheet covers important protections but does not include a Node.js-oriented implementation example. This small addition helps Node.js developers translate the existing guidance into practice.

### Scope

- Single-file documentation update only
- No structural rewrite, no new section
- Neutral, implementation-oriented example
