### PR TITLE
Remove duplicate AI agent risk entry

### DIFF
--- a/cheatsheets/AI_Agent_Security_Cheat_Sheet.md
+++ b/cheatsheets/AI_Agent_Security_Cheat_Sheet.md
@@ -17,7 +17,6 @@ AI agents are autonomous systems powered by Large Language Models (LLMs) that ca
 - **Denial of Wallet (DoW)**: Attacks causing excessive API/compute costs through unbounded agent loops.
 - **Sensitive Data Exposure**: PII, credentials, or confidential data inadvertently included in agent context or logs.
 - **Supply Chain Attacks**: Compromising third-party tools, APIs, or data sources used by agents.
-- **AI Console Malicious Configuration**: Malicious input consumed by the underlying AAL that prompts a change in the configuration of a poorly protected developer console.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

Removes a duplicate `AI Console Malicious Configuration` entry from the Key Risks section of the AI Agent Security Cheat Sheet.

The clearer existing entry remains in place, so the risk is still covered without repeating the same heading.

## Verification

- `git diff --check`