### PR TITLE
Update DotNet_Security_Cheat_Sheet.md

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -801,7 +801,7 @@ DO NOT: Use the BinaryFormatter type which is dangerous and [not recommended]
 .NET offers several in-box serializers that can handle untrusted data safely:
 
 - XmlSerializer and DataContractSerializer to serialize object graphs into and from XML. Do not confuse DataContractSerializer with NetDataContractSerializer.
-- BinaryReader and BinaryWriter for XML and JSON.
+- BinaryReader and BinaryWriter for reading and writing primitive data types (such as Int32, Double, Boolean, and String) in binary format.
 - The System.Text.Json APIs to serialize object graphs into JSON.
 
 ### A09 Security Logging and Monitoring Failures


### PR DESCRIPTION
### Summary
This PR corrects a technical inaccuracy in the **DotNet Security Cheat Sheet** regarding the description of `BinaryReader` and `BinaryWriter`.

### Issue
In the section **A08 Software and Data Integrity Failures**, the cheat sheet states that `BinaryReader` and `BinaryWriter` are used **"for XML and JSON"**. This is incorrect. These classes are designed for reading and writing primitive data types in binary format, not for processing structured text formats like XML or JSON.

The original text:
> `BinaryReader` and `BinaryWriter` for XML and JSON.

### Correction
This PR updates the description to accurately reflect the purpose of these classes:
> `BinaryReader` and `BinaryWriter` for reading and writing primitive data types (such as `Int32`, `Double`, `Boolean`, and `String`) in binary format.

The full corrected paragraph will read:
> Do not use the `BinaryFormatter` type which is insecure and not recommended for data processing. .NET offers several in-box serializers that can handle untrusted data safely:
> - `XmlSerializer` and `DataContractSerializer` to serialize object graphs into and from XML. Do not confuse `DataContractSerializer` with `NetDataContractSerializer`.
> - `BinaryReader` and `BinaryWriter` for reading and writing primitive data types (such as `Int32`, `Double`, `Boolean`, and `String`) in binary format.
> - The `System.Text.Json` APIs to serialize object graphs into JSON.

### Scope and Sourcing (required)
- **Scope**: This PR is focused and modifies a single cheat sheet (`DotNet_Security_Cheat_Sheet.md`), correcting a single factual error in the listed recommendations.
- **Sourcing**: The correction is based on the official Microsoft .NET API documentation:
    - [`BinaryReader Class`](https://learn.microsoft.com/en-us/dotnet/api/system.io.binaryreader): "Reads primitive data types as binary values in a specific encoding."
    - [`BinaryWriter Class`](https://learn.microsoft.com/en-us/dotnet/api/system.io.binarywriter): "Writes primitive types in binary to a stream."
    - [`System.Text.Json`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json) and [`XmlSerializer`](https://learn.microsoft.com/en-us/dotnet/api/system.xml.serialization.xmlserializer) are the correct APIs for JSON and XML respectively. I have read and confirmed these sources.

### AI Tool Usage Disclosure
- [x] I have NOT used any AI tool to generate the contents of this PR.