### PR TITLE
docs(sec-8-11): add action_ref content address, receipt field spec, EU AI Act Article 12 mapping

### DIFF
--- a/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
+++ b/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
@@ -173,6 +173,7 @@ Use the **JSON Canonicalization Scheme (JCS), [RFC 8785](https://www.rfc-editor.
 - Canonicalize every receipt with RFC 8785 (JCS) before signing, and again before verifying.
 - Sign over the hash of the canonical bytes, not raw or pretty-printed JSON.
 - Record the canonicalization, hash, and signature algorithm in the receipt (for example `canon: jcs`, `alg: ecdsa-p256-sha256`) so any verifier can reproduce it.
+- Derive a stable **content address** (`action_ref`) for each action: `action_ref = SHA-256(JCS({agent_id, action_type, scope, timestamp_ms}))`. This 64-character hex string uniquely and recomputably identifies the action across systems, enabling cross-system receipt correlation without replaying the full event log.
 
 ### Don't
 
@@ -205,6 +206,22 @@ A receipt stating "screened, no match" is meaningless without which version of t
 - Include the sanctions-list source(s), version or publication date, and screening timestamp **inside the signed receipt**.
 - Define a maximum acceptable list age, record it in the receipt, and fail-closed if it is exceeded.
 - Make list freshness auditable after the fact from the receipt alone.
+- Bind the freshness record to the specific agent action using the `action_ref` content address (Section 8), so an auditor can link the screening result to the transaction without relying on log position:
+
+```json
+{
+  "screening_sources": [
+    {
+      "list": "OFAC-SDN",
+      "version": "2026-06-04",
+      "freshness_max_age_hours": 24,
+      "screening_timestamp_ms": 1749081600000
+    }
+  ],
+  "result": "no_match",
+  "action_ref": "a3f7c2..."
+}
+```
 
 ### Don't
 
@@ -223,6 +240,7 @@ The controls in this cheat sheet map to common AML and sanctions obligations. Th
 | Sanctions-list freshness in receipt (Section 10) | Obligation to screen against current lists; sanctions-evasion controls |
 | Fail-closed enforcement (Section 5) | Blocking obligations for sanctioned parties |
 | Trust-tiered limits (Section 6) | Risk-based approach (FATF Recommendation 1); monitoring thresholds |
+| Signed receipt with `action_ref` content address (Sections 4, 8-10) | EU AI Act Article 12 (automatic tamper-evident logging for high-risk AI systems, enforcement August 2, 2026); ISO/IEC 42001 Annex A (AI management system records) |
 
 ### Do
 

--- a/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
+++ b/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
@@ -173,7 +173,7 @@ Use the **JSON Canonicalization Scheme (JCS), [RFC 8785](https://www.rfc-editor.
 - Canonicalize every receipt with RFC 8785 (JCS) before signing, and again before verifying.
 - Sign over the hash of the canonical bytes, not raw or pretty-printed JSON.
 - Record the canonicalization, hash, and signature algorithm in the receipt (for example `canon: jcs`, `alg: ecdsa-p256-sha256`) so any verifier can reproduce it.
-- Derive a stable **content address** (`action_ref`) for each action: `action_ref = SHA-256(JCS({agent_id, action_type, scope, timestamp_ms}))`. This 64-character hex string uniquely and recomputably identifies the action across systems, enabling cross-system receipt correlation without replaying the full event log.
+- Derive a stable **content address** (`action_ref`) for each action: `action_ref = HEX(SHA-256(JCS({agent_id, action_type, scope, timestamp_ms})))`. This 64-character hex string uniquely and recomputably identifies the action across systems, enabling cross-system receipt correlation without replaying the full event log. This construct originates from [OWASP Agentic Skills Top 10 AST09](https://github.com/OWASP/www-project-agentic-skills-top-10/blob/main/ast09.md), where it is specified as normative implementation guidance for execution receipts.
 
 ### Don't
 
@@ -240,7 +240,7 @@ The controls in this cheat sheet map to common AML and sanctions obligations. Th
 | Sanctions-list freshness in receipt (Section 10) | Obligation to screen against current lists; sanctions-evasion controls |
 | Fail-closed enforcement (Section 5) | Blocking obligations for sanctioned parties |
 | Trust-tiered limits (Section 6) | Risk-based approach (FATF Recommendation 1); monitoring thresholds |
-| Signed receipt with `action_ref` content address (Sections 4, 8-10) | EU AI Act Article 12 (automatic tamper-evident logging for high-risk AI systems, enforcement August 2, 2026); ISO/IEC 42001 Annex A (AI management system records) |
+| Signed receipt with `action_ref` content address (Sections 4, 8-10) | EU AI Act Article 12 (automatic tamper-evident logging for high-risk AI systems, enforcement December 2, 2027); ISO/IEC 42001 Annex A (AI management system records) |
 
 ### Do
 

--- a/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
+++ b/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
@@ -173,7 +173,15 @@ Use the **JSON Canonicalization Scheme (JCS), [RFC 8785](https://www.rfc-editor.
 - Canonicalize every receipt with RFC 8785 (JCS) before signing, and again before verifying.
 - Sign over the hash of the canonical bytes, not raw or pretty-printed JSON.
 - Record the canonicalization, hash, and signature algorithm in the receipt (for example `canon: jcs`, `alg: ecdsa-p256-sha256`) so any verifier can reproduce it.
-- Derive a stable **content address** (`action_ref`) for each action: `action_ref = HEX(SHA-256(JCS({agent_id, action_type, scope, timestamp_ms})))`. This 64-character hex string uniquely and recomputably identifies the action across systems, enabling cross-system receipt correlation without replaying the full event log. This construct originates from [OWASP Agentic Skills Top 10 AST09](https://github.com/OWASP/www-project-agentic-skills-top-10/blob/main/ast09.md), where it is specified as normative implementation guidance for execution receipts.
+- Derive a stable **content address** (`action_ref`) for each action: `action_ref = HEX(SHA-256(JCS({agent_id, action_type, scope, timestamp_ms})))`. This 64-character hex string uniquely and recomputably identifies the action across systems, enabling cross-system receipt correlation without replaying the full event log. [OWASP Agentic Skills Top 10 AST09](https://github.com/OWASP/www-project-agentic-skills-top-10/blob/main/ast09.md) names `action_ref` as a "content-derived join key, independently recomputable" in the outcome receipt. It does not specify a construction. The SHA-256-over-JCS formula above is one way to satisfy that property and is a proposed pattern, not a standardised one.
+
+> **What in this section is standardised, and what is not.** RFC 8785 (JCS) and
+> RFC 8032 (Ed25519) are published IETF specifications, and the canonicalization and
+> signature behaviours described above follow from them directly. The `action_ref`
+> content address, the receipt field set, and the correlation pattern built on them are
+> proposed patterns. No RFC, NIST publication, or published audit framework specifies
+> them, and no conformance suite currently tests them. Treat them as one worked
+> implementation of the underlying requirement rather than as a standard to conform to.
 
 ### Don't
 
@@ -240,7 +248,7 @@ The controls in this cheat sheet map to common AML and sanctions obligations. Th
 | Sanctions-list freshness in receipt (Section 10) | Obligation to screen against current lists; sanctions-evasion controls |
 | Fail-closed enforcement (Section 5) | Blocking obligations for sanctioned parties |
 | Trust-tiered limits (Section 6) | Risk-based approach (FATF Recommendation 1); monitoring thresholds |
-| Signed receipt with `action_ref` content address (Sections 4, 8-10) | EU AI Act Article 12 (automatic tamper-evident logging for high-risk AI systems, enforcement December 2, 2027); ISO/IEC 42001 Annex A (AI management system records) |
+| Signed receipt with `action_ref` content address (Sections 4, 8-10) | EU AI Act Article 12, which requires that high-risk systems "shall technically allow for the automatic recording of events (logs) over the lifetime of the system". Article 12 requires the record to exist; it does not require it to be signed, tamper-evident, or produced by a party other than the system being logged. Most of the Act applies from 2 August 2026, and Article 6(1) from 2 August 2027. |
 
 ### Do
 

--- a/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
+++ b/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
@@ -168,20 +168,14 @@ A compliance receipt is only verifiable across systems if every party serializes
 
 Use the **JSON Canonicalization Scheme (JCS), [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)**, to produce a deterministic byte representation before hashing and signing. The signer canonicalizes, hashes (for example with SHA-256), then signs; every verifier canonicalizes the received receipt identically and checks the signature. This makes receipts verifiable by **any** counterparty, regulator, or downstream agent, not just the issuing system.
 
+This subsection proposes an implementation of that requirement rather than describing an existing standard. RFC 8785 (JCS) and RFC 8032 (Ed25519) are published IETF specifications, and the canonicalization and signature behaviors described below follow from them directly. The `action_ref` content address, the receipt field set, and the correlation pattern built on them are proposed patterns. No RFC, NIST publication, or published audit framework specifies them, and no conformance suite currently tests them. Treat them as one worked implementation of the underlying requirement rather than as a standard to conform to.
+
 ### Do
 
 - Canonicalize every receipt with RFC 8785 (JCS) before signing, and again before verifying.
 - Sign over the hash of the canonical bytes, not raw or pretty-printed JSON.
 - Record the canonicalization, hash, and signature algorithm in the receipt (for example `canon: jcs`, `alg: ecdsa-p256-sha256`) so any verifier can reproduce it.
-- Derive a stable **content address** (`action_ref`) for each action: `action_ref = HEX(SHA-256(JCS({agent_id, action_type, scope, timestamp_ms})))`. This 64-character hex string uniquely and recomputably identifies the action across systems, enabling cross-system receipt correlation without replaying the full event log. [OWASP Agentic Skills Top 10 AST09](https://github.com/OWASP/www-project-agentic-skills-top-10/blob/main/ast09.md) names `action_ref` as a "content-derived join key, independently recomputable" in the outcome receipt. It does not specify a construction. The SHA-256-over-JCS formula above is one way to satisfy that property and is a proposed pattern, not a standardised one.
-
-> **What in this section is standardised, and what is not.** RFC 8785 (JCS) and
-> RFC 8032 (Ed25519) are published IETF specifications, and the canonicalization and
-> signature behaviours described above follow from them directly. The `action_ref`
-> content address, the receipt field set, and the correlation pattern built on them are
-> proposed patterns. No RFC, NIST publication, or published audit framework specifies
-> them, and no conformance suite currently tests them. Treat them as one worked
-> implementation of the underlying requirement rather than as a standard to conform to.
+- Derive a stable **content address** (`action_ref`) for each action: `action_ref = HEX(SHA-256(JCS({agent_id, action_type, scope, timestamp_ms})))`. This 64-character hex string uniquely and recomputably identifies the action across systems, enabling cross-system receipt correlation without replaying the full event log. [OWASP Agentic Skills Top 10 AST09](https://github.com/OWASP/www-project-agentic-skills-top-10/blob/main/ast09.md) names `action_ref` as a "content-derived join key, independently recomputable" in the outcome receipt. It does not specify a construction. The SHA-256-over-JCS formula above is one way to satisfy that property and is a proposed pattern, not a standardized one.
 
 ### Don't
 


### PR DESCRIPTION
## Summary

Refinements to Sections 8, 10 and 11 of the AML and Sanctions Compliance for AI Agent Payments cheat sheet, following up on PR #2209 and #2210.

Rewritten on 27 August after @mackowski's review, which asked for a disclaimer distinguishing proposed patterns from established standards. Writing that disclaimer turned up three errors in my own text, so this PR now does four things.

**Section 8, the `action_ref` content address.** A stable, recomputable content address for an agent action, so receipts can be correlated across systems without replaying the event log.

**Section 8, a standardised-versus-proposed disclaimer.** RFC 8785 (JCS) and RFC 8032 (Ed25519) are published IETF specifications and the canonicalization and signature guidance follows from them. The `action_ref` construction, the receipt field set, and the correlation pattern are proposed patterns that no RFC, NIST publication, or published audit framework specifies, and no conformance suite tests. The text now says so in the section itself.

**Section 10, a worked receipt** binding sanctions-list freshness to that content address.

**Section 11, the regulatory mapping row**, corrected. See below.

## Corrections to my own earlier text in this PR

- **AST09 does not specify the construction.** I had written that the formula "is specified as normative implementation guidance" in [OWASP Agentic Skills Top 10 AST09](https://github.com/OWASP/www-project-agentic-skills-top-10/blob/main/ast09.md). It is not. That file contains the string `action_ref` exactly once, in the outcome receipt field list, as "content-derived join key, independently recomputable". It names a property. The `HEX(SHA-256(JCS(...)))` construction is mine, and the text now attributes it to me.
- **Article 12 does not say tamper-evident.** The mapping row claimed "automatic tamper-evident logging". [Article 12](https://artificialintelligenceact.eu/article/12/) requires that high-risk systems "shall technically allow for the automatic recording of events (logs) over the lifetime of the system". It requires the record to exist. It does not require it to be signed, tamper-evident, or produced by a party other than the system being logged. The row now quotes it and states what it does not cover.
- **The date was wrong.** The diff said "enforcement December 2, 2027". There is no such date. Most of the Act applies from 2 August 2026 and Article 6(1) from 2 August 2027.
- **The ISO/IEC 42001 Annex A citation is removed.** It is a paid standard, I had not read the clause I was citing, and a clause number nobody in this thread has read is not a citation.

Scope: one file, `cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md`. markdownlint passes with 0 errors.

---

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the Cheat Sheet template. *(not applicable, this edits an existing sheet)*
- [x] All the markdown files do not raise any validation policy violation.
- [x] All the markdown files follow these format rules.
- [ ] All your assets are stored in the **assets** folder. *(not applicable, no assets)*
- [ ] All the images used are in the **PNG** format. *(not applicable, no images)*
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution.
- [x] The CI build of your PR pass.

## Scope and sourcing (required)

- [x] This PR is focused: it modifies a single cheat sheet, and the scope is described in the PR body.
- [x] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source linked inline, or is explicitly labelled in the text as a proposed pattern rather than a standard.
- [x] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations.

On that last box: it would not have been honest to tick it on the earlier version of this PR. The ISO/IEC 42001 Annex A citation was exactly the failure that box is there to prevent, and the AST09 attribution overstated what that document says. Both are fixed, and every remaining citation has been checked against the primary text.

## AI Tool Usage Disclosure (required for all PRs)

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `Claude Opus (Anthropic)` and the prompt used was, in substance, *"review this open PR against the reviewer's request for a disclaimer, check every citation in it against the primary source, and correct anything that overstates what the source says."* I have independently verified every citation and technical claim against the cited source, including reading `ast09.md` and the text of EU AI Act Article 12 directly rather than relying on a summary. The three corrections listed above are the result of that check.
