### PR TITLE
LLM Prompt Injection: suggest established string-metric libraries (#1686)

### DIFF
--- a/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.md
@@ -193,6 +193,14 @@ class PromptInjectionFilter:
         return text[:10000]  # Limit length
 ```
 
+The `_is_similar_word` helper above is intentionally minimal and only catches anagram-style scrambles. For production deployments, prefer an established [string metric](https://en.wikipedia.org/wiki/String_metric) library so the detector covers a wider range of obfuscations:
+
+- **Levenshtein / Damerau-Levenshtein distance**: catches insertions, deletions, substitutions, and (Damerau variant) adjacent transpositions. Threshold of `1` or `2` over short keywords reliably catches typoglycemia variants and common typos. Available in `python-Levenshtein`, `rapidfuzz`, Java `apache-commons-text`, and Go `agnivade/levenshtein`.
+- **Jaro-Winkler similarity**: weights matching prefixes higher, useful when the attacker preserves the start of a token. Common in record-linkage libraries.
+- **Phonetic algorithms (Soundex, Metaphone, NYSIIS)**: catch homophone-style obfuscations but are English-biased; combine with one of the above rather than using alone.
+
+Pick the algorithm that matches the obfuscation classes in your threat model, set a strict similarity threshold, and pre-compute it against the keyword list at startup so per-request cost stays bounded.
+
 ### Structured Prompts with Clear Separation
 
 Use structured formats that clearly separate instructions from user data. See [StruQ research](https://arxiv.org/abs/2402.06363) for the foundational approach to structured queries.


### PR DESCRIPTION
Closes #1686.

## What this changes

Adds a short paragraph immediately after the `PromptInjectionFilter` example in the **Input Validation and Sanitization** section, pointing readers to standard string-metric libraries (Levenshtein/Damerau-Levenshtein, Jaro-Winkler, Soundex/Metaphone) as the production-grade alternative to the cheat sheet's minimal `_is_similar_word` helper. Existing code stays as a teaching example.

## How it maps to the thread

The discussion converged on @kwwall's suggestion:

> we shouldn't just go inventing our own as others are likely to be more complete. I did a [...] search and the first thing I discovered is what I think we are looking for here is an area of Computer Science called "string metric"

and @Prasad-JB's wrap:

> Maybe the cheatsheet could briefly list these common approaches (Levenshtein, Hamming, Jaro-Winkler, etc.) with a short note on their pros/cons, and then point readers to external references for deeper dives.

This PR does exactly that: brief list, short pros/cons, link to the [string metric Wikipedia article](https://en.wikipedia.org/wiki/String_metric) as the external reference.

## Scope

- One file modified: `cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.md`
- 8 lines added, no removals
- Architectural guidance, no code blocks (per @kwwall's "list it as a suggestion rather than trying to write it as code")
- Mentions concrete library names per ecosystem so readers don't have to do the search themselves

## Linting

- `npm run lint-markdown` — clean
- `npm run lint-terminology` — clean