### PR TITLE
Fix duplicated 'the the' in Django CS

### DIFF
--- a/cheatsheets/Django_Security_Cheat_Sheet.md
+++ b/cheatsheets/Django_Security_Cheat_Sheet.md
@@ -152,7 +152,7 @@ For more details:
   </form>
   ```
 
-- For AJAX calls, the CSRF token for the request has to be extracted prior to being used in the the AJAX call.  
+- For AJAX calls, the CSRF token for the request has to be extracted prior to being used in the AJAX call.  
 - Additional recommendations and controls can be found at Django's [Cross Site Request Forgery protection](https://docs.djangoproject.com/en/5.2/ref/csrf/) documentation.
 
 ## Cross Site Scripting (XSS)


### PR DESCRIPTION
Removes a duplicated word in the Django Security Cheat Sheet CSRF section:

- Before: "prior to being used in **the the** AJAX call"
- After: "prior to being used in **the** AJAX call"

Per `CONTRIBUTING.md`, small typo fixes do not require an issue.