### PR TITLE
Serverless secrets: platform config, not env vars

### DIFF
--- a/cheatsheets/Serverless_FaaS_Security_Cheat_Sheet.md
+++ b/cheatsheets/Serverless_FaaS_Security_Cheat_Sheet.md
@@ -14,7 +14,7 @@ This cheat sheet provides best practices to secure serverless applications and m
 - Cold start data leakage (persistent state, side-channel timing).
 - Function chaining abuse (compromised function invoking others).
 - Shared environment risks (multi-tenant leakage, `/tmp` reuse).
-- Hardcoded secrets in code or env vars.
+- Hardcoded secrets in code or platform config.
 - Excessive network access.
 
 ## Best Practices
@@ -130,8 +130,7 @@ def lambda_handler(event, context):
 
 ### 6. Secrets Management
 
-- Avoid storing secrets in environment variables.
-- Fetch secrets from vaults using local caching extensions where possible, not env vars.
+- Fetch secrets at runtime from a vault or caching extension — not from platform-level function configuration (e.g. Lambda Environment Variables).
 - Use ephemeral credentials (STS, workload identity federation).
 - Rotate secrets automatically.
 
@@ -221,7 +220,7 @@ shasum -a 256 layer.zip
 
 - Enforce least privilege per function.
 - Validate all event inputs.
-- Fetch secrets from vaults, not env vars.
+- Fetch secrets from vaults, not platform config.
 - Restrict network egress.
 - Monitor invocations and logs.
 


### PR DESCRIPTION
### Description

Clarifies "environment variables" -> "platform config" to distinguish
persisted function configuration (Lambda Environment Variables panel,
visible to management APIs/IaC) from transient process variables
(`getenv()`/`environ[]`).

### Problem

"Avoid storing secrets in environment variables" appears three times
without clarification. This conflicts with 12-factor config principles
and obscures the actual risk: secrets in deployment metadata vs. secrets
fetched at runtime.

### Changes

1. Key Risks (line 18): `env vars` -> `platform config`.
2. Secrets Management (lines 133-134): merge bullets, add
   "platform-level function configuration (e.g. Lambda Environment
   Variables)".
3. Do's/Don'ts (line 223): `env vars` -> `platform config`.

- [x] Not a new Cheat Sheet (N/A: Cheat Sheet template).
- [x] All the markdown files do not raise any validation policy
      violation.
- [x] All the markdown files follow the format rules.
- [x] No new assets added (N/A: assets folder).
- [x] No new images added (N/A: PNG format).
- [x] No new website references added (N/A: link formatting).
- [x] Verified the wording change against the surrounding sections
      for internal consistency (see #2293).
- [ ] CI build pass (pending CI run).

## Scope and sourcing (required)

- [x] This PR is focused: it modifies a single cheat sheet, and the
      scope is described in the PR body.
- [x] No new technical claims are introduced; this only disambiguates
      existing wording (N/A: primary sourcing).
- [x] No new sources are cited (N/A: source verification).

This PR fixes issue #2293.

## AI Tool Usage Disclosure (required for all PRs)

- [x] I have used AI tools to generate the contents of this PR. I have
    verified the contents and I affirm the results. The LLM used is
    `Claude Sonnet 4.5 (via pi coding agent)` and the prompt used was
    an interactive discussion: investigating when/why the "avoid env
    vars" wording was added (git history, PR #2015, issue #2011),
    working through the platform-config-vs-process-env distinction,
    and drafting/wordsmithing the three wording changes. I wrote and
    reviewed the final wording myself, in Vim (btw). :heart:
