### PR TITLE
Replace abandoned deepfence reference in Vulnerable Dependency Management CS

### DIFF
--- a/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
@@ -242,9 +242,12 @@ It's important to ensure, during the selection process of a vulnerable dependenc
         - Full support: NodeJS, JavaScript.
         - HTML report available via this [module](https://www.npmjs.com/package/npm-audit-html).
     - [OWASP Dependency Track](https://dependencytrack.org/) can be used to manage vulnerable dependencies across an organization.
-    - [ThreatMapper](https://github.com/deepfence/ThreatMapper)
-        - Full support: Base OS, Java, NodeJS, JavaScript, Ruby, Python
-        - Targets: Kubernetes (nodes and container), Docker (node and containers), Fargate (containers), Bare Metal/VM (Host and app)
+    - [Trivy](https://github.com/aquasecurity/trivy)
+        - Full support: Base OS, Java, NodeJS, JavaScript, Ruby, Python, Go, .NET, Rust, PHP, Dart, Swift
+        - Targets: Kubernetes (nodes and containers), Docker (nodes and containers), filesystem, Git repositories, cloud images
+    - [Grype](https://github.com/anchore/grype)
+        - Full support across mainstream language ecosystems with SBOM-driven scanning
+        - Targets: container images, filesystems, and SBOMs produced by [Syft](https://github.com/anchore/syft)
 - Commercial
     - [Snyk](https://snyk.io/) (open source and free option available):
         - [Full support](https://snyk.io/docs/) for many languages and package manager.


### PR DESCRIPTION
Companion to #2120, #2122, and #2123. The `ThreatMapper` reference in `cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md` is part of the same set of abandoned deepfence references flagged by the upstream security advisory: https://github.com/deepfence/ThreatMapper/issues/2429 (title: "SECURITY ADVISORY: Project Abandoned & Official Domain (deepfence.io) Hijacked").

### Change

Replaced the `ThreatMapper` entry in the "Free" dependency/vulnerability scanners list with two currently maintained tools that cover the same scope:

- [Trivy](https://github.com/aquasecurity/trivy) for container, filesystem, and Git-repo scanning across mainstream language ecosystems.
- [Grype](https://github.com/anchore/grype) for SBOM-driven vulnerability scanning, typically paired with [Syft](https://github.com/anchore/syft) for SBOM generation.

Kept the same bullet-list format as the rest of the section to minimise visual diff.

### Notes

- Single file, scope limited to the deepfence reference plus equivalent replacements.
- Related deepfence cleanups in Kubernetes (#2120), Docker (#2122), and Attack Surface Analysis (#2123) cheat sheets are in separate PRs.
- Lint clean.