### PR TITLE
Add “Common Pitfalls in Input Validation” Section to Strengthen Practical Guidance

### DIFF
--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -45,7 +45,7 @@ Data that appears safe before serialization can become unsafe once parsed again.
 
 ### Trusting Internal APIs or Microservices Too Much
 
-It’s common for internal services to skip validation because they’re “inside the perimeter.” But modern attacks often target internal trust boundaries. Every service—internal or external—needs proper validation. [CISA Zero Trust Maturity Model](https://www.cisa.gov/resources-tools/resources/zero-trust-maturity-model).
+Modern Zero Trust guidance (such as the CISA Zero Trust Maturity Model) emphasizes that no system -internal or external should be implicitly trusted based on network location. This principle applies to internal APIs and microservices, which must validate all inputs even when operating inside the perimeter.
 
 ### Not Validating File Uploads or Filenames
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -41,7 +41,8 @@ Note: Client‑side validation and denylisting are already covered in the sectio
 
 ### Skipping Validation After Deserialization
 
-Data that appears safe before serialization can become unsafe once parsed again. Formats like JSON, XML, and protobuf may contain unexpected structures or types after deserialization. Always validate after deserialization, when the final structure is known.Reference: OWASP Deserialization Cheat Sheet (cheatsheetseries.owasp.org in Bing).
+Data that appears safe before serialization can become unsafe once parsed again. Formats like JSON, XML, and protobuf may contain unexpected structures or types after deserialization. Always validate after deserialization, when the final structure is known.
+Reference: OWASP Deserialization Cheat Sheet (cheatsheetseries.owasp.org in Bing).
 
 ### Trusting Internal APIs or Microservices Too Much
 
@@ -62,7 +63,8 @@ Reference: OWASP API Security Top 10 – API4:2023 (Unrestricted Resource Consum
 
 ### Overlooking Unicode Normalization
 
-Normalization must occur before validation so that visually similar or canonically equivalent characters are evaluated consistently. However, Unicode TR36 warns that normalization alone is not a security control — it must be paired with strict allowlisting and canonicalization rules.Reference: Unicode Technical Report #36 (Security Considerations).
+Normalization must occur before validation so that visually similar or canonically equivalent characters are evaluated consistently. However, Unicode TR36 warns that normalization alone is not a security control — it must be paired with strict allowlisting and canonicalization rules.
+Reference: Unicode Technical Report #36 (Security Considerations).
 
 ### Assuming JSON Input Is Automatically Safe
 
@@ -70,7 +72,8 @@ JSON feels structured and predictable, but attackers can still inject harmful st
 
 ### Forgetting to Validate Before Logging or Storing Data
 
-Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.*Reference: OWASP Logging Cheat Sheet*  
+Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.
+*Reference: OWASP Logging Cheat Sheet*  
 
 ### Allowlist vs Denylist
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -49,7 +49,7 @@ Modern Zero Trust guidance (such as the CISA Zero Trust Maturity Model) emphasiz
 
 ### Not Validating File Uploads or Filenames
 
-File uploads are a huge attack surface. You need to validate the file type, size, extension, and even the filename. Attackers can sneak in traversal sequences or special characters that cause trouble later. [OWASP File Upload Cheat Sheet](https://cheatsheetseries.owasp.org/)
+File uploads are a huge attack surface. You need to validate the file type, size, extension, and even the filename. Attackers can sneak in traversal sequences or special characters that cause trouble later. [OWASP File Upload Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html)
 
 ### Using Unsafe or Overly Complex Regular Expressions
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -68,6 +68,7 @@ Reference: Unicode Technical Report #36 (Security Considerations).
 ### Assuming JSON Input Is Automatically Safe
 
 JSON feels structured and predictable, but attackers can still inject harmful strings, unexpected types, or oversized payloads. It needs the same level of validation as any other input.
+Reference: OWASP API Security Top 10 – API8:2023 (Security Misconfiguration).
 
 ### Forgetting to Validate Before Logging or Storing Data
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -33,6 +33,50 @@ Input validation can be implemented using any programming technique that allows 
 - Regular expressions for any other structured data covering the whole input string `(^...$)` and **not** using "any character" wildcard (such as `.` or `\S`)
 - Denylisting known dangerous patterns can be used as an additional layer of defense, but it should supplement - not replace - allowlisting, to help catch some commonly observed attacks or patterns without relying on it as the main validation method.
 
+## Common Pitfalls in Input Validation
+
+Even when teams try to implement input validation, a lot of applications still end up vulnerable because of small oversights or assumptions that don’t hold up in the real world. These are some of the issues that come up again and again during security reviews and incident investigations.
+
+### Relying Only on Client-Side Validation
+
+Client-side checks (like JavaScript validation or HTML5 rules) are helpful for user experience, but they’re not security controls. Anyone can bypass them by turning off scripts, modifying requests, or using tools like curl or Burp. The server must always validate the final input. [OWASP Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
+
+### Using Blacklists Instead of Whitelists
+
+Trying to block “bad” input with a blacklist almost always fails. Attackers can use encoding tricks, alternate characters, or new payloads you didn’t think of. It’s much safer to define what *good* input looks like and only allow that. [NIST SP 800‑53 SA-11](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)
+
+### Skipping Validation After Deserialization
+
+Data that looked safe before serialization can become unsafe once it’s parsed again. Formats like JSON, XML, and protobuf can hide unexpected structures or types. Always validate *after* deserialization, when you know exactly what the data looks like. [OWASP Deserialization Cheat Sheet](https://cheatsheetseries.owasp.org/)
+
+### Trusting Internal APIs or Microservices Too Much
+
+It’s common for internal services to skip validation because they’re “inside the perimeter.” But modern attacks often target internal trust boundaries. Every service—internal or external—needs proper validation. [CISA Zero Trust Guidance](https://www.cisa.gov/zero-trust-maturity-model)
+
+### Not Validating File Uploads or Filenames
+
+File uploads are a huge attack surface. You need to validate the file type, size, extension, and even the filename. Attackers can sneak in traversal sequences or special characters that cause trouble later. [OWASP File Upload Cheat Sheet](https://cheatsheetseries.owasp.org/)
+
+### Using Unsafe or Overly Complex Regular Expressions
+
+Some regex patterns can cause catastrophic backtracking (ReDoS), slowing your server to a crawl. Keep patterns simple, anchored, and performance-tested. [OWASP ReDoS Prevention](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)
+
+### Ignoring Nested JSON or Large Arrays
+
+Attackers often hide malicious data deep inside nested objects or huge arrays. Validation needs to walk the entire structure and enforce limits at every level.
+
+### Overlooking Unicode Normalization
+
+Unicode can be tricky. Different characters can look identical or behave unexpectedly, which can let attackers slip past naive filters. Normalizing input (like using NFC) helps avoid these issues. [Unicode Security Considerations](https://unicode.org/reports/tr36/)
+
+### Assuming JSON Input Is Automatically Safe
+
+JSON feels structured and predictable, but attackers can still inject harmful strings, unexpected types, or oversized payloads. It needs the same level of validation as any other input.
+
+### Forgetting to Validate Before Logging or Storing Data
+
+Unvalidated input written to logs or databases can lead to log injection, stored XSS, or parsing errors later. Validation should happen before the data goes anywhere—logs included.
+
 ### Allowlist vs Denylist
 
 It is a common mistake to use denylist validation in order to try to detect possibly dangerous characters and patterns like the apostrophe `'` character, the string `1=1`, or the `<script>` tag, but this is a massively flawed approach as it is trivial for an attacker to bypass such filters.

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -45,7 +45,8 @@ Data that appears safe before serialization can become unsafe once parsed again.
 Reference: OWASP Deserialization Cheat Sheet (cheatsheetseries.owasp.org in Bing).
 
 ### Trusting Internal APIs or Microservices Too Much
-It’s common for internal services to skip validation because they’re “inside the perimeter.” But modern attacks often target internal trust boundaries. Every service—internal or external—needs proper validation. [CISA Zero Trust Maturity Model](https://www.cisa.gov/resources-tools/resources/zero-trust-maturity-model)
+
+It’s common for internal services to skip validation because they’re “inside the perimeter.” But modern attacks often target internal trust boundaries. Every service—internal or external—needs proper validation. [CISA Zero Trust Maturity Model](https://www.cisa.gov/resources-tools/resources/zero-trust-maturity-model).
 
 ### Not Validating File Uploads or Filenames
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -67,14 +67,12 @@ Reference: Unicode Technical Report #36 (Security Considerations).
 
 ### Assuming JSON Input Is Automatically Safe
 
-Because JSON is a structured data format, developers sometimes assume its contents are inherently safe. However, JSON payloads remain untrusted input. Applications should validate field presence, data types, length, ranges, and overall structure before processing.[OWASP Input Validation Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html).
-
+Because JSON is a structured data format, developers sometimes assume its contents are inherently safe. However, JSON payloads remain untrusted input. Applications should validate field presence, data types, length, ranges, and overall structure before processing.[OWASP Logging Cheat Sheet](<https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html>)
 
 ### Forgetting to Validate Before Logging or Storing Data
 
-Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.[OWASP Logging Cheat Sheet ](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html ).
+Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.[OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html).
  
-
 ### Allowlist vs Denylist
 
 It is a common mistake to use denylist validation in order to try to detect possibly dangerous characters and patterns like the apostrophe `'` character, the string `1=1`, or the `<script>` tag, but this is a massively flawed approach as it is trivial for an attacker to bypass such filters.

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -35,7 +35,7 @@ Input validation can be implemented using any programming technique that allows 
 
 ## Common Pitfalls in Input Validation
 
-Even when teams try to implement input validation, a lot of applications still end up vulnerable because of small oversights or assumptions that don’t hold up in the real world. These are some of the issues that come up again and again during security reviews and incident investigations.
+Even when teams try to implement input validation, a lot of applications still end up vulnerable because of small oversights or assumptions that don’t hold up in the real world.These are common implementation mistakes that frequently lead to validation weaknesses in real-world applications.
 
 Note: Client‑side validation and denylisting are already covered in the sections below. See “Server‑Side Validation” and “Allowlist vs Denylist” for detailed guidance.
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -67,13 +67,13 @@ Reference: Unicode Technical Report #36 (Security Considerations).
 
 ### Assuming JSON Input Is Automatically Safe
 
-JSON feels structured and predictable, but attackers can still inject harmful strings, unexpected types, or oversized payloads. It needs the same level of validation as any other input.
-Reference: OWASP API Security Top 10 – API8:2023 (Security Misconfiguration).
+Because JSON is a structured data format, developers sometimes assume its contents are inherently safe. However, JSON payloads remain untrusted input. Applications should validate field presence, data types, length, ranges, and overall structure before processing.[OWASP Input Validation Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html).
+
 
 ### Forgetting to Validate Before Logging or Storing Data
 
-Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.
-*Reference: OWASP Logging Cheat Sheet*  
+Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.[OWASP Logging Cheat Sheet ](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html ).
+ 
 
 ### Allowlist vs Denylist
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -41,7 +41,7 @@ Note: Client‑side validation and denylisting are already covered in the sectio
 
 ### Skipping Validation After Deserialization
 
-Data that appears safe before serialization can become unsafe once parsed again. Formats like JSON, XML, and protobuf may contain unexpected structures or types after deserialization. Always validate after deserialization, when the final structure is known.Reference: OWASP Deserialization Cheat Sheet (cheatsheetseries.owasp.org in Bing)
+Data that appears safe before serialization can become unsafe once parsed again. Formats like JSON, XML, and protobuf may contain unexpected structures or types after deserialization. Always validate after deserialization, when the final structure is known.Reference: OWASP Deserialization Cheat Sheet (cheatsheetseries.owasp.org in Bing).
 
 ### Trusting Internal APIs or Microservices Too Much
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -37,17 +37,11 @@ Input validation can be implemented using any programming technique that allows 
 
 Even when teams try to implement input validation, a lot of applications still end up vulnerable because of small oversights or assumptions that don’t hold up in the real world. These are some of the issues that come up again and again during security reviews and incident investigations.
 
-### Relying Only on Client-Side Validation
-
-Client-side checks (like JavaScript validation or HTML5 rules) are helpful for user experience, but they’re not security controls. Anyone can bypass them by turning off scripts, modifying requests, or using tools like curl or Burp. The server must always validate the final input. [OWASP Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
-
-### Using Blacklists Instead of Whitelists
-
-Trying to block “bad” input with a blacklist almost always fails. Attackers can use encoding tricks, alternate characters, or new payloads you didn’t think of. It’s much safer to define what *good* input looks like and only allow that. [NIST SP 800‑53 SA-11](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)
+Note: Client‑side validation and denylisting are already covered in the sections below. See “Server‑Side Validation” and “Allowlist vs Denylist” for detailed guidance.
 
 ### Skipping Validation After Deserialization
 
-Data that looked safe before serialization can become unsafe once it’s parsed again. Formats like JSON, XML, and protobuf can hide unexpected structures or types. Always validate *after* deserialization, when you know exactly what the data looks like. [OWASP Deserialization Cheat Sheet](https://cheatsheetseries.owasp.org/)
+Data that appears safe before serialization can become unsafe once parsed again. Formats like JSON, XML, and protobuf may contain unexpected structures or types after deserialization. Always validate after deserialization, when the final structure is known.Reference: OWASP Deserialization Cheat Sheet (cheatsheetseries.owasp.org in Bing)
 
 ### Trusting Internal APIs or Microservices Too Much
 
@@ -63,11 +57,12 @@ Some regex patterns can cause catastrophic backtracking (ReDoS), slowing your se
 
 ### Ignoring Nested JSON or Large Arrays
 
-Attackers often hide malicious data deep inside nested objects or huge arrays. Validation needs to walk the entire structure and enforce limits at every level.
+Attackers may hide malicious or unexpected data deep inside nested objects or extremely large arrays. Validation should enforce limits on depth, element count, and overall structure to prevent resource‑exhaustion or parser abuse.
+Reference: OWASP API Security Top 10 – API4:2023 (Unrestricted Resource Consumption).
 
 ### Overlooking Unicode Normalization
 
-Unicode can be tricky. Different characters can look identical or behave unexpectedly, which can let attackers slip past naive filters. Normalizing input (like using NFC) helps avoid these issues. [Unicode Security Considerations](https://unicode.org/reports/tr36/)
+Normalization must occur before validation so that visually similar or canonically equivalent characters are evaluated consistently. However, Unicode TR36 warns that normalization alone is not a security control — it must be paired with strict allowlisting and canonicalization rules.Reference: Unicode Technical Report #36 (Security Considerations).
 
 ### Assuming JSON Input Is Automatically Safe
 
@@ -75,7 +70,7 @@ JSON feels structured and predictable, but attackers can still inject harmful st
 
 ### Forgetting to Validate Before Logging or Storing Data
 
-Unvalidated input written to logs or databases can lead to log injection, stored XSS, or parsing errors later. Validation should happen before the data goes anywhere—logs included.
+Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.*Reference: OWASP Logging Cheat Sheet*  
 
 ### Allowlist vs Denylist
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -45,8 +45,7 @@ Data that appears safe before serialization can become unsafe once parsed again.
 Reference: OWASP Deserialization Cheat Sheet (cheatsheetseries.owasp.org in Bing).
 
 ### Trusting Internal APIs or Microservices Too Much
-
-It’s common for internal services to skip validation because they’re “inside the perimeter.” But modern attacks often target internal trust boundaries. Every service—internal or external—needs proper validation. [CISA Zero Trust Guidance](https://www.cisa.gov/zero-trust-maturity-model)
+It’s common for internal services to skip validation because they’re “inside the perimeter.” But modern attacks often target internal trust boundaries. Every service—internal or external—needs proper validation. [CISA Zero Trust Maturity Model](https://www.cisa.gov/resources-tools/resources/zero-trust-maturity-model)
 
 ### Not Validating File Uploads or Filenames
 

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -67,12 +67,12 @@ Reference: Unicode Technical Report #36 (Security Considerations).
 
 ### Assuming JSON Input Is Automatically Safe
 
-Because JSON is a structured data format, developers sometimes assume its contents are inherently safe. However, JSON payloads remain untrusted input. Applications should validate field presence, data types, length, ranges, and overall structure before processing.[OWASP Logging Cheat Sheet](<https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html>)
+Because JSON is a structured data format, developers sometimes assume its contents are inherently safe. However, JSON payloads remain untrusted input. Applications should validate field presence, data types, length, ranges, and overall structure before processing.[OWASP Input Validation Cheat Sheet](<https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html>)
 
 ### Forgetting to Validate Before Logging or Storing Data
 
-Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.[OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html).
- 
+Input validation reduces unexpected or malformed data, but log injection is primarily mitigated through output encoding when writing to logs. Applications should validate structure and type on input, and then safely encode log entries on output to prevent injection.[OWASP Logging Cheat Sheet](<https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html>)
+
 ### Allowlist vs Denylist
 
 It is a common mistake to use denylist validation in order to try to detect possibly dangerous characters and patterns like the apostrophe `'` character, the string `1=1`, or the `<script>` tag, but this is a massively flawed approach as it is trivial for an attacker to bypass such filters.

--- a/cheatsheets/Input_Validation_Cheat_Sheet.md
+++ b/cheatsheets/Input_Validation_Cheat_Sheet.md
@@ -41,8 +41,7 @@ Note: Client‑side validation and denylisting are already covered in the sectio
 
 ### Skipping Validation After Deserialization
 
-Data that appears safe before serialization can become unsafe once parsed again. Formats like JSON, XML, and protobuf may contain unexpected structures or types after deserialization. Always validate after deserialization, when the final structure is known.
-Reference: OWASP Deserialization Cheat Sheet (cheatsheetseries.owasp.org in Bing).
+Data that appears safe before serialization can become unsafe once parsed again. Formats like JSON, XML, and protobuf may contain unexpected structures or types after deserialization. Always validate after deserialization, when the final structure is known.*Reference: [OWASP Deserialization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html).
 
 ### Trusting Internal APIs or Microservices Too Much
 

--- a/cheatsheets/Multifactor_Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Multifactor_Authentication_Cheat_Sheet.md
@@ -343,6 +343,34 @@ Email verification requires that the user enters a code or clicks a link sent to
 - Email may be received by the same device the user is authenticating from.
 - Susceptible to phishing.
 
+- ## Modern MFA Attack Patterns (Vendor‑Neutral)
+
+Even with MFA in place, attackers continue to find ways around it. The patterns below reflect common techniques seen across modern environments. These examples are vendor-neutral and focus on the underlying weaknesses rather than specific products or malware families.
+
+### MFA Fatigue / Push Abuse
+Attackers repeatedly trigger push notifications to overwhelm users until one is approved accidentally or out of frustration.
+
+### Token Theft
+Session cookies, refresh tokens, or other post-authentication tokens can be stolen and reused, allowing attackers to bypass MFA entirely.
+
+### Reverse-Proxy Phishing Kits
+Phishing frameworks can intercept MFA codes or session tokens in real time by sitting between the user and the legitimate service.
+
+### Cloud MFA Misconfigurations
+Legacy protocols, weak conditional access rules, or incomplete MFA enforcement can leave gaps that attackers exploit.
+
+### Weak MFA on Remote Access Services
+Services like RDP, SSH, or VPN may have MFA enabled inconsistently or incorrectly, allowing attackers to gain initial access.
+
+### Cross-Platform MFA Weaknesses
+When MFA is applied differently across Windows, Linux, and cloud systems, attackers may target the weakest link to move laterally.
+
+### Device Compromise
+If a user’s device is already compromised, attackers may approve MFA prompts, steal tokens, or intercept authentication flows.
+
+### Token Replay
+Captured or intercepted tokens can sometimes be reused if they are not bound to the device, session, or client.
+
 ## Something You Are
 
 Inherence-based authentication is based on the physical attributes of the user. This is less common for web applications as it requires the user to have specific hardware, and is often considered to be the most invasive in terms of privacy. However, it is commonly used for operating system authentication, and is also used in some mobile applications.

--- a/cheatsheets/Multifactor_Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Multifactor_Authentication_Cheat_Sheet.md
@@ -343,32 +343,40 @@ Email verification requires that the user enters a code or clicks a link sent to
 - Email may be received by the same device the user is authenticating from.
 - Susceptible to phishing.
 
-- ## Modern MFA Attack Patterns (Vendor‑Neutral)
+## Modern MFA Attack Patterns (Vendor‑Neutral)
 
 Even with MFA in place, attackers continue to find ways around it. The patterns below reflect common techniques seen across modern environments. These examples are vendor-neutral and focus on the underlying weaknesses rather than specific products or malware families.
 
 ### MFA Fatigue / Push Abuse
+
 Attackers repeatedly trigger push notifications to overwhelm users until one is approved accidentally or out of frustration.
 
 ### Token Theft
+
 Session cookies, refresh tokens, or other post-authentication tokens can be stolen and reused, allowing attackers to bypass MFA entirely.
 
 ### Reverse-Proxy Phishing Kits
+
 Phishing frameworks can intercept MFA codes or session tokens in real time by sitting between the user and the legitimate service.
 
 ### Cloud MFA Misconfigurations
+
 Legacy protocols, weak conditional access rules, or incomplete MFA enforcement can leave gaps that attackers exploit.
 
 ### Weak MFA on Remote Access Services
+
 Services like RDP, SSH, or VPN may have MFA enabled inconsistently or incorrectly, allowing attackers to gain initial access.
 
 ### Cross-Platform MFA Weaknesses
+
 When MFA is applied differently across Windows, Linux, and cloud systems, attackers may target the weakest link to move laterally.
 
 ### Device Compromise
+
 If a user’s device is already compromised, attackers may approve MFA prompts, steal tokens, or intercept authentication flows.
 
 ### Token Replay
+
 Captured or intercepted tokens can sometimes be reused if they are not bound to the device, session, or client.
 
 ## Something You Are

--- a/cheatsheets/Multifactor_Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Multifactor_Authentication_Cheat_Sheet.md
@@ -345,39 +345,39 @@ Email verification requires that the user enters a code or clicks a link sent to
 
 ## Modern MFA Attack Patterns (Vendor‑Neutral)
 
-Even with MFA in place, attackers continue to find ways around it. The patterns below reflect common techniques seen across modern environments. These examples are vendor-neutral and focus on the underlying weaknesses rather than specific products or malware families.
+Even with MFA in place, attackers continue to find ways around it. The patterns below reflect common techniques seen across modern environments. These examples are vendor-neutral and focus on underlying weaknesses rather than specific products or malware families.
 
 ### MFA Fatigue / Push Abuse
 
-Attackers repeatedly trigger push notifications to overwhelm users until one is approved accidentally or out of frustration.
+Attackers repeatedly trigger push notifications to overwhelm users until one is approved accidentally or out of frustration. This technique has been widely documented in real-world intrusions. [Microsoft](https://www.microsoft.com/en-us/security/blog/2022/09/12/defending-against-mfa-fatigue-attacks/)
 
 ### Token Theft
 
-Session cookies, refresh tokens, or other post-authentication tokens can be stolen and reused, allowing attackers to bypass MFA entirely.
+Session cookies, refresh tokens, or other post-authentication tokens can be stolen and reused, allowing attackers to bypass MFA entirely. NIST highlights the risks of session hijacking and the importance of binding authentication to the client. [NIST SP 800‑63B](https://pages.nist.gov/800-63-3/sp800-63b.html)
 
 ### Reverse-Proxy Phishing Kits
 
-Phishing frameworks can intercept MFA codes or session tokens in real time by sitting between the user and the legitimate service.
+Reverse-proxy phishing frameworks can intercept MFA codes or session tokens in real time by sitting between the user and the legitimate service. CISA recommends phishing-resistant MFA specifically to mitigate these attacks. [CISA](https://www.cisa.gov/news-events/alerts/2022/10/31/implementing-phishing-resistant-mfa)
 
 ### Cloud MFA Misconfigurations
 
-Legacy protocols, weak conditional access rules, or incomplete MFA enforcement can leave gaps that attackers exploit.
+Legacy protocols, weak conditional access rules, or incomplete MFA enforcement can leave gaps that attackers exploit. Misconfigurations are a leading cause of MFA bypass in cloud environments. [Microsoft](https://www.microsoft.com/en-us/security/blog/2021/10/07/5-identity-attack-vectors-and-how-to-prevent-them/)
 
 ### Weak MFA on Remote Access Services
 
-Services like RDP, SSH, or VPN may have MFA enabled inconsistently or incorrectly, allowing attackers to gain initial access.
+Services like RDP, SSH, or VPN may have MFA enabled inconsistently or incorrectly, allowing attackers to gain initial access. CISA advisories frequently highlight remote-access MFA gaps in real incidents. [CISA](https://www.cisa.gov/news-events/cybersecurity-advisories)
 
 ### Cross-Platform MFA Weaknesses
 
-When MFA is applied differently across Windows, Linux, and cloud systems, attackers may target the weakest link to move laterally.
+When MFA is applied differently across Windows, Linux, SaaS, and cloud systems, attackers may target the weakest link to move laterally. NIST emphasizes consistent authenticator assurance across systems. [NIST SP 800‑63B](https://pages.nist.gov/800-63-3/sp800-63b.html)
 
 ### Device Compromise
 
-If a user’s device is already compromised, attackers may approve MFA prompts, steal tokens, or intercept authentication flows.
+If a user’s device is already compromised, attackers may approve MFA prompts, steal tokens, or intercept authentication flows. Compromised endpoints remain a major vector for MFA bypass. [Microsoft](https://www.microsoft.com/en-us/security/blog/2023/03/13/understanding-identity-based-attacks/)
 
 ### Token Replay
 
-Captured or intercepted tokens can sometimes be reused if they are not bound to the device, session, or client.
+Captured or intercepted tokens can sometimes be reused if they are not bound to the device, session, or client. Google Cloud provides detailed analysis of session hijacking and replay attacks. [Google Cloud](https://cloud.google.com/blog/topics/threat-intelligence/understanding-session-hijacking)
 
 ## Something You Are
 


### PR DESCRIPTION
This update adds a new “Common Pitfalls in Input Validation” section to the Input Validation Cheat Sheet, as discussed in Issue #2228. The goal is to highlight the real‑world mistakes that developers frequently make even when they believe they are validating input correctly. These issues appear repeatedly during assessments, code reviews, and incident investigations, so documenting them helps readers avoid subtle but high‑impact vulnerabilities.

The new section covers practical pitfalls such as relying only on client‑side validation, using blacklists instead of whitelists, skipping validation after deserialization, trusting internal services too much, unsafe or overly complex regular expressions, Unicode normalization issues, assumptions about JSON input, and missing validation before logging or storing data. Each point is written in a clear, human tone and includes references to relevant OWASP, NIST, CISA, and Unicode guidance.

This section fits naturally after the “Implementing Input Validation” heading and before the allowlisting/denylisting discussion. It strengthens the cheat sheet by giving readers a realistic understanding of where input validation commonly fails in practice, complementing the existing guidance on how to implement it correctly.

# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [ ] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [ ] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [ ] Any references to websites have been formatted as `[TEXT](URL)`
- [ ] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [ ] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

## Scope and sourcing (required)

- [ ] This PR is focused: it modifies a single cheat sheet, or a small coordinated set, and the scope is described in the PR body.
- [ ] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source (RFC, NIST, OWASP standard, vendor documentation, peer-reviewed research) linked inline as `[text](URL)`.
- [ ] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations.

If your PR is related to an issue, please finish your PR text with the following line:

This PR fixes issue  #2228 .

## AI Tool Usage Disclosure (required for all PRs)

Please select exactly one of the following options. PRs that leave this section blank will be closed.

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [X] I used AI assistance only to help draft and refine the wording for this section. All content was manually reviewed, edited, and validated by me. The LLM used is Microsoft Copilot, and the prompt used was: “Help draft and refine the wording for a concise, human‑tone PR title and description. I added a new ‘Common Pitfalls in Input Validation’ section to the Input Validation Cheat Sheet based on Issue #2228. The prompt should help produce a clear explanation of what was added, why it matters, and how it improves the cheat sheet, written in a natural and professional style.” I have independently verified every citation and technical claim against the cited sources.
 [Feel free to add more details if needed]

    
Thank you again for your contribution :smiley:
