### PR TITLE
CSRF: expand SameSite limitations and clarify when it can stand alone

### DIFF
--- a/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
@@ -419,7 +419,27 @@ Set-Cookie: JSESSIONID=xxxxx; SameSite=Lax
 
 All modern desktop and mobile browsers support the `SameSite` attribute. The main exceptions are legacy browsers including Opera Mini (all versions), UC Browser for Android, and older mobile browsers (iOS Safari < 13.2, Android Browser < 97). To track the browsers implementing it and know how the attribute is used, refer to the following [service](https://caniuse.com/#feat=same-site-cookie-attribute). Chrome implemented `SameSite=Lax` as the default behavior in 2020, and Firefox and Edge have followed suit. Additionally, the `Secure` flag is required for cookies that are marked as `SameSite=None`.
 
-It is important to note that this attribute should be implemented as an additional layer _defense in depth_ concept. This attribute protects the user through the browsers supporting it, and it contains as well 2 ways to bypass it as mentioned in the following [section](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02#section-5.3.7.1). This attribute should not replace a CSRF Token. Instead, it should co-exist with that token to protect  the user in a more robust way.
+#### Limitations of SameSite
+
+`SameSite` is useful as a defense-in-depth control but it does not replace a proper CSRF defense in most deployments. Treat the following as known gaps when reasoning about how much protection it actually provides:
+
+- **`Lax` only blocks unsafe methods.** The default `Lax` behavior still allows the cookie on top-level navigations that use [safe methods](https://tools.ietf.org/html/rfc7231#section-4.2.1) (`GET`, `HEAD`, `OPTIONS`, `TRACE`). If any state-changing operation in the application is reachable via a `GET` request, `SameSite=Lax` will not stop it. This is the single most common way `SameSite`-based defenses fail in practice. Review every `GET` endpoint and ensure that none of them mutate server-side state.
+- **`SameSite` is scoped to the registrable domain, not the origin.** A cookie set on `app.example.com` with any `SameSite` value is still considered "same-site" when the request originates from `anything.example.com`. If your application shares a registrable domain with content you do not fully control (multi-tenant SaaS on a shared parent domain, subdomain-hosted user content, legacy subdomains, an acquired product running on the same parent domain, third-party services on subdomains), a vulnerability or malicious actor on any of those sibling hosts can issue requests that the browser will treat as same-site. This also amplifies the impact of [subdomain takeovers](Subdomain_Takeover_Prevention_Cheat_Sheet.md): an attacker who claims a dangling subdomain can issue requests that your `SameSite`-protected cookies will accompany.
+- **Top-level navigation and window-opening tricks.** An attacker who can get a victim to perform a top-level navigation or open a new window targeting your site (including through prerendering hints, `window.open`, or clicking a crafted link) can generate a request the browser treats as same-site. `SameSite=Strict` blocks most of these at the cost of breaking legitimate cross-site links into the app.
+- **Browser coverage is not universal.** While current mainstream browsers enforce `SameSite=Lax` by default, users on older browsers, embedded browsers, or non-mainstream clients may receive cookies that behave as if no `SameSite` value were set. Do not assume all traffic enjoys the protection.
+- **Client-side CSRF is unaffected.** `SameSite` operates on cross-site requests. It does not protect against client-side CSRF (see the earlier section on _Dealing with Client-Side CSRF Attacks_) where malicious input causes same-origin JavaScript in your own application to issue a state-changing request.
+
+##### When SameSite May Be Sufficient On Its Own
+
+In narrow deployments `SameSite` alone can provide a reasonable CSRF defense, provided every one of the following holds:
+
+- The application does not share a registrable domain with any host, subdomain, or service you do not fully control.
+- No `GET` (or other safe-method) endpoint in the application performs a state-changing action. All state changes require `POST`, `PUT`, `PATCH`, or `DELETE`.
+- The session cookie is set with `SameSite=Strict`, or `SameSite=Lax` combined with the `__Host-` prefix and a strict audit of every `GET` handler.
+- Origin or Referer verification (see below) is in place for defense in depth on state-changing endpoints.
+- You are comfortable excluding users whose browsers do not enforce `SameSite`, or you accept the residual risk that those users face.
+
+For any application that does not meet all of the above, `SameSite` should be treated as a defense-in-depth layer and combined with a CSRF token or a double-submit pattern rather than relied on alone.
 
 ### Using Standard Headers to Verify Origin
 


### PR DESCRIPTION
Addresses #1101

Replaces the short paragraph about "two ways to bypass" `SameSite` with practical guidance on the real-world gaps developers should know about, plus a narrow list of conditions under which `SameSite` can serve as a primary CSRF defense.

### What changed

In the **SameSite (Cookie Attribute)** section, after the existing intro and examples, the final paragraph was replaced with two new subsections:

**`#### Limitations of SameSite`** covers:

- `Lax` only blocks unsafe methods, so any state-changing `GET` endpoint is unprotected (the single most common failure in practice).
- `SameSite` is scoped to the registrable domain, not the origin. Sibling hosts and sub-domains you don't fully control can still issue same-site requests. This also amplifies the impact of subdomain takeovers (with a link to the Subdomain Takeover Prevention CS).
- Top-level navigation and window-opening tricks.
- Uneven browser coverage on legacy/embedded clients.
- `SameSite` does not protect against client-side CSRF.

**`##### When SameSite May Be Sufficient On Its Own`** gives the narrow set of conditions (no shared registrable domain, no state-changing safe-method endpoints, `Strict` or `Lax` + `__Host-` prefix, origin/referer check for defense in depth) under which teams can reasonably rely on `SameSite` without a token, per @jmanico's feedback in the issue discussion.

### Discussion context

@jmanico (core team) confirmed in the issue that the existing two-bypass paragraph was outdated and invited a PR: _"Would you like to give us a PR that addresses your points?"_ The issue author (@madelson) identified the two specific gaps that most deployments hit (shared registrable domain and state-changing GETs), and this PR codifies both plus the adjacent concerns into the cheat sheet.

### Scope

- Single file modified.
- No content removed beyond the outdated paragraph; the token-based recommendations elsewhere in the cheat sheet are unchanged.
- Pre-existing StackOverflow links flag as 403 under the link-checker due to bot detection; none of those are from this change.

### Checklist

- [x] `npm run lint-markdown` clean
- [x] `npm run lint-terminology` clean
- [x] No new dead links introduced
- [x] US English
- [x] Single file, architectural guidance, no code changes