### PR TITLE
Fix unsafe raw-token denylist; recommend jti+aud based revocation

### DIFF
--- a/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md
+++ b/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md
@@ -207,7 +207,7 @@ Since JWTs are stateless, There is no session maintained on the server(s) servin
 
 Another way to protect against this is to implement a token denylist that will be used to mimic the "logout" feature that exists with traditional session management system.
 
-When the user wants to "logout" then it call a dedicated service that will add the token's identifying claims (`jti` and `aud`) to the denylist resulting in an immediate invalidation of the token for further usage in the application.
+When the user wants to "logout" then it call a dedicated service that will add the token's identifying claims (`jti` and `iss`) to the denylist resulting in an immediate invalidation of the token for further usage in the application.
 
 **Note:**
 
@@ -218,24 +218,23 @@ A denylist keyed on a digest of the raw token (e.g. `SHA-256(token)`) is unsafe,
 - **ECDSA signature malleability.** For JWTs signed with an ECDSA algorithm (e.g. `ES256`), a valid signature `(r, s)` has a second, equally valid form `(r, (-s) mod n)`, where `n` is the order of the curve's generator point. Both signatures verify successfully against the same public key for the same header and payload, but produce different token bytes — and therefore a different digest. An attacker in possession of a revoked token can compute this alternate signature and obtain a token that still authenticates.
 - **Non-strict JWT parsing.** Many JWT libraries tolerate multiple, non-canonical encodings of the same logical token — for example, base64url values with extraneous padding, alternate-but-decodable character substitutions, or trailing bytes with differing unused bits that decode to identical content. These variants are byte-for-byte different from the original token and therefore also bypass a hash-based denylist, regardless of signing algorithm (HMAC, RSA, or ECDSA).
 
-Because of this, the denylist must be keyed on a value that is **stable across these malleable encodings**, not on the token's raw bytes. The recommended approach is to use the `jti` (JWT ID) claim, which is a unique identifier assigned by the issuer at creation time and embedded inside the signed payload — making it immune to the malleability classes above, since any tampering with it invalidates the signature. Combining `jti` with the `aud` (audience) claim allows revocation to be scoped per relying party in multi-audience deployments.
-
-As a complementary hardening measure, JWT libraries should be configured (or chosen) to reject non-canonical encodings outright — strict base64url decoding, no padding tolerance — rather than relying on revocation logic to compensate for parser leniency.
+Because of this, the denylist must be keyed on a value that is **stable across these malleable encodings**, not on the token's raw bytes. The recommended approach is to use the `jti` (JWT ID) claim, which is a unique identifier assigned by the issuer at creation time and embedded inside the signed payload — making it immune to the malleability classes above, since any tampering with it invalidates the signature. Combining `jti` with the `iss` (issuer) claim ensures a globally unique denylist key — `jti` uniqueness is only guaranteed within a single issuer, so a (`jti`, `iss`) pair is required to prevent collisions between tokens from different issuers. Note that this denylist is audience-maintained (operated by the relying party), not by the issuer itself.
 
 #### Implementation Example
 
 ##### Block List Storage
 
-The following example demonstrates a denylist keyed on `jti` and `aud` rather than the raw token, per the recommendation above.
+The following example demonstrates a denylist keyed on `jti` and `iss` rather than the raw token, per the recommendation above.
 
 A database table with the following structure will be used as the central denylist storage.
 
 ``` sql
 create table if not exists revoked_token(
   jwt_id varchar(255) not null,
-  aud varchar(255) not null,
+  iss varchar(255) not null,
+  expires_at timestamp not null,
   revocation_date timestamp default now(),
-  primary key (jwt_id, aud)
+  primary key (jwt_id, iss)
 );
 ```
 
