### PR TITLE
Bump express-rate-limit to resolve ip-address advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,13 +1065,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1511,9 +1511,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What changed

This updates the lockfile-only transitive dev dependency chain:

- `express-rate-limit`: `8.4.1` -> `8.5.2`
- `ip-address`: `10.1.0` -> `10.2.0`

`npm audit --omit=optional` currently reports a moderate advisory for `ip-address` (`GHSA-v2v4-37r5-5v8g`) through `express-rate-limit`. The newer `express-rate-limit` release depends on `ip-address` `^10.2.0`, which clears the advisory.

## Validation

Ran locally after `npm ci`:

- `npm test`
- `npm audit --omit=optional`
- `git diff --check`

`npm audit --omit=optional` reports `found 0 vulnerabilities` after this lockfile update.