### PR TITLE
Fix deploy job: remove Slack notification

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -88,17 +88,3 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages
-    - name: Send update to Slack
-      if: always()
-      env:
-        JOB_STATUS: ${{ job.status }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-      run: |
-        case "$JOB_STATUS" in
-          success)   MSG='Offline website deployment: **success**' ;;
-          failure)   MSG='Offline website deployment: **fail**' ;;
-          cancelled) MSG='Offline website deployment **cancelled**' ;;
-          *)         MSG="Offline website deployment: **$JOB_STATUS**" ;;
-        esac
-        payload=$(jq -nc --arg text "$MSG" '{text: $text}')
-        curl -fsSL -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -89,12 +89,16 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages
     - name: Send update to Slack
-      uses: innocarpe/actions-slack@b2f50d9d8037ef8a1f77fa4659767747120124e4 # v1.1
-      with:
-        status: ${{ job.status }}
-        success_text: 'Offline website deployment: **success**'
-        failure_text: 'Offline website deployment: **fail**'
-        cancelled_text: 'Offline website deployment **cancelled**'
+      if: always()
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JOB_STATUS: ${{ job.status }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      run: |
+        case "$JOB_STATUS" in
+          success)   MSG='Offline website deployment: **success**' ;;
+          failure)   MSG='Offline website deployment: **fail**' ;;
+          cancelled) MSG='Offline website deployment **cancelled**' ;;
+          *)         MSG="Offline website deployment: **$JOB_STATUS**" ;;
+        esac
+        payload=$(jq -nc --arg text "$MSG" '{text: $text}')
+        curl -fsSL -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Summary

Removes the `Send update to Slack` step from `Build and deploy offline website`.

The previously pinned `innocarpe/actions-slack@b2f50d9d8037ef8a1f77fa4659767747120124e4` action fails during action metadata loading because its `action.yml` contains `${{ job.status }}` in an input description. Since Slack deployment notifications are not necessary, this PR removes the notification step instead of replacing the third-party action.

The deploy still publishes to `gh-pages`; the removed Slack step was last in the job and only affected notification.

## Test plan

- [x] Workflow YAML parses: `python3 -c "import yaml; yaml.safe_load(open(\".github/workflows/build-and-deploy-website.yml\"))"`
- [ ] After merge, the next push to `master` shows `Build and deploy offline website` green
