### PR TITLE
Add CSRF, CSP-violation, excess-session, and logout events to Logging Vocabulary

### DIFF
--- a/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
@@ -820,7 +820,7 @@ CRITICAL
 ### malicious_csrf:[userid|IP]
 
 **Description**
-When a state-changing request arrives without a valid anti-CSRF token (or with a mismatched token, Origin, or Referer) it may indicate a cross-site request forgery attempt. Block the request and log the attempt.
+When a state-changing request arrives without a valid anti-CSRF token (or with a mismatched token, Origin, or Referer) it may indicate a cross-site request forgery attempt. Block the request and log the attempt. See the [OWASP Cross-Site Request Forgery Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) for token and Origin/Referer validation guidance.
 
 **Level:**
 WARN
@@ -845,7 +845,7 @@ WARN
 **Description**
 When a browser reports a Content-Security-Policy violation to your report endpoint, log the violation. In Report-Only mode this is high-noise — browser extensions and injected third-party scripts trigger benign violations — so WARN is appropriate; promote to CRITICAL only if you treat enforced-mode blocks as attack signal.
 
-_NOTE: CSP report fields such as `document-uri`, `referrer`, and `blocked-uri` routinely contain full URLs whose query strings carry session or reset tokens. Strip the query string/fragment before logging, and prefer the effective-directive + blocked-uri (origin+path) over the full report body to avoid a secondary sensitive-data or log-injection risk._
+_NOTE: CSP report fields such as `document-uri`, `referrer`, and `blocked-uri` are URL-valued (see the [W3C Content Security Policy Level 3](https://www.w3.org/TR/CSP3/#violation-events) violation report definition) and routinely contain full URLs whose query strings carry session or reset tokens. Strip the query string/fragment before logging, and prefer the effective-directive + blocked-uri (origin+path) over the full report body to avoid a secondary sensitive-data or log-injection risk._
 
 **Level:**
 WARN

--- a/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
@@ -53,6 +53,7 @@ Some languages have libraries which ease the job of adopting this logging vocabu
 
 - Python: [lucabello/owasp-logger](https://github.com/lucabello/owasp-logger)
 - C#/.NET: [byteguard-hq/byteguard-security-logger](https://github.com/ByteGuard-HQ/byteguard-security-logger)
+- Python / Java / Go / Node.js: [thatsjet/security_event_logger](https://github.com/thatsjet/security_event_logger)
 
 ## Format
 
@@ -510,6 +511,28 @@ Expected service limit ceilings should be established and alerted when exceeded,
 
 ---
 
+### excess_sessions_exceeded[userid,max]
+
+**Description**
+When a user exceeds the maximum number of concurrent sessions allowed it should be logged. An unusually high concurrent-session count can indicate credential sharing or account takeover.
+
+**Level:**: WARN
+
+**Example:**
+
+```
+{
+    "datetime": "2019-01-01 00:00:00,000",
+    "appid": "foobar.netportal_auth",
+    "event": "excess_sessions_exceeded:app.foobarapi.prod,5",
+    "level": "WARN",
+    "description": "User app.foobarapi.prod exceeded the max of 5 concurrent sessions",
+    ...
+}
+```
+
+---
+
 ## File Upload [UPLOAD]
 
 ### upload_complete[userid,filename,type]
@@ -648,7 +671,7 @@ WARN
 
 ---
 
-## Malicious Behavior [MALICIOUS
+## Malicious Behavior [MALICIOUS]
 
 ### malicious_excess_404:[userid|IP,useragent]
 
@@ -788,6 +811,54 @@ CRITICAL
     "event": "malicious_direct_reference:joebob1, Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
     "level": "CRITICAL",
     "description": "User joebob1 attempted to access an object to which they are not authorized",
+    ...
+}
+```
+
+---
+
+### malicious_csrf:[userid|IP]
+
+**Description**
+When a state-changing request arrives without a valid anti-CSRF token (or with a mismatched token, Origin, or Referer) it may indicate a cross-site request forgery attempt. Block the request and log the attempt.
+
+**Level:**
+WARN
+
+**Example:**
+
+```
+{
+    "datetime": "2019-01-01 00:00:00,000",
+    "appid": "foobar.netportal_auth",
+    "event": "malicious_csrf:joebob1",
+    "level": "WARN",
+    "description": "A state-changing request from joebob1 was missing a valid anti-CSRF token",
+    ...
+}
+```
+
+---
+
+### malicious_csp_violation:[userid|IP,effective_directive,blocked_uri,useragent]
+
+**Description**
+When a browser reports a Content-Security-Policy violation to your report endpoint, log the violation. In Report-Only mode this is high-noise — browser extensions and injected third-party scripts trigger benign violations — so WARN is appropriate; promote to CRITICAL only if you treat enforced-mode blocks as attack signal.
+
+_NOTE: CSP report fields such as `document-uri`, `referrer`, and `blocked-uri` routinely contain full URLs whose query strings carry session or reset tokens. Strip the query string/fragment before logging, and prefer the effective-directive + blocked-uri (origin+path) over the full report body to avoid a secondary sensitive-data or log-injection risk._
+
+**Level:**
+WARN
+
+**Example:**
+
+```
+{
+    "datetime": "2019-01-01 00:00:00,000",
+    "appid": "foobar.netportal_auth",
+    "event": "malicious_csp_violation:203.0.113.7,script-src,https://foobar.com/dashboard,Mozilla/5.0",
+    "level": "WARN",
+    "description": "A CSP violation for directive script-src was reported by a browser at 203.0.113.7",
     ...
 }
 ```
@@ -1098,6 +1169,29 @@ INFO
     "event": "session_expired:joebob1,revoked",
     "level": "INFO",
     "description": "User joebob1 session expired due to administrator revocation.",
+    ...
+}
+```
+
+---
+
+### session_logout:[userid,sessionid]
+
+**Description**
+When a user explicitly logs out (as opposed to a timeout or administrative revocation) the event may be logged. This is a more explicit alternative to `session_expired:[userid,logout]` for systems that distinguish a user-initiated logout.
+
+**Level:**
+INFO
+
+**Example:**
+
+```
+{
+    "datetime": "2019-01-01 00:00:00,000",
+    "appid": "foobar.netportal_auth",
+    "event": "session_logout:joebob1,kx12ab",
+    "level": "INFO",
+    "description": "User joebob1 logged out",
     ...
 }
 ```


### PR DESCRIPTION
## Summary

Adds four new event types and one logger-library reference to the Logging Vocabulary Cheat Sheet, plus a small heading fix. All additions follow the existing entry format (description, level, JSON example).

- **`excess_sessions_exceeded[userid,max]`** (Session Management) — concurrent-session limit exceeded; signal for credential sharing / account takeover. `WARN`.
- **`malicious_csrf[userid|IP]`** (Malicious Behavior) — state-changing request missing/with-mismatched anti-CSRF token, Origin, or Referer. `WARN`.
- **`malicious_csp_violation[userid|IP,effective_directive,blocked_uri,useragent]`** (Malicious Behavior) — browser-reported CSP violation, with a note to strip query strings/fragments from CSP report URLs (they can carry session/reset tokens) to avoid a secondary sensitive-data / log-injection risk. `WARN`.
- **`session_logout[userid,sessionid]`** (Session Management) — explicit user-initiated logout, distinct from timeout/admin revocation. `INFO`.
- Added Python/Java/Go/Node.js logger library reference under the libraries list.
- Fixed the **Malicious Behavior** heading (was missing its closing `]`).

## Checklist

- [x] All the markdown files follow the [format rules](../CONTRIBUTING.md#markdown).
- [x] Any references to websites have been formatted as `[TEXT](URL)`.
- [x] You verified/tested the effectiveness of your contribution.
- [x] N/A — not a new Cheat Sheet; no assets/images added.
- [ ] The CI build of your PR passes (will be confirmed by CI on this PR).

## Scope and sourcing

- [x] This PR is focused: it modifies a single cheat sheet (Logging Vocabulary).
- These additions follow the established vocabulary-definition format used throughout this cheat sheet, which defines event names/levels/examples rather than citing a primary source per entry. The CSP note reflects standard guidance on keeping tokens out of logs.

## AI Tool Usage Disclosure

- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `Claude (Opus 4.8) via Claude Code`, and the prompt used was to draft new Logging Vocabulary event-type entries (CSRF, CSP violation, excess concurrent sessions, user-initiated logout) matching the cheat sheet's existing entry format. I have independently verified every technical claim and the cited reference.
