### PR TITLE
Fix typo: plan text -> plain text

### DIFF
--- a/cheatsheets/Web_Service_Security_Cheat_Sheet.md
+++ b/cheatsheets/Web_Service_Security_Cheat_Sheet.md
@@ -20,7 +20,7 @@ Transport confidentiality protects against eavesdropping and man-in-the-middle a
 
 User authentication verifies the identity of the user or the system trying to connect to the service. Such authentication is usually a function of the container of the web service.
 
-**Rule**: If used, Basic Authentication must be conducted over [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security), but Basic Authentication is not recommended because it discloses secrets in plan text (base64 encoded) in HTTP Headers.
+**Rule**: If used, Basic Authentication must be conducted over [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security), but Basic Authentication is not recommended because it discloses secrets in plain text (base64 encoded) in HTTP Headers.
 
 **Rule**: Client Certificate Authentication using [Mutual-TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) is a common form of authentication that is recommended where appropriate. See: [Authentication Cheat Sheet](Authentication_Cheat_Sheet.md).
 


### PR DESCRIPTION
Closes #2102

One-character typo fix in the User Authentication section of the Web Service Security Cheat Sheet:

- Before: "discloses secrets in **plan** text (base64 encoded)"
- After: "discloses secrets in **plain** text (base64 encoded)"

No other changes.