### PR TITLE
fix: swap color and fallback in Slack message format

### DIFF
--- a/scripts/Identify_Old_Issue_And_PR.py
+++ b/scripts/Identify_Old_Issue_And_PR.py
@@ -89,7 +89,7 @@ if len(sys.argv) == 2:
         color = "good"
     else:
         color = "warning"
-    message = "{\"text\": \"Old PR and Issue identification watchdog\",\"attachments\": [ {\"fallback\": \"%s\",\"color\":\"%s\",\"title\": \"Status\",\"text\": \"%s\"}]}" % (color, buffer, buffer)
+    message = "{\"text\": \"Old PR and Issue identification watchdog\",\"attachments\": [ {\"fallback\": \"%s\",\"color\":\"%s\",\"title\": \"Status\",\"text\": \"%s\"}]}" % (buffer, color, buffer)
     request_headers = {"Content-Type": "application/json"}
     response = requests.post(sys.argv[1], headers=request_headers, data=message)
     if response.status_code != 200:


### PR DESCRIPTION
Fixes #2227 — swapped color and fallback format arguments in Slack notification payload. fallback was receiving the color value (e.g. "good"/"warning") instead of a descriptive text, while color was receiving the full status buffer.