### PR TITLE
Fix typo in Secure Cloud Architecture Cheat Sheet

### DIFF
--- a/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.md
+++ b/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.md
@@ -137,7 +137,7 @@ This could be a necessary approach for applications found in financial, military
 
 #### 2. High trust example
 
-Next, consider the an opposite approach, where everything is trusted. In this instance, the "dangerous" user input is trusted and essentially handed directly to a high criticality business component. The auth/identity resource is not used at all. In this instance, there is higher likelihood of a successful attack against the system, because there are no controls in place to prevent it. Additionally, this setup could be considered wasteful, as both the auth/identity and ephemeral IAM servers are not necessarily performing their intended function. *(These could be shared corporate resources that aren't being used to their full potential).*
+Next, consider the opposite approach, where everything is trusted. In this instance, the "dangerous" user input is trusted and essentially handed directly to a high criticality business component. The auth/identity resource is not used at all. In this instance, there is higher likelihood of a successful attack against the system, because there are no controls in place to prevent it. Additionally, this setup could be considered wasteful, as both the auth/identity and ephemeral IAM servers are not necessarily performing their intended function. *(These could be shared corporate resources that aren't being used to their full potential).*
 
 ![Complete Trust Across Boundaries](../assets/Secure_Cloud_Architecture_Trust_Boundaries_3.png)
 


### PR DESCRIPTION
 # Description

  Corrects a small typo in the Secure Cloud Architecture Cheat Sheet.

  Changed "the an opposite approach" to "the opposite approach" for readability.

  # Checklist

  - [x] This PR is focused: it modifies a single cheat sheet, and the scope is described in the PR body.
  - [x] No technical claims, recommendations, or threat assertions were added.
  - [x] This is a documentation-only typo fix.

  ## AI Tool Usage Disclosure

  - [x] I have used AI tools to identify and prepare this typo fix. I have verified the contents and I affirm the
  results. The LLM used is ChatGPT/Codex, GPT-5. The prompt used was: "For my University cyber course I need to
  contribute to an open-source cybersecurity project for a portfolio activity. Scan this repo for any typos."


  I reviewed the surrounding section for similar obvious wording issues and kept this PR limited to the confirmed typo