### PR TITLE
Add AI Model Ops resource controls

### DIFF
--- a/cheatsheets/Secure_AI_Model_Ops_Cheat_Sheet.md
+++ b/cheatsheets/Secure_AI_Model_Ops_Cheat_Sheet.md
@@ -67,6 +67,10 @@ Orphaned Deployments – Test or deprecated models left accessible in production
 - Validate and sanitize all inputs.
 - Use rate limiting and abuse detection (e.g. bot detection, anomaly scoring).
 - Use structured prompt templates for LLMs to separate instructions from user input.
+- Set per-tenant token, request, concurrency, and spend limits to reduce denial-of-wallet risk.
+- Enforce recursion, retry, and chain-depth limits for agentic or tool-using inference flows.
+- Implement circuit breakers or kill switches for abnormal cost, latency, or tool-call spikes.
+- Monitor usage telemetry in near real time and alert on sudden changes in tokens, requests, or spend.
 
 ### 5. Deployment & Infrastructure
 


### PR DESCRIPTION
## Summary

Expands the Secure AI/ML Model Ops Cheat Sheet's Inference API Security guidance with concise resource-control recommendations for denial-of-wallet and unbounded-consumption risks.

This adds guidance for:

- per-tenant token, request, concurrency, and spend limits
- recursion, retry, and chain-depth limits
- circuit breakers or kill switches for abnormal cost or tool-call spikes
- near-real-time usage telemetry and alerts

Addresses part of #1781.

## Verification

- `git diff --check`