### PR TITLE
Replace abandoned deepfence tool references in Docker CS

### DIFF
--- a/cheatsheets/Docker_Security_Cheat_Sheet.md
+++ b/cheatsheets/Docker_Security_Cheat_Sheet.md
@@ -279,8 +279,8 @@ References:
 Container scanning tools are especially important as part of a successful security strategy. They can detect known vulnerabilities, secrets and misconfigurations in container images and provide a report of the findings with recommendations on how to fix them. Some examples of popular container scanning tools are:
 
 - Free
-    - [Clair](https://github.com/coreos/clair)
-    - [ThreatMapper](https://github.com/deepfence/ThreatMapper)
+    - [Clair](https://github.com/quay/clair)
+    - [Grype](https://github.com/anchore/grype)
     - [Trivy](https://github.com/aquasecurity/trivy)
 - Commercial
     - [Snyk](https://snyk.io/) **(open source and free option available)**
@@ -292,7 +292,8 @@ Container scanning tools are especially important as part of a successful securi
 To detect secrets in images:
 
 - [ggshield](https://github.com/GitGuardian/ggshield) **(open source and free option available)**
-- [SecretScanner](https://github.com/deepfence/SecretScanner) **(open source)**
+- [Gitleaks](https://github.com/gitleaks/gitleaks) **(open source)**
+- [TruffleHog](https://github.com/trufflesecurity/trufflehog) **(open source)**
 
 To detect misconfigurations in Kubernetes:
 


### PR DESCRIPTION
Companion to #2120. The deepfence organization has been abandoned and their domain hijacked; see the upstream security advisory: https://github.com/deepfence/ThreatMapper/issues/2429

Two references in `cheatsheets/Docker_Security_Cheat_Sheet.md` point to deepfence projects that should no longer be recommended.

### Changes

**Container scanning tools section**:

- Removed `[ThreatMapper](https://github.com/deepfence/ThreatMapper)` from the "Free" list.
- Added `[Grype](https://github.com/anchore/grype)` in its place.
- Updated the Clair link from the archived `github.com/coreos/clair` to its canonical current home `github.com/quay/clair` (Clair moved to the Quay project years ago; the old CoreOS repo is archived).

**Secret detection section**:

- Removed `[SecretScanner](https://github.com/deepfence/SecretScanner)`.
- Added `[Gitleaks](https://github.com/gitleaks/gitleaks)` and `[TruffleHog](https://github.com/trufflesecurity/trufflehog)`, which are the two most widely recommended open-source secret scanners today.

### Notes

- Single file, scope limited to replacing the deepfence references and fixing the related stale Clair URL.
- Related deepfence cleanups in Kubernetes, Attack Surface Analysis, and Vulnerable Dependency Management cheat sheets are in separate PRs.
- Lint clean.