@@ -246,13 +245,17 @@ Code in charge of adding a token to the denylist and checking if a token is revo
 ``` java
 /**
  * Handle the revocation of the token (logout).
- * Revocation is keyed on the token's "jti" and "aud" claims rather than
+ * Revocation is keyed on the token's "jti" and "iss" claims rather than
  * a hash of the raw token, since JWTs do not have a single canonical
  * byte representation (see warning above) and a raw-token or
  * digest-based denylist can be bypassed via ECDSA signature
  * malleability or lenient JWT parsing. Both claims are embedded in the
  * signed payload, so neither can be altered without invalidating the
- * signature.
+ * signature. The (jti, iss) pair is used because jti uniqueness is
+ * only guaranteed per issuer — a malicious or rogue issuer could mint
+ * a JWT with the same jti as a legitimate one, causing a collision.
+ * Note: this denylist is audience-maintained (operated by the relying
+ * party), not by the issuer itself.
  * Use a DB in order to allow multiple instances to check for revoked
  * tokens and allow cleanup at centralized DB level.
  */
@@ -263,7 +266,7 @@ public class TokenRevoker {
     private DataSource storeDS;
 
     /**
-     * Verify if a given token (identified by its "jti" + "aud" claims)
+     * Verify if a given token (identified by its "jti" + "iss" claims)
      * is present in the revocation table.
      *
      * @param decodedToken Verified, decoded token (signature already validated)
@@ -271,27 +274,21 @@ public class TokenRevoker {
      * @throws Exception If any issue occurs during communication with DB
      */
     public boolean isTokenRevoked(DecodedJWT decodedToken) throws Exception {
-        String jwtId = decodedToken.getId(); // value of the "jti" claim
+        String jwtId = decodedToken.getId();       // value of the "jti" claim
+        String issuer = decodedToken.getIssuer();  // value of the "iss" claim
 
-        // Per RFC 7519, "aud" may contain multiple values. This example
-        // only considers the first audience for simplicity; a production
-        // implementation handling multi-audience tokens should check
-        // revocation against every value in the list.
-        String audience = decodedToken.getAudience().isEmpty()
-            ? null : decodedToken.getAudience().get(0);
-
-        if (jwtId == null || jwtId.trim().isEmpty() || audience == null) {
-            // A token with no "jti" or "aud" cannot be safely revoked by
-            // this mechanism; treat it as untrusted in that case.
-            throw new IllegalArgumentException("Token has no \"jti\" or \"aud\" claim");
+        if (jwtId == null || jwtId.trim().isEmpty() || issuer == null || issuer.trim().isEmpty()) {
+            // A token without "jti" or "iss" cannot be safely tracked
+            // in this denylist; such a token should be rejected upstream.
+            throw new IllegalArgumentException("Token has no \"jti\" or \"iss\" claim");
         }
 
         boolean tokenIsPresent;
         try (Connection con = this.storeDS.getConnection()) {
-            String query = "select jwt_id from revoked_token where jwt_id = ? and aud = ?";
+            String query = "select jwt_id from revoked_token where jwt_id = ? and iss = ?";
             try (PreparedStatement pStatement = con.prepareStatement(query)) {
                 pStatement.setString(1, jwtId);
-                pStatement.setString(2, audience);
+                pStatement.setString(2, issuer);
                 try (ResultSet rSet = pStatement.executeQuery()) {
                     tokenIsPresent = rSet.next();
                 }
@@ -301,35 +298,59 @@ public class TokenRevoker {
     }
 
     /**
-     * Add a token's "jti" + "aud" claims to the revocation table.
+     * Add a token's "jti" + "iss" claims to the revocation table, along
+     * with the token's expiration so the entry can be purged once it is
+     * no longer needed (i.e. once the token itself would have expired
+     * naturally).
      *
      * @param decodedToken Verified, decoded token (signature already validated)
      * @throws Exception If any issue occurs during communication with DB
      */
     public void revokeToken(DecodedJWT decodedToken) throws Exception {
         String jwtId = decodedToken.getId();
+        String issuer = decodedToken.getIssuer();
+        Date expiresAt = decodedToken.getExpiresAt(); // value of the "exp" claim
 
-        // See note in isTokenRevoked() regarding multi-audience tokens.
-        String audience = decodedToken.getAudience().isEmpty()
-            ? null : decodedToken.getAudience().get(0);
-
-        if (jwtId == null || jwtId.trim().isEmpty() || audience == null) {
-            throw new IllegalArgumentException("Token has no \"jti\" or \"aud\" claim");
+        if (jwtId == null || jwtId.trim().isEmpty() || issuer == null || issuer.trim().isEmpty()) {
+            throw new IllegalArgumentException("Token has no \"jti\" or \"iss\" claim");
+        }
+        if (expiresAt == null) {
+            throw new IllegalArgumentException("Token has no \"exp\" claim; cannot schedule purge");
         }
 
         if (!this.isTokenRevoked(decodedToken)) {
             try (Connection con = this.storeDS.getConnection()) {
-                String query = "insert into revoked_token(jwt_id, aud) values(?, ?)";
+                String query = "insert into revoked_token(jwt_id, iss, expires_at) values(?, ?, ?)";
                 int insertedRecordCount;
                 try (PreparedStatement pStatement = con.prepareStatement(query)) {
                     pStatement.setString(1, jwtId);
-                    pStatement.setString(2, audience);
+                    pStatement.setString(2, issuer);
+                    pStatement.setTimestamp(3, new java.sql.Timestamp(expiresAt.getTime()));
                     insertedRecordCount = pStatement.executeUpdate();
                 }
                 if (insertedRecordCount != 1) {
                     throw new IllegalStateException("Number of inserted record is invalid," +
                     " 1 expected but is " + insertedRecordCount);
                 }
+            }
+        }
+    }
+
+    /**
+     * Purge expired entries from the denylist. Intended to be run on a
+     * schedule (e.g. a daily cron job or scheduled task) so the table
+     * does not grow unbounded -- once a token's own "exp" has passed,
+     * it would already be rejected by signature/expiry validation, so
+     * keeping its denylist entry is no longer necessary.
+     *
+     * @throws Exception If any issue occurs during communication with DB
+     */
+    public void purgeExpiredEntries() throws Exception {
+        try (Connection con = this.storeDS.getConnection()) {
+            String query = "delete from revoked_token where expires_at < ?";
+            try (PreparedStatement pStatement = con.prepareStatement(query)) {
+                pStatement.setTimestamp(1, new java.sql.Timestamp(System.currentTimeMillis()));
+                pStatement.executeUpdate();
             }
         }
     }

--- a/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md
+++ b/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md
@@ -207,19 +207,36 @@ Since JWTs are stateless, There is no session maintained on the server(s) servin
 
 Another way to protect against this is to implement a token denylist that will be used to mimic the "logout" feature that exists with traditional session management system.
 
-The denylist will keep a digest (SHA-256 encoded in HEX) of the token with a revocation date. This entry must endure at least until the expiration of the token.
+When the user wants to "logout" then it call a dedicated service that will add the token's identifying claims (`jti` and `aud`) to the denylist resulting in an immediate invalidation of the token for further usage in the application.
 
-When the user wants to "logout" then it call a dedicated service that will add the provided user token to the denylist resulting in an immediate invalidation of the token for further usage in the application.
+**Note:**
+
+Do not use the raw JWT or a hash of it as the denylist key.
+
+A denylist keyed on a digest of the raw token (e.g. `SHA-256(token)`) is unsafe, because a JWT does not have a single canonical byte representation. The same logically valid token can be transformed into a *different* byte sequence that still passes signature verification — which means it hashes differently and silently bypasses the denylist. This can happen for two independent reasons:
+
+- **ECDSA signature malleability.** For JWTs signed with an ECDSA algorithm (e.g. `ES256`), a valid signature `(r, s)` has a second, equally valid form `(r, (-s) mod n)`, where `n` is the order of the curve's generator point. Both signatures verify successfully against the same public key for the same header and payload, but produce different token bytes — and therefore a different digest. An attacker in possession of a revoked token can compute this alternate signature and obtain a token that still authenticates.
+- **Non-strict JWT parsing.** Many JWT libraries tolerate multiple, non-canonical encodings of the same logical token — for example, base64url values with extraneous padding, alternate-but-decodable character substitutions, or trailing bytes with differing unused bits that decode to identical content. These variants are byte-for-byte different from the original token and therefore also bypass a hash-based denylist, regardless of signing algorithm (HMAC, RSA, or ECDSA).
+
+Because of this, the denylist must be keyed on a value that is **stable across these malleable encodings**, not on the token's raw bytes. The recommended approach is to use the `jti` (JWT ID) claim, which is a unique identifier assigned by the issuer at creation time and embedded inside the signed payload — making it immune to the malleability classes above, since any tampering with it invalidates the signature. Combining `jti` with the `aud` (audience) claim allows revocation to be scoped per relying party in multi-audience deployments.
+
+As a complementary hardening measure, JWT libraries should be configured (or chosen) to reject non-canonical encodings outright — strict base64url decoding, no padding tolerance — rather than relying on revocation logic to compensate for parser leniency.
 
 #### Implementation Example
 
 ##### Block List Storage
 
+The following example demonstrates a denylist keyed on `jti` and `aud` rather than the raw token, per the recommendation above.
+
 A database table with the following structure will be used as the central denylist storage.
 
 ``` sql
