### PR TITLE
Add Gabriel Corona to project leaders and security contacts

### DIFF
--- a/Preface.md
+++ b/Preface.md
@@ -14,6 +14,7 @@ Project leaders:
 
 - [Jim Manico](https://github.com/jmanico)
 - [Jakub Maćkowski](https://github.com/mackowski)
+- [Gabriel Corona](https://github.com/randomstuff)
 
 Core team:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,4 +19,4 @@ Instead, submit a private report including clear steps to reproduce and details 
 
 - <jim.manico@owasp.org>
 - <jakub.mackowski@owasp.org>
-- <shlomo.heigh@owasp.org>
+- <corona.gabriel@gmail.com>


### PR DESCRIPTION
Adds Gabriel Corona (@randomstuff) to the Preface project leaders list and updates the security contact list to include him in place of Shlomo Heigh.

README already lists him as a leader (via #2253); this covers the remaining Preface and SECURITY references.