### PR TITLE
Fix grammar and some code logic in input validation cheat sheet

### DIFF
--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -25,7 +25,7 @@ It is always recommended to prevent attacks as early as possible in the processi
 
 Input validation can be implemented using any programming technique that allows effective enforcement of syntactic and semantic correctness, for example:
 
-- Data type validators available natively in web application frameworks (such as [Django Validators](https://docs.djangoproject.com/en/1.11/ref/validators/), [Apache Commons Validators](https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/package-summary.html#doc.Usage.validator) etc).
+- Use data type validators available natively in web application frameworks (such as [Django Validators](https://docs.djangoproject.com/en/1.11/ref/validators/), [Apache Commons Validators](https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/package-summary.html#doc.Usage.validator) etc).
 - Validation against [JSON Schema](http://json-schema.org/) and [XML Schema (XSD)](https://www.w3schools.com/xml/schema_intro.asp) for input in these formats.
 - Type conversion (e.g. `Integer.parseInt()` in Java, `int()` in Python) with strict exception handling
 - Minimum and maximum value range check for numerical parameters and dates, minimum and maximum length check for strings.
@@ -72,7 +72,7 @@ Developing regular expressions can be complicated, and is well beyond the scope 
 
 There are lots of resources on the internet about how to write regular expressions, including this [site](https://www.regular-expressions.info/) and the [OWASP Validation Regex Repository](https://owasp.org/www-community/OWASP_Validation_Regex_Repository).
 
-When designing regular expression, be aware of [RegEx Denial of Service (ReDoS) attacks](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS). These attacks cause a program using a poorly designed Regular Expression to operate very slowly and utilize CPU resources for a very long time.
+When designing regular expressions, be aware of [RegEx Denial of Service (ReDoS) attacks](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS). These attacks cause a program using a poorly designed Regular Expression to operate very slowly and utilize CPU resources for a very long time.
 
 In summary, input validation should:
 
@@ -80,7 +80,7 @@ In summary, input validation should:
 - Define the allowed set of characters to be accepted.
 - Define a minimum and maximum length for the data (e.g. `{1,25}`).
 
-## Allow List Regular Expression Examples
+## Allowlist Regular Expression Examples
 
 Validating a U.S. Zip Code (5 digits plus optional -4)
 
@@ -158,13 +158,13 @@ Check the [File Upload Cheat Sheet](File_Upload_Cheat_Sheet.md).
 
 ### Public Serving of Uploaded Content
 
-- Ensure uploaded images are served with the correct content-type (e.g. `image/jpeg`, `application/x-xpinstall`)
+- Ensure uploaded images are served with the correct content-type (e.g. `image/jpeg`, `image/png`)
 
 ### Beware of Specific File Types
 
 The upload feature should be using an allowlist approach to only allow specific file types and extensions. However, it is important to be aware of the following file types that, if allowed, could result in security vulnerabilities:
 
-- **crossdomain.xml** / **clientaccesspolicy.xml:** allows cross-domain data loading in Flash, Java and Silverlight. If permitted on sites with authentication this can permit cross-domain data theft and CSRF attacks. Note this can get pretty complicated depending on the specific plugin version in question, so its best to just prohibit files named "crossdomain.xml" or "clientaccesspolicy.xml".
+- **crossdomain.xml** / **clientaccesspolicy.xml:** allows cross-domain data loading in Flash, Java and Silverlight. If permitted on sites with authentication this can permit cross-domain data theft and CSRF attacks. Note this can get pretty complicated depending on the specific plugin version in question, so it's best to just prohibit files named "crossdomain.xml" or "clientaccesspolicy.xml".
 - **.htaccess** and **.htpasswd:** Provides server configuration options on a per-directory basis, and should not be permitted. See [HTACCESS documentation](http://en.wikipedia.org/wiki/Htaccess).
 - Web executable script files are suggested not to be allowed such as `aspx, asp, css, swf, xhtml, rhtml, shtml, jsp, js, pl, php, cgi`.
 


### PR DESCRIPTION
This PR improves grammar, fixes code logic.
No functional changes were made.

- In line 161.  `application/x-xpinstall` is not an image content type — it's the MIME type for Firefox extension installer files. It doesn't belong in a list of image content-type examples.

- There should be `image/png`.


