### PR TITLE
LLM Prompt Injection: add Model-Based Guardrails subsection (#2135)

### DIFF
--- a/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.md
@@ -323,6 +323,25 @@ For LLM agents with tool access:
 - Monitor for encoding attempts and HTML injection
 - Track agent reasoning patterns and tool usage
 
+### Model-Based Guardrails
+
+A separate model can act as a filter on the inputs and outputs of the primary LLM. This is sometimes called the "LLM-as-judge" or "guardrail model" pattern, and it sits alongside the deterministic controls described above, not in place of them. Open guardrail models include Llama Guard, ShieldGemma, IBM Granite Guardian, and Prompt Guard. NVIDIA NeMo Guardrails provides a framework for orchestrating these checks within an application.
+
+There are three useful placements:
+
+- **Input screening.** Run user prompts and any retrieved or fetched context (RAG documents, tool output, web pages, email bodies) through a classifier before the primary model sees them. Pattern-based filters do not reliably catch indirect injection in untrusted content; a model trained for this task will catch cases that regex misses.
+- **Output screening.** Score the primary model's response against a policy before it is returned to the user or passed to a downstream tool. This is where successful injections that produced system prompt leakage, exfiltration markup, or policy-violating content can be caught after the fact.
+- **Action screening.** For agent systems, evaluate each proposed tool call against the original user intent. A guardrail that sees only the user's task and the action the agent wants to take, without the untrusted intermediate context, will refuse actions that drifted because of an injected instruction.
+
+The strongest architectural form of this idea is the **dual-LLM pattern**, [described by Simon Willison](https://simonwillison.net/2023/Apr/25/dual-llm-pattern/). A privileged LLM holds the tools but never reads untrusted content directly. A quarantined LLM reads untrusted content but cannot take action. The privileged model receives only structured summaries or labels from the quarantined one, which breaks the path that injected instructions need to reach the actor.
+
+**Caveats:**
+
+- A guardrail LLM is itself an LLM and is itself susceptible to prompt injection. Treat it as one layer in a defense-in-depth design, not as a replacement for input validation, structured prompts, least-privilege tool scopes, or human approval on destructive actions.
+- The guardrail should have a different attack surface than the primary model. A purpose-trained classifier is preferable to a general-purpose chat model from the same family, because the same jailbreak that defeats the primary model is more likely to defeat a guardrail that shares its training and prompt format.
+- Each guardrail call adds latency and cost. Reserve heavier checks for higher-risk paths (tool invocations, ingestion of external content, sensitive output) and rely on cheaper deterministic checks for routine traffic.
+- Log every guardrail decision and watch for drift. Sudden changes in the approval rate, or in the distribution of refusal reasons, often precede a working bypass.
+
 ## Secure Implementation Pipeline
 
 ```python


### PR DESCRIPTION
Closes #2135.

## What this changes

Adds a new **Model-Based Guardrails** subsection at the end of the **Additional Defenses** section in the LLM Prompt Injection Prevention Cheat Sheet. Existing content is untouched.

## Why

The cheat sheet's existing defenses are entirely deterministic: regex, structured prompts, output regex monitoring, HITL, rate limiting. Pattern matching does not reliably catch indirect injection in RAG content, tool output, fetched web pages, or email bodies, which is the case where model-based guardrails actually earn their keep. The word "guardrail" appeared three times in the sheet before this change, but only as a passing mention and two outbound links. There was no architectural discussion of LLM-as-judge, output moderation models, or the dual-LLM pattern, despite how widely deployed these patterns now are.

## What the new section covers

- The three useful placements: input screening, output screening, and action screening for agents
- The dual-LLM pattern as the strongest architectural form, with a reference to Simon Willison's original writeup
- Concrete projects to point readers at: Llama Guard, ShieldGemma, IBM Granite Guardian, Prompt Guard, NVIDIA NeMo Guardrails
- Explicit caveats: guardrail LLMs are themselves injection-prone, the guardrail should not share an attack surface with the primary model, latency and cost compound, and guardrail decisions should be logged and monitored for drift
