### PR TITLE
Add Token Status List reference as issuer-side revocation alternative

### DIFF
--- a/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md
+++ b/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md
@@ -357,6 +357,12 @@ public class TokenRevoker {
 }
 ```
 
+#### Issuer-Side Revocation: Token Status List
+
+The denylist approach described above is typically operated by the relying party (resource server) — it works well when the audience maintains its own revocation state close to where tokens are validated. However, in some deployments the issuer needs to centrally broadcast revocation state to multiple relying parties without requiring each one to maintain its own denylist.
+
+For this use case, the IETF [Token Status List (TSL)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-status-list) draft defines a scalable, issuer-maintained revocation mechanism. TSL is used in SD-JWT Verifiable Credentials, mobile Driving Licenses (mDL), and other high-scale deployments where a single issuer serves many relying parties. Consult the TSL draft for implementation guidance when issuer-side revocation is required.
+
 ### Token Information Disclosure
 
 #### Symptom

--- a/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md
+++ b/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.md
@@ -361,7 +361,8 @@ public class TokenRevoker {
 
 The denylist approach described above is typically operated by the relying party (resource server) — it works well when the audience maintains its own revocation state close to where tokens are validated. However, in some deployments the issuer needs to centrally broadcast revocation state to multiple relying parties without requiring each one to maintain its own denylist.
 
-For this use case, the IETF [Token Status List (TSL)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-status-list) draft defines a scalable, issuer-maintained revocation mechanism. TSL is used in SD-JWT Verifiable Credentials, mobile Driving Licenses (mDL), and other high-scale deployments where a single issuer serves many relying parties. Consult the TSL draft for implementation guidance when issuer-side revocation is required.
+For this use case, the IETF [Token Status List (TSL)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-status-list) draft defines a scalable, issuer-maintained revocation mechanism. TSL is used in SD-JWT Verifiable Credentials and other high-scale
+deployments where a single issuer serves many relying parties. Consult the TSL draft for implementation guidance when issuer-side revocation is required.
 
 ### Token Information Disclosure
 


### PR DESCRIPTION
# You're A Rockstar

Thank you for submitting a Pull Request (PR) to the Cheat Sheet Series.

> :triangular_flag_on_post: If your PR is related to grammar/typo mistakes, please double-check the file for other mistakes in order to fix all the issues in the current cheat sheet.

Please make sure that for your contribution:

- [ ] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md).
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [ ] All your assets are stored in the **assets** folder.
- [ ] All the images used are in the **PNG** format.
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

## Scope and sourcing (required)

- [x] This PR is focused: it modifies a single cheat sheet, or a small coordinated set, and the scope is described in the PR body.
- [x] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source (RFC, NIST, OWASP standard, vendor documentation, peer-reviewed research) linked inline as `[text](URL)`.
- [x] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations.

If your PR is related to an issue, please finish your PR text with the following line:

## What this PR does

Adds a brief note under the JWT revocation section documenting the distinction between audience-maintained denylists (the (jti, iss) approach from #2242) and issuer-side revocation via the IETF Token Status List draft, as suggested by @randomstuff in the #2242 review.

## Changes

- `JSON_Web_Token_for_Java_Cheat_Sheet.md`: added a new `#### Issuer-Side Revocation: Token Status List` subsection explaining when TSL is the more appropriate pattern and linking to the IETF draft for implementation guidance.

This PR fixes issue #`2252`.

## AI Tool Usage Disclosure (required for all PRs)

Please select exactly one of the following options. PRs that leave this section blank will be closed.

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `Claude (Anthropic, Sonnet 4.6)` and the prompt used was an iterative conversation covering: drafting a brief note documenting the distinction between audience-maintained denylists and issuer-side revocation via the IETF Token Status List draft, as a follow-up to PR #2242. I have independently verified the TSL draft link (https://datatracker.ietf.org/doc/html/draft-ietf-oauth-status-list) confirms it is an active IETF draft, and verified that SD-JWT Verifiable Credentials and mobile Driving Licenses (mDL) are documented use cases within the draft itself.

Thank you again for your contribution :smiley:
