### PR TITLE
Pin first-party actions and Docker base, narrow workflow permissions

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build offline website
@@ -14,13 +17,13 @@ jobs:
       WORKFLOW_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
     steps:
     - name: Setup Action
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 20.x
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
     - name: Install system dependencies for lxml
@@ -36,7 +39,7 @@ jobs:
     - name: Test bundle
       run: zip -T bundle.zip
     - name: Upload bundle as artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Bundle
         path: bundle.zip
@@ -50,7 +53,7 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0 # fetch all branches
     - name: Install dependencies
@@ -62,7 +65,7 @@ jobs:
         shopt -s extglob
         rm -rdfv !("CNAME"|"robots.txt"|"_config.yml")
     - name: Download new build from artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Bundle
     - name: Display structure of downloaded files

--- a/.github/workflows/identify-old-issues-and-pr.yml
+++ b/.github/workflows/identify-old-issues-and-pr.yml
@@ -16,9 +16,9 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: SetUp python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
     - name: Install python dependencies

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -16,9 +16,9 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 20.x
     - name: Install dependencies

--- a/.github/workflows/md_lint_check.yml
+++ b/.github/workflows/md_lint_check.yml
@@ -15,9 +15,9 @@ jobs:
       CI: true
     steps:
     - name: Setup Action
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 20.x
     - name: Install dependencies

--- a/.github/workflows/publishing-check.yml
+++ b/.github/workflows/publishing-check.yml
@@ -13,9 +13,9 @@ jobs:
       CI: true
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.12-slim
 WORKDIR /usr/src/app
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary

Third hardening PR in this thread (after #2176, #2177). Rebased on master after #2179 landed the v6/v6/v6/v7/v8 major bumps with floating tags.

1. **SHA-pin first-party `actions/*` steps** across all workflows, targeting the new majors that #2179 shipped:
   - `actions/checkout@v6` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
   - `actions/setup-node@v6` → `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0`
   - `actions/setup-python@v6` → `a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0`
   - `actions/upload-artifact@v7` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
   - `actions/download-artifact@v8` → `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`

   No functional bumps — same major lines, just pinned to immutable commits. Dependabot's `github-actions` ecosystem (added in #2177) will keep these current. The Mini Shai-Hulud chain ran through GitHub Actions internals, so hardened-mode hygiene now recommends SHA-pinning first-party actions too.

2. **Pin `python:latest` → `python:3.12-slim`** in `Dockerfile`. Matches the Python 3.12 target the `publishing-check` workflow already uses. Dependabot's `docker` ecosystem will offer digest pinning and base-image bumps.

3. **Narrow permissions** in `build-and-deploy-website.yml`:
   - Workflow-level: `contents: read` (default-deny)
   - Build job inherits read-only — it only uploads an artifact, no token writes needed
   - Deploy job already has its `contents: write` override (landed via #2185)

All other workflows on master already have explicit `permissions:` blocks.

## Test plan

- [ ] `Markdown Lint Check`, `Markdown Link Check`, `Build website`, and CodeQL checks pass on this PR
- [ ] On next push to master, `Build and deploy offline website` succeeds and publishes to `gh-pages`
