### PR TITLE
Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -84,12 +84,12 @@ jobs:
         git add --all .
         git commit -a -m "Deploy the generated website via GitHub Actions"
     - name: Publish the build to gh-pages
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599 # v1.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages
     - name: Send update to Slack
-      uses: innocarpe/actions-slack@v1
+      uses: innocarpe/actions-slack@b2f50d9d8037ef8a1f77fa4659767747120124e4 # v1.1
       with:
         status: ${{ job.status }}
         success_text: 'Offline website deployment: **success**'

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -38,7 +38,7 @@ jobs:
         echo ::set-output name=links::**Following links are broken:** %0A$links
     - name: Send comment to PR with broken links
       if: failure() && github.event_name == 'pull_request'
-      uses: thollander/actions-comment-pull-request@main
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
         message: ${{ steps.brokenlinks.outputs.links }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

In light of the active Mini Shai-Hulud npm/GitHub Actions supply-chain campaign (May 11–12, 2026, 170+ packages compromised across `@tanstack`, `@mistralai`, etc.), this PR pins our three third-party GitHub Actions to verified commit SHAs so a compromised maintainer release cannot silently land in CI on the next workflow run.

Changes:

- `ad-m/github-push-action@master` → `4cc74773234f74829a8c21bc4d69dd4be9cfa599` (v1.1.0)
- `innocarpe/actions-slack@v1` → `b2f50d9d8037ef8a1f77fa4659767747120124e4` (v1.1)
- `thollander/actions-comment-pull-request@main` → `24bffb9b452ba05a4f3f77933840a6a841d1b32b` (v3.0.1)

Each SHA was resolved via the GitHub API against the action's release tag and the underlying commit was inspected for legitimacy.

Note on `ad-m/github-push-action`: the action had a maintainer handoff in 2023; the v1.1.0 commit is a Node 20→24 runtime bump (consistent with the GitHub Actions deprecation timeline) by a GitHub-verified contributor. A follow-up could remove this action entirely in favor of `git push` (the workflow already does the config/commit steps manually), but that's a separate change.

First-party `actions/*` steps remain on major-version tags in this PR — they are a candidate for a follow-up pinning + Dependabot pass.

## Test plan

- [ ] `Build and deploy offline website` workflow runs on next push to `master` and successfully publishes to `gh-pages`
- [ ] `Markdown Link Check` workflow runs on next PR and posts a comment on failure as before
