### PR TITLE
Replace abandoned deepfence and weaveworks tooling references

### DIFF
--- a/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.md
+++ b/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.md
@@ -35,7 +35,7 @@ With this approach, you don't need to understand every endpoint in order to unde
 
 Microservice and Cloud Native applications are comprised of multiple smaller components, loosely coupled using APIs and independently scalable. When assessing the attack surface for applications of this architectural style, you should prioritize the components that are reachable from an attack source (e.g. external traffic from the Internet). Such components may be located behind tiers of proxies, load balancers and ingress controllers, and may auto-scale without warning.
 
-Open source tooling such as [Scope](https://github.com/weaveworks/scope) or [ThreatMapper](https://github.com/deepfence/ThreatMapper) assist in visualizing the attack surface.
+Open source tooling such as [Cilium Hubble](https://github.com/cilium/hubble) and [kubeshark](https://github.com/kubeshark/kubeshark) assist in visualizing the attack surface for Kubernetes and service-mesh deployments.
 
 ## Identifying and Mapping the Attack Surface
 


### PR DESCRIPTION
Companion to #2120 and #2122. Two references in `cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.md` point to projects that are no longer safe or maintained to recommend:

- **deepfence/ThreatMapper**: organisation abandoned and the deepfence.io domain hijacked in early 2026. See upstream security advisory https://github.com/deepfence/ThreatMapper/issues/2429
- **weaveworks/scope**: Weaveworks shut down in early 2024 and Scope is no longer actively maintained.

### Change

Replaced both with currently maintained alternatives for attack-surface visualisation in container and service-mesh environments:

- [Cilium Hubble](https://github.com/cilium/hubble) for eBPF-based network observability
- [kubeshark](https://github.com/kubeshark/kubeshark) for Kubernetes traffic viewing

### Notes

- Single line change, single file.
- Related deepfence cleanups in Kubernetes, Docker, and Vulnerable Dependency Management cheat sheets are in separate PRs.
- Lint clean.