### PR TITLE
Replace gh-pages push action with git push

### DIFF
--- a/.github/workflows/build-and-deploy-website.yml
+++ b/.github/workflows/build-and-deploy-website.yml
@@ -44,6 +44,8 @@ jobs:
     name: Deploy offline website
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI: true
     steps:
@@ -84,7 +86,4 @@ jobs:
         git add --all .
         git commit -a -m "Deploy the generated website via GitHub Actions"
     - name: Publish the build to gh-pages
-      uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599 # v1.1.0
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: gh-pages
+      run: git push origin HEAD:gh-pages


### PR DESCRIPTION
## Summary

Replaces the third-party `ad-m/github-push-action` step in `Build and deploy offline website` with a native `git push origin HEAD:gh-pages` command.

Adds explicit `contents: write` permission to the deploy job so the workflow token can publish to `gh-pages`. The build, artifact download, commit, and branch target behavior are otherwise unchanged.

## Test plan

- [x] Workflow YAML parses: `python3 -c "import yaml; yaml.safe_load(open(\".github/workflows/build-and-deploy-website.yml\"))"`
- [x] `git diff --check`
