### PR TITLE
New Cheat Sheet dealing with authorization policy dimensions and distribution

### DIFF
--- a/cheatsheets_draft/Authorization_Policy_Dimensions_And_Distribution_Cheat_Sheet.md
+++ b/cheatsheets_draft/Authorization_Policy_Dimensions_And_Distribution_Cheat_Sheet.md
@@ -2,7 +2,7 @@
 
 Before choosing an authorization pattern, you need to understand the context it must operate in. This Cheat Sheet introduces the key dimensions that characterize how policies are owned, how quickly they must take effect, and how they reach the Policy Decision Points (PDPs) that evaluate them. These dimensions directly influence which [Authorization Patterns](Authorization_Patterns_Cheat_Sheet.md) are suitable for your system — and which are not.
 
-> See also: *Cheat Sheet 5 – Authorization Data Dimensions, Distribution & Performance*
+> See also: *Authorization Data Dimensions, Distribution & Performance*
 
 ## Policy Characteristics
 
@@ -10,7 +10,6 @@ Policy characteristics define how authorization policies are authored, maintaine
 
 > **Don't confuse change latency with change frequency.**
 > Frequency describes how often policies are updated — this affects governance and authoring workflows. Latency describes how quickly an update must reach the PDPs once published. Both are independent dimensions and both influence architecture choices.
-
 
 ### Policy Ownership
 
@@ -50,11 +49,11 @@ Policy change latency requirements directly determine how policies must be deliv
 
 Policies are proactively pushed from the Policy Administration Point (PAP) to the PDP and stored locally for evaluation. This strategy suits policies that tend to have immediate to fast change latencies, requiring agile, incremental updates without disrupting service availability.
 
-**Pros**
+#### Pros
 
 - Enables dynamic policy updates without PDP redeployment, supporting high availability.
 
-**Cons**
+#### Cons
 
 - Requires robust synchronization mechanisms to deploy the correct versions of required policies to each PDP instance.
 - Demands governance controls to enforce ownership boundaries — e.g., microservice teams must only be able to update their own policies, while domain or central teams retain control over shared or organizational policies.
@@ -65,11 +64,11 @@ Policies are proactively pushed from the Policy Administration Point (PAP) to th
 
 Policies are embedded directly within the PDP (e.g., as code, or as static configuration) and cannot be updated without restarting or redeploying the PDP. Stability and operational simplicity are prioritized over agility.
 
-**Pros**
+#### Pros
 
 - Simplifies policy management, as policies are bundled with the PDP, and no external synchronization is needed.
 
-**Cons**
+#### Cons
 
 - Increases deployment overhead, as changes involve rebuilding and/or redeploying the PDP.
 - Limits scalability for needs with frequent policy adjustments.
@@ -79,21 +78,21 @@ Policies are embedded directly within the PDP (e.g., as code, or as static confi
 
 ## Operational Considerations
 
-| Dimension | Out-of-Band Delivered | Embedded |
-|---|---|---|
-| **Suitable latency** | Immediate, Fast | Delayed |
-| **Deployment overhead** | Low (no redeployment needed) | High (rebuild/redeploy per change) |
-| **Sync mechanism required** | Yes | No |
-| **Governance complexity** | Medium — ownership boundaries must be enforced at the distribution layer | Medium — deploying team implicitly controls policy activation |
-| **Scalability for frequent changes** | High | Low |
+| Dimension                            | Out-of-Band Delivered                                                    | Embedded                                                      |
+|--------------------------------------|--------------------------------------------------------------------------|---------------------------------------------------------------|
+| **Suitable latency**                 | Immediate, Fast                                                          | Delayed                                                       |
+| **Deployment overhead**              | Low (no redeployment needed)                                             | High (rebuild/redeploy per change)                            |
+| **Sync mechanism required**          | Yes                                                                      | No                                                            |
+| **Governance complexity**            | Medium — ownership boundaries must be enforced at the distribution layer | Medium — deploying team implicitly controls policy activation |
+| **Scalability for frequent changes** | High                                                                     | Low                                                           |
 
 ## Ownership × Latency × Distribution — Quick Reference
 
-| Ownership | Typical Change Latency | Recommended Distribution Strategy |
-|---|---|---|
-| Microservice Team | Immediate to Fast | Out-of-Band Delivered |
-| Domain Level | Fast | Out-of-Band Delivered |
-| Central (Org) | Fast to Delayed | Out-of-Band Delivered or Embedded |
+| Ownership         | Typical Change Latency | Recommended Distribution Strategy |
+|-------------------|------------------------|-----------------------------------|
+| Microservice Team | Immediate to Fast      | Out-of-Band Delivered             |
+| Domain Level      | Fast                   | Out-of-Band Delivered             |
+| Central (Org)     | Delayed                | Embedded                          |
 
 ## Security Considerations
 

--- a/cheatsheets_draft/Authorization_Policy_Dimensions_And_Distribution_Cheat_Sheet.md
+++ b/cheatsheets_draft/Authorization_Policy_Dimensions_And_Distribution_Cheat_Sheet.md
@@ -1,0 +1,106 @@
+# Authorization Policy Dimensions & Distribution
+
+Before choosing an authorization pattern, you need to understand the context it must operate in. This Cheat Sheet introduces the key dimensions that characterize how policies are owned, how quickly they must take effect, and how they reach the Policy Decision Points (PDPs) that evaluate them. These dimensions directly influence which [Authorization Patterns](Authorization_Patterns_Cheat_Sheet.md) are suitable for your system — and which are not.
+
+> See also: *Cheat Sheet 5 – Authorization Data Dimensions, Distribution & Performance*
+
+## Policy Characteristics
+
+Policy characteristics define how authorization policies are authored, maintained, and updated over time, influencing their management and distribution. Two key dimensions, **policy ownership** and **policy change latency**, guide these processes and are critical for operationalizing authorization systems.
+
+> **Don't confuse change latency with change frequency.**
+> Frequency describes how often policies are updated — this affects governance and authoring workflows. Latency describes how quickly an update must reach the PDPs once published. Both are independent dimensions and both influence architecture choices.
+
+
+### Policy Ownership
+
+Policy ownership identifies who is responsible for authoring and maintaining a given policy. It defines governance boundaries — determining who may create, modify, review, and deploy policies — and often indicates how composable or layered policies need to be.
+
+Three levels of ownership are common in distributed systems:
+
+- **Microservice Team:** Policies authored and maintained by the team responsible for a specific microservice. These are typically focused on local enforcement logic and closely tied to internal service semantics.
+  *Example:* A recommendation service defines request filters that exclude certain products based on internal scoring thresholds or active experiments.
+
+- **Domain Level:** Policies shared across services within a business domain, often requiring coordination between teams. These policies may be abstracted and reused across multiple services.
+  *Example:* A subscription domain enforces business rules about grace periods, usage limits, or billing thresholds that are referenced by billing, customer portal, and notification services.
+
+- **Central (Organization Level):** Policies governed by a central security, compliance, or platform team. These typically apply across domains or services and provide the foundation upon which more granular policies are built.
+  *Example:* An organizational policy defines acceptable data residency constraints or standard access conditions for administrative APIs.
+
+### Policy Change Latency
+
+Policy change latency describes how quickly a change must be reflected in the system once introduced. It should not be confused with the **frequency** of policy changes (how often they occur), or with **input data freshness** (how quickly attribute updates must be reflected in policy decisions). While policy change frequency influences governance and authoring processes, the latency defines how fast policies must be deployed and propagated across services to take effect.
+
+Three latency levels are common:
+
+- **Immediate:** Policies must take effect as soon as they are changed (seconds to minutes).
+  *Example:* A financial system introduces a temporary block on a specific payment method due to detected processing errors. The rule itself (block this method) must be enforced immediately across all services to prevent further transactions.
+
+- **Fast:** Policies should be effective within hours to days of being changed.
+  *Example:* A sales team requests an update to discount eligibility rules for enterprise customers. Once approved and authored, the new policy should be effective by the next business day.
+
+- **Delayed:** Policies can take effect on a longer timescale — weeks or more.
+  *Example:* A data retention policy update mandated by new legislation is scheduled for enforcement with the next release.
+
+## Policy Distribution Strategies
+
+Policy change latency requirements directly determine how policies must be delivered to PDPs. Two primary strategies exist, each with distinct trade-offs.
+
+### Out-of-Band Delivered Policies
+
+Policies are proactively pushed from the Policy Administration Point (PAP) to the PDP and stored locally for evaluation. This strategy suits policies that tend to have immediate to fast change latencies, requiring agile, incremental updates without disrupting service availability.
+
+**Pros**
+
+- Enables dynamic policy updates without PDP redeployment, supporting high availability.
+
+**Cons**
+
+- Requires robust synchronization mechanisms to deploy the correct versions of required policies to each PDP instance.
+- Demands governance controls to enforce ownership boundaries — e.g., microservice teams must only be able to update their own policies, while domain or central teams retain control over shared or organizational policies.
+
+> **Best fit:** Immediate and fast change latency requirements.
+
+### Embedded Policies
+
+Policies are embedded directly within the PDP (e.g., as code, or as static configuration) and cannot be updated without restarting or redeploying the PDP. Stability and operational simplicity are prioritized over agility.
+
+**Pros**
+
+- Simplifies policy management, as policies are bundled with the PDP, and no external synchronization is needed.
+
+**Cons**
+
+- Increases deployment overhead, as changes involve rebuilding and/or redeploying the PDP.
+- Limits scalability for needs with frequent policy adjustments.
+- Introduces governance challenges, since the team deploying the PDP effectively decides which policies get bundled and activated, even if those policies are owned by different teams or organizational units.
+
+> **Best fit:** Delayed change latency requirements.
+
+## Operational Considerations
+
+| Dimension | Out-of-Band Delivered | Embedded |
+|---|---|---|
+| **Suitable latency** | Immediate, Fast | Delayed |
+| **Deployment overhead** | Low (no redeployment needed) | High (rebuild/redeploy per change) |
+| **Sync mechanism required** | Yes | No |
+| **Governance complexity** | Medium — ownership boundaries must be enforced at the distribution layer | Medium — deploying team implicitly controls policy activation |
+| **Scalability for frequent changes** | High | Low |
+
+## Ownership × Latency × Distribution — Quick Reference
+
+| Ownership | Typical Change Latency | Recommended Distribution Strategy |
+|---|---|---|
+| Microservice Team | Immediate to Fast | Out-of-Band Delivered |
+| Domain Level | Fast | Out-of-Band Delivered |
+| Central (Org) | Fast to Delayed | Out-of-Band Delivered or Embedded |
+
+## Security Considerations
+
+Policy ownership and distribution are not purely operational concerns — they directly affect the security posture of the authorization system.
+
+**Governance gaps in out-of-band delivery** can allow teams to deploy policies beyond their ownership scope, effectively overriding organizational or domain-level rules. Distribution pipelines must enforce strict ownership boundaries and include policy review steps.
+
+**Governance gaps in embedded policies** are more subtle: because policies are bundled with the PDP at build time, the team performing the deployment determines what gets activated — regardless of who authored the policy. This risk increases in multi-team environments where central or domain-level policies coexist with service-specific ones.
+
+In both strategies, changes to policies should be subject to the same review and audit processes as changes to application code. Unreviewed policy changes — even well-intentioned ones — are a common source of broken access control vulnerabilities.


### PR DESCRIPTION
Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).


# Description 

This PR relates to #1980 and continues my series of cheat sheets related to the update/replacement of the Microservice Security Cheat Sheet. It builds on the accompanying [blog post series](https://www.innoq.com/en/blog/2025/07/whats-wrong-with-the-current-owasp-microservice-security-cheat-sheet/).

The content is taken from [part 6](https://www.innoq.com/en/blog/2025/08/owasp-microservice-security-cheat-sheet-update-decision-dimensions-for-authz-patterns/) of the series, but focuses exclusively on policy-related dimensions. Data-related dimensions will be addressed in a separate cheat sheet to keep both documents more focused and easier to digest.

Previous related PRs:
- #1746 
- #1808 
- #1809 

p.s. Sorry for making you wait for this update for so long.