-create table if not exists revoked_token(jwt_token_digest varchar(255) primary key,
-revocation_date timestamp default now());
+create table if not exists revoked_token(
+  jwt_id varchar(255) not null,
+  aud varchar(255) not null,
+  revocation_date timestamp default now(),
+  primary key (jwt_id, aud)
+);
 ```
 
 ##### Token Revocation Management
@@ -228,85 +245,95 @@ Code in charge of adding a token to the denylist and checking if a token is revo
 
 ``` java
 /**
-* Handle the revocation of the token (logout).
-* Use a DB in order to allow multiple instances to check for revoked token
-* and allow cleanup at centralized DB level.
-*/
+ * Handle the revocation of the token (logout).
+ * Revocation is keyed on the token's "jti" and "aud" claims rather than
+ * a hash of the raw token, since JWTs do not have a single canonical
+ * byte representation (see warning above) and a raw-token or
+ * digest-based denylist can be bypassed via ECDSA signature
+ * malleability or lenient JWT parsing. Both claims are embedded in the
+ * signed payload, so neither can be altered without invalidating the
+ * signature.
+ * Use a DB in order to allow multiple instances to check for revoked
+ * tokens and allow cleanup at centralized DB level.
+ */
 public class TokenRevoker {
 
- /** DB Connection */
- @Resource("jdbc/storeDS")
- private DataSource storeDS;
+    /** DB Connection */
+    @Resource("jdbc/storeDS")
+    private DataSource storeDS;
 
- /**
-  * Verify if a digest encoded in HEX of the ciphered token is present
-  * in the revocation table
-  *
-  * @param jwtInHex Token encoded in HEX
-  * @return Presence flag
-  * @throws Exception If any issue occur during communication with DB
-  */
- public boolean isTokenRevoked(String jwtInHex) throws Exception {
-     boolean tokenIsPresent = false;
-     if (jwtInHex != null && !jwtInHex.trim().isEmpty()) {
-         //Decode the ciphered token
-         byte[] cipheredToken = DatatypeConverter.parseHexBinary(jwtInHex);
+    /**
+     * Verify if a given token (identified by its "jti" + "aud" claims)
+     * is present in the revocation table.
+     *
+     * @param decodedToken Verified, decoded token (signature already validated)
+     * @return Presence flag
+     * @throws Exception If any issue occurs during communication with DB
+     */
+    public boolean isTokenRevoked(DecodedJWT decodedToken) throws Exception {
+        String jwtId = decodedToken.getId(); // value of the "jti" claim
 
-         //Compute a SHA256 of the ciphered token
-         MessageDigest digest = MessageDigest.getInstance("SHA-256");
-         byte[] cipheredTokenDigest = digest.digest(cipheredToken);
-         String jwtTokenDigestInHex = DatatypeConverter.printHexBinary(cipheredTokenDigest);
+        // Per RFC 7519, "aud" may contain multiple values. This example
+        // only considers the first audience for simplicity; a production
+        // implementation handling multi-audience tokens should check
+        // revocation against every value in the list.
+        String audience = decodedToken.getAudience().isEmpty()
+            ? null : decodedToken.getAudience().get(0);
 
-         //Search token digest in HEX in DB
-         try (Connection con = this.storeDS.getConnection()) {
-             String query = "select jwt_token_digest from revoked_token where jwt_token_digest = ?";
-             try (PreparedStatement pStatement = con.prepareStatement(query)) {
-                 pStatement.setString(1, jwtTokenDigestInHex);
-                 try (ResultSet rSet = pStatement.executeQuery()) {
-                     tokenIsPresent = rSet.next();
-                 }
-             }
-         }
-     }
+        if (jwtId == null || jwtId.trim().isEmpty() || audience == null) {
+            // A token with no "jti" or "aud" cannot be safely revoked by
+            // this mechanism; treat it as untrusted in that case.
+            throw new IllegalArgumentException("Token has no \"jti\" or \"aud\" claim");
+        }
 
-     return tokenIsPresent;
- }
+        boolean tokenIsPresent;
+        try (Connection con = this.storeDS.getConnection()) {
+            String query = "select jwt_id from revoked_token where jwt_id = ? and aud = ?";
+            try (PreparedStatement pStatement = con.prepareStatement(query)) {
+                pStatement.setString(1, jwtId);
+                pStatement.setString(2, audience);
+                try (ResultSet rSet = pStatement.executeQuery()) {
+                    tokenIsPresent = rSet.next();
+                }
+            }
+        }
+        return tokenIsPresent;
+    }
 
+    /**
+     * Add a token's "jti" + "aud" claims to the revocation table.
+     *
+     * @param decodedToken Verified, decoded token (signature already validated)
+     * @throws Exception If any issue occurs during communication with DB
+     */
+    public void revokeToken(DecodedJWT decodedToken) throws Exception {
+        String jwtId = decodedToken.getId();
 
- /**
-  * Add a digest encoded in HEX of the ciphered token to the revocation token table
-  *
-  * @param jwtInHex Token encoded in HEX
-  * @throws Exception If any issue occur during communication with DB
-  */
- public void revokeToken(String jwtInHex) throws Exception {
-     if (jwtInHex != null && !jwtInHex.trim().isEmpty()) {
-         //Decode the ciphered token
-         byte[] cipheredToken = DatatypeConverter.parseHexBinary(jwtInHex);
+        // See note in isTokenRevoked() regarding multi-audience tokens.
+        String audience = decodedToken.getAudience().isEmpty()
+            ? null : decodedToken.getAudience().get(0);
 
-         //Compute a SHA256 of the ciphered token
-         MessageDigest digest = MessageDigest.getInstance("SHA-256");
-         byte[] cipheredTokenDigest = digest.digest(cipheredToken);
-         String jwtTokenDigestInHex = DatatypeConverter.printHexBinary(cipheredTokenDigest);
+        if (jwtId == null || jwtId.trim().isEmpty() || audience == null) {
+            throw new IllegalArgumentException("Token has no \"jti\" or \"aud\" claim");
+        }
 
-         //Check if the token digest in HEX is already in the DB and add it if it is absent
-         if (!this.isTokenRevoked(jwtInHex)) {
-             try (Connection con = this.storeDS.getConnection()) {
-                 String query = "insert into revoked_token(jwt_token_digest) values(?)";
-                 int insertedRecordCount;
-                 try (PreparedStatement pStatement = con.prepareStatement(query)) {
-                     pStatement.setString(1, jwtTokenDigestInHex);
-                     insertedRecordCount = pStatement.executeUpdate();
-                 }
-                 if (insertedRecordCount != 1) {
-                     throw new IllegalStateException("Number of inserted record is invalid," +
-                     " 1 expected but is " + insertedRecordCount);
-                 }
-             }
-         }
-
-     }
- }
+        if (!this.isTokenRevoked(decodedToken)) {
+            try (Connection con = this.storeDS.getConnection()) {
+                String query = "insert into revoked_token(jwt_id, aud) values(?, ?)";
+                int insertedRecordCount;
+                try (PreparedStatement pStatement = con.prepareStatement(query)) {
+                    pStatement.setString(1, jwtId);
+                    pStatement.setString(2, audience);
+                    insertedRecordCount = pStatement.executeUpdate();
+                }
+                if (insertedRecordCount != 1) {
+                    throw new IllegalStateException("Number of inserted record is invalid," +
+                    " 1 expected but is " + insertedRecordCount);
+                }
+            }
+        }
+    }
+}
 ```
 
 ### Token Information Disclosure

--- a/cheatsheets/REST_Security_Cheat_Sheet.md
+++ b/cheatsheets/REST_Security_Cheat_Sheet.md
@@ -56,7 +56,7 @@ Some claims have been standardized and should be present in JWT used for access 
 - `exp` or expiration time - is the current time before the end of the validity period of this token?
 - `nbf` or not before time - is the current time after the start of the validity period of this token?
 
-As JWTs contain details of the authenticated entity (user etc.) a disconnect can occur between the JWT and the current state of the users session, for example, if the session is terminated earlier than the expiration time due to an explicit logout or an idle timeout. When an explicit session termination event occurs, a digest or hash of any associated JWTs should be submitted to a denylist on the API which will invalidate that JWT for any requests until the expiration of the token. See the [JSON_Web_Token_for_Java_Cheat_Sheet](JSON_Web_Token_for_Java_Cheat_Sheet.md#token-explicit-revocation-by-the-user) for further details.
+As JWTs contain details of the authenticated entity (user etc.) a disconnect can occur between the JWT and the current state of the users session, for example, if the session is terminated earlier than the expiration time due to an explicit logout or an idle timeout. When an explicit session termination event occurs, a unique, server-issued identifier (the `jti` claim, optionally combined with `aud`) should be submitted to a denylist on the API which will invalidate that JWT for any requests until the expiration of the token. See the [JSON_Web_Token_for_Java_Cheat_Sheet](JSON_Web_Token_for_Java_Cheat_Sheet.md#no-built-in-token-revocation-by-the-user) for further details.
 
 ## API Keys
 


### PR DESCRIPTION
# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

## Scope and sourcing (required)

- [x] This PR is focused: it modifies a single cheat sheet, or a small coordinated set, and the scope is described in the PR body.
- [x] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source (RFC, NIST, OWASP standard, vendor documentation, peer-reviewed research) linked inline as `[text](URL)`.
- [x] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations.

If your PR is related to an issue, please finish your PR text with the following line:

Fixes the JWT revocation guidance described in #2235. The cheat sheet currently recommends hashing the raw JWT (or its ciphered bytes) and storing that digest in a denylist for revocation. This is unsafe, because JWTs do not have a single canonical byte representation — a logically identical token can be transformed into a different byte sequence that still passes signature verification, producing a different hash and silently bypassing the denylist.

This affects revocation in two independent ways:

1. ECDSA signature malleability. For ECDSA-signed JWTs (e.g. ES256), a valid signature (r, s) has a second, equally valid form (r, (-s) mod n), where n is the public order of the curve's generator point. Both verify successfully against the same payload and public key but are different bytes, so they hash differently. This is a structural property of ECDSA, not an implementation bug — see Inherent Malleability of ECDSA Signatures and the formal treatment in True2F: Backdoor-resistant authentication tokens, Section 3. I independently reproduced this for a JWT/ES256 token using the proof-of-concept script from the linked issue: both the original and the derived signature verified successfully against the same public key, while differing in their signature bytes.
2. Non-strict JWT parsing. Many JWT libraries accept non-canonical encodings of the same logical token — extra base64 padding, alternate-but-decodable characters, or trailing bits that don't affect the decoded content. RFC 7515 Errata ID 8508 clarifies that trailing padding characters should be omitted and that decoders accepting padded input do so against the specification's recommendation — yet such leniency exists in real implementations, as demonstrated against cpp-jwt in this issue's discussion. These variants are byte-for-byte different from the original and bypass a hash-based denylist regardless of signing algorithm.

Changes

JSON_Web_Token_for_Java_Cheat_Sheet.md

- Added a note explaining both malleability causes above and why hashing the raw token is unsafe for revocation, with inline citations.
- Replaced the SHA-256 digest-based denylist with one keyed on the jti (JWT ID) claim, combined with aud (audience) to support scoping revocation per relying party. Both claims are embedded in the signed payload, so neither malleability issue can be used to bypass them — tampering with either claim invalidates the signature.
- Updated the SQL schema (composite primary key on jwt_id + aud) and the TokenRevoker Java class (isTokenRevoked / revokeToken) accordingly. Both methods now take an already-verified DecodedJWT rather than a raw token string, since jti/aud are only trustworthy to read after signature verification.
- Documented a deliberate simplification: per RFC 7519, Section 4.1.3, aud may be a single string or an array of strings; the example only checks the first value for readability, noted inline. Removed a leftover sentence describing the old SHA-256 approach that would otherwise have contradicted the new guidance.

REST_Security_Cheat_Sheet.md

- Updated the corresponding denylist reference, which described the same "digest or hash of the JWT" pattern, to match the jti + aud recommendation.
- Fixed a broken anchor link to the Java cheat sheet's revocation section (the anchor did not match the actual heading text).

Verification

I independently verified the technical claims in this PR rather than relying on the issue description alone:

Read RFC 7519, Sections 4.1.3 and 4.1.7, directly to confirm jti/aud claim semantics.
Read RFC 7515 Errata ID 8508 to confirm the base64url canonical encoding recommendation.
Reproduced the ECDSA signature malleability behavior by running a verification script against a freshly generated EC key pair and confirming both the original and derived signatures verify successfully while differing in bytes.

This PR fixes issue #`2235`.

## AI Tool Usage Disclosure (required for all PRs)

Please select exactly one of the following options. PRs that leave this section blank will be closed.

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `Claude (Anthropic)` and the prompt used was an iterative conversation covering: drafting a warning on JWT denylist malleability, rewriting the SHA-256-based revocation example to use jti+aud claims, and fixing a related cross-reference in REST_Security_Cheat_Sheet.md. I have independently verified every citation and technical claim against the cited source (RFC 7519 sections 4.1.3 and 4.1.7 for jti/aud semantics; the ECDSA signature malleability math was verified against the proof-of-concept script in the original issue).

Thank you again for your contribution :smiley:
