### PR TITLE
Replace abandoned/hijacked deepfence tool references in Kubernetes CS

### DIFF
--- a/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
+++ b/cheatsheets/Kubernetes_Security_Cheat_Sheet.md
@@ -349,7 +349,7 @@ Learn more about webhook at <https://kubernetes.io/docs/reference/access-authn-a
 
 Since new vulnerabilities are always being discovered, you may not always know if your containers may have recently-disclosed vulnerabilities (CVEs) or outdated packages. To maintain a strong security posture, do regular production scanning of first-party containers (applications you have built and previously scanned) as well as third-party containers (which are sourced from trusted repository and vendors).
 
-Open Source projects such as [ThreatMapper](https://github.com/deepfence/ThreatMapper) can assist in identifying and prioritizing vulnerabilities.
+Open Source projects such as [Trivy](https://github.com/aquasecurity/trivy), [Grype](https://github.com/anchore/grype), and [Clair](https://github.com/quay/clair) can assist in identifying and prioritizing vulnerabilities.
 
 --
 
@@ -632,7 +632,7 @@ Also see the [Secrets Management](Secrets_Management_Cheat_Sheet.md) cheat sheet
 
 We strongly recommend that you review the secret material present on the container against the principle of 'least privilege' and assess the risk posed by a compromise.
 
-Remember that open-source tools such as [SecretScanner](https://github.com/deepfence/SecretScanner) and [ThreatMapper](https://github.com/deepfence/ThreatMapper) can scan container filesystems for sensitive resources, such as API tokens, passwords, and keys. Such resources would be accessible to any user who had access to the unencrypted container filesystem, whether during build, at rest in a registry or backup, or running.
+Remember that open-source tools such as [Trivy](https://github.com/aquasecurity/trivy) and [Gitleaks](https://github.com/gitleaks/gitleaks) can scan container filesystems for sensitive resources, such as API tokens, passwords, and keys. Such resources would be accessible to any user who had access to the unencrypted container filesystem, whether during build, at rest in a registry or backup, or running.
 
 ---
 


### PR DESCRIPTION
Closes #2106

The deepfence organization has been abandoned and the deepfence.io domain was hijacked in early 2026. See the upstream security advisory: https://github.com/deepfence/ThreatMapper/issues/2429 (title: "SECURITY ADVISORY: Project Abandoned & Official Domain (deepfence.io) Hijacked").

Three references in `cheatsheets/Kubernetes_Security_Cheat_Sheet.md` point to projects under that org and should no longer be recommended. This PR replaces each with a currently maintained alternative.

### Changes

1. **Implement continuous security vulnerability scanning** section: replaced the `ThreatMapper` reference with three actively maintained open-source image scanners:
   - [Trivy](https://github.com/aquasecurity/trivy) (Aqua Security)
   - [Grype](https://github.com/anchore/grype) (Anchore)
   - [Clair](https://github.com/quay/clair) (Quay / Red Hat)

2. **Finding exposed secrets** section: replaced `SecretScanner` and `ThreatMapper` with:
   - [Trivy](https://github.com/aquasecurity/trivy) (also does filesystem secret scanning)
   - [Gitleaks](https://github.com/gitleaks/gitleaks)

3. **Network traffic analysis** section: replaced the `deepfence/PacketStreamer` reference with [Cilium](https://github.com/cilium/cilium) (through its Hubble observability layer). Also updated the `kinvolk/inspektor-gadget` URL to its current location at `inspektor-gadget/inspektor-gadget`, since the kinvolk organisation was retired after the Microsoft acquisition.

### Notes

- Three related deepfence references in Docker_Security_Cheat_Sheet.md, Attack_Surface_Analysis_Cheat_Sheet.md, and Vulnerable_Dependency_Management_Cheat_Sheet.md are being addressed in separate PRs to keep each diff focused on a single file (per `CONTRIBUTING.md`).
- `npm run lint-markdown` and `npm run lint-terminology` both pass.