### PR TITLE
Fix stray backtick in SQL Injection cheat sheet code example

### DIFF
--- a/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md
@@ -177,7 +177,7 @@ For example:
 
 ```java
 public String someMethod(boolean sortOrder) {
- String SQLquery = "some SQL ... order by Salary " + (sortOrder ? "ASC" : "DESC");`
+ String SQLquery = "some SQL ... order by Salary " + (sortOrder ? "ASC" : "DESC");
  ...
 ```
 

--- a/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md
@@ -183,7 +183,7 @@ public String someMethod(boolean sortOrder) {
 
 Any time user input can be converted to a non-String, like a date, numeric, boolean, enumerated type, etc. before it is appended to a query, or used to select a value to append to the query, this ensures it is safe to do so.
 
-Input validation is also recommended as a secondary defense in ALL cases, even when using bind variables as discussed earlier in this article. More techniques on how to implement strong input validation is described in the [Input Validation Cheat Sheet](Input_Validation_Cheat_Sheet.md).
+Input validation is also recommended as a secondary defense in ALL cases, even when using bind variables as discussed earlier in this article. More techniques on how to implement strong input validation techniquies are described in the [Input Validation Cheat Sheet](Input_Validation_Cheat_Sheet.md).
 
 ### Defense Option 4: STRONGLY DISCOURAGED: Escaping All User-Supplied Input
 


### PR DESCRIPTION
This PR removes an extra backtick in a code example in the SQL Injection Prevention Cheat Sheet, fixing a formatting issue.

No functional changes were made.