### PR TITLE
Harden PR config to deter low-effort/AI-slop contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,17 +15,23 @@ Please make sure that for your contribution:
 - [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
 - [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).
 
+## Scope and sourcing (required)
+
+- [ ] This PR is focused: it modifies a single cheat sheet, or a small coordinated set, and the scope is described in the PR body.
+- [ ] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source (RFC, NIST, OWASP standard, vendor documentation, peer-reviewed research) linked inline as `[text](URL)`.
+- [ ] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations.
+
 If your PR is related to an issue, please finish your PR text with the following line:
 
 This PR fixes issue #`<REPLACE WITH ISSUE NUMBER>`.
 
 ## AI Tool Usage Disclosure (required for all PRs)
 
-Please select one of the following options:
+Please select exactly one of the following options. PRs that leave this section blank will be closed.
 
 - [ ] I have NOT used any AI tool to generate the contents of this PR.
 - [ ] I have used AI tools to generate the contents of this PR. I have verified
     the contents and I affirm the results. The LLM used is `[llm name and version]`
-    and the prompt used is `[your prompt here]`. [Feel free to add more details if needed]
+    and the prompt used is `[your prompt here]`. I have independently verified every citation and technical claim against the cited source. [Feel free to add more details if needed]
 
 Thank you again for your contribution :smiley:

--- a/.github/workflows/citation-check.yml
+++ b/.github/workflows/citation-check.yml
@@ -1,0 +1,63 @@
+name: Citation Density Check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  citations:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify new H2 sections include at least one citation
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | grep -E '^cheatsheets/.+\.md$' || true)
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No published cheat sheets touched; skipping citation check."
+            exit 0
+          fi
+
+          fail=0
+
+          for f in "${files[@]}"; do
+            [ -f "$f" ] || continue
+
+            mapfile -t added_h2_lines < <(git diff -U0 "$BASE_SHA" "$HEAD_SHA" -- "$f" \
+              | grep -E '^\+## ' | sed 's/^+//' || true)
+
+            [ "${#added_h2_lines[@]}" -eq 0 ] && continue
+
+            for heading in "${added_h2_lines[@]}"; do
+              start=$(grep -nFx "$heading" "$f" | head -1 | cut -d: -f1 || true)
+              [ -z "$start" ] && continue
+
+              next=$(awk -v s="$start" 'NR>s && /^## / {print NR; exit}' "$f")
+              if [ -z "$next" ]; then
+                section=$(awk -v s="$start" 'NR>=s' "$f")
+              else
+                section=$(awk -v s="$start" -v e="$next" 'NR>=s && NR<e' "$f")
+              fi
+
+              if ! printf '%s' "$section" | grep -qE '\[[^]]+\]\(https?://[^)]+\)'; then
+                echo "::error file=$f::New H2 section '$heading' contains no inline citation ([text](https://...)). Cite a primary source (RFC, NIST, OWASP standard, vendor doc)."
+                fail=1
+              fi
+            done
+          done
+
+          exit "$fail"

--- a/.github/workflows/pr-scope-check.yml
+++ b/.github/workflows/pr-scope-check.yml
@@ -1,0 +1,61 @@
+name: PR Scope Check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  scope:
+    runs-on: ubuntu-24.04
+    env:
+      MAX_CHEATSHEETS_TOUCHED: 3
+      MAX_NET_ADDITIONS: 1500
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Evaluate PR scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          touched=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | grep -E '^cheatsheets(_draft)?/.+\.md$' \
+            | sort -u || true)
+          touched_count=$(printf '%s\n' "$touched" | grep -c . || true)
+
+          additions=$(git diff --numstat "$BASE_SHA" "$HEAD_SHA" \
+            | awk '$1 ~ /^[0-9]+$/ {a+=$1} END {print a+0}')
+          deletions=$(git diff --numstat "$BASE_SHA" "$HEAD_SHA" \
+            | awk '$2 ~ /^[0-9]+$/ {d+=$2} END {print d+0}')
+          net=$(( additions - deletions ))
+
+          echo "Cheat sheets touched: $touched_count"
+          printf '%s\n' "$touched"
+          echo "Net additions: $net (additions=$additions, deletions=$deletions)"
+
+          fail=0
+
+          if [ "$touched_count" -gt "$MAX_CHEATSHEETS_TOUCHED" ]; then
+            echo "::error::This PR modifies $touched_count cheat sheets (limit: $MAX_CHEATSHEETS_TOUCHED). Split into focused PRs, one cheat sheet or one coordinated set per PR."
+            fail=1
+          fi
+
+          if [ "$net" -gt "$MAX_NET_ADDITIONS" ]; then
+            if ! printf '%s' "$PR_BODY" | grep -qE '#[0-9]+'; then
+              echo "::error::Net additions ($net) exceed $MAX_NET_ADDITIONS lines and the PR body does not reference a tracking issue. Link an issue (e.g., 'Fixes #1234') that justifies the scope."
+              fail=1
+            fi
+          fi
+
+          exit "$fail"


### PR DESCRIPTION
## Summary

Three config-level (not policy) changes that raise the cost of low-effort and unverified-AI contributions, in response to #2172:

- **`.github/workflows/pr-scope-check.yml`** — fails a PR that touches more than 3 cheat sheets, or whose net additions exceed 1500 lines without a linked tracking issue. Bulk, multi-cheatsheet rewrites are the most common slop pattern; this turns them into a CI failure instead of a maintainer-review burden.
- **`.github/workflows/citation-check.yml`** — every newly added H2 section under `cheatsheets/` must include at least one inline `[text](https://...)` link. Forces sourced claims at the section level. Catches the "confidently-wrong unsourced advice" failure mode.
- **`.github/pull_request_template.md`** — adds a Scope and Sourcing block requiring focused scope, primary-source citations, and an attestation that the contributor read each source. Tightens the existing AI disclosure to require exactly one option and an explicit citation-verification claim.

Both workflows are pure shell + `git diff` — no external actions beyond `actions/checkout@v4`. Threshold envs (`MAX_CHEATSHEETS_TOUCHED`, `MAX_NET_ADDITIONS`) are at the top of the scope workflow and easy to tune.

## Companion changes for repo admins

These need API/UI changes, not a PR:

1. Turn on `required_conversation_resolution` on `master`:
   ```
   gh api -X PUT repos/OWASP/CheatSheetSeries/branches/master/protection/required_conversation_resolution
   ```
2. Turn on `require_last_push_approval` (closes the "approved-then-push-slop" pattern):
   ```
   gh api -X PATCH repos/OWASP/CheatSheetSeries/branches/master/protection/required_pull_request_reviews      -F require_last_push_approval=true
   ```
3. Add the new checks as required status checks once they have run once on `master`.

A separate issue will track expanding CODEOWNERS coverage and discussing an LLM-slop pattern linter.

## Test plan

- [ ] Confirm both workflows show up in the Actions tab on this PR
- [ ] `pr-scope-check` passes for this PR (3 files, well under threshold)
- [ ] `citation-check` passes (no new H2 sections in `cheatsheets/`)
- [ ] Manually re-run with a draft PR that touches 4+ cheat sheets to confirm scope check fails
- [ ] Manually re-run with a draft PR that adds an unsourced H2 to confirm citation check fails
- [ ] Once merged, add both checks to required status checks on `master`

Refs #2172