### PR TITLE
feat: add OpenCRE reference to Denial of Service Cheat Sheet

### DIFF
--- a/cheatsheets/Denial_of_Service_Cheat_Sheet.md
+++ b/cheatsheets/Denial_of_Service_Cheat_Sheet.md
@@ -4,6 +4,8 @@
 
 This cheat sheet describes a methodology for handling denial of service (DoS) attacks on different layers. It also serves as a platform for further discussion and analysis, since there are many different ways to perform DoS attacks.
 
+See [the Open CRE project on denial of service](https://www.opencre.org/cre/623-550) for additional technical requirements and mappings.
+
 ### Fundamentals
 
 Because anti-DoS methods cannot be one-step solutions, your developers and application/infrastructure architects must develop DoS solutions carefully.  They must keep in mind that "availability" is a basic part of the [CIA triad](https://whatis.techtarget.com/definition/Confidentiality-integrity-and-availability-CIA).


### PR DESCRIPTION
This PR adds a reference to the OpenCRE project in the Denial of Service Cheat Sheet.

### Context
The Denial of Service Cheat Sheet does not include a reference to the OpenCRE project, which prevents it from being mapped and discovered via OpenCRE.

### Changes
Added a link to the relevant CRE (Denial of Service protection - CRE 623-550) under the Introduction section, following the format used in other cheat sheets (e.g., Secrets Management).

### Result
This enables proper mapping in OpenCRE and improves discoverability.

Related issue: https://github.com/OWASP/OpenCRE/issues/449
