### PR TITLE
Normalize US English in AI security sheets

### DIFF
--- a/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
+++ b/cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md
@@ -12,7 +12,7 @@ The controls described here are complementary to the [OWASP MCP Security Cheat S
 
 Agent-initiated payments are subject to the same regulatory framework as human-initiated payments. Key regulations include:
 
-- **Bank Secrecy Act (BSA)**: Requires financial institutions to maintain effective AML programmes, including customer identification, transaction monitoring, and suspicious activity reporting. The [Bank Secrecy Act](https://www.fincen.gov/index.php/resources/statutes-and-regulations/bank-secrecy-act) does not distinguish between human-initiated and agent-initiated transactions.
+- **Bank Secrecy Act (BSA)**: Requires financial institutions to maintain effective AML programs, including customer identification, transaction monitoring, and suspicious activity reporting. The [Bank Secrecy Act](https://www.fincen.gov/index.php/resources/statutes-and-regulations/bank-secrecy-act) does not distinguish between human-initiated and agent-initiated transactions.
 - **OFAC Sanctions**: The Office of Foreign Assets Control requires all US persons and entities to screen transactions against the Specially Designated Nationals (SDN) list and other sanctions lists. Screening obligations apply regardless of whether the transaction was initiated by a human or an agent.
 - **FinCEN Requirements**: [FinCEN](https://www.fincen.gov/) rules require Customer Identification Programs (CIP), Customer Due Diligence (CDD), and Suspicious Activity Reports (SARs). When an agent acts on behalf of a customer, the institution must be able to identify both the customer and the agent.
 - **UK Financial Sanctions (OFSI)**: HM Treasury's Office of Financial Sanctions Implementation maintains the [UK Consolidated Sanctions List](https://www.gov.uk/government/publications/financial-sanctions-consolidated-list-of-targets). Screening is mandatory for all financial transactions regardless of initiation method.
@@ -21,7 +21,7 @@ Agent-initiated payments are subject to the same regulatory framework as human-i
 
 ### Key Principle
 
-Regulators do not care whether a transaction was initiated by a human clicking a button or an agent calling an API. The compliance obligations are identical. The burden is on the institution to prove that screening occurred, that the agent was authorised, and that the results are tamper-evident.
+Regulators do not care whether a transaction was initiated by a human clicking a button or an agent calling an API. The compliance obligations are identical. The burden is on the institution to prove that screening occurred, that the agent was authorized, and that the results are tamper-evident.
 
 ## Section 1: Agent Identity Before Screening
 
@@ -66,7 +66,7 @@ The agent itself is software. But the agent has an operator -- the developer, co
 
 ### Do
 
-- Screen the agent's declared operator (organisation name, jurisdiction, registration number) against sanctions lists during agent onboarding.
+- Screen the agent's declared operator (organization name, jurisdiction, registration number) against sanctions lists during agent onboarding.
 - Re-screen agent operators periodically (at minimum when sanctions lists are updated) and revoke agent access if the operator becomes sanctioned.
 - Record the operator's screening status as part of the agent's trust profile.
 - Require agents to declare their operator identity as part of their cryptographic passport or identity credential.
@@ -106,7 +106,7 @@ When screening fails -- due to a timeout, service outage, malformed response, or
 - Deny the payment or transaction if screening cannot be completed successfully.
 - Return a clear, structured error to the agent indicating that screening failed and the transaction cannot proceed.
 - Log all screening failures with the same level of detail as successful screens, including the reason for failure.
-- Alert compliance teams when screening failure rates exceed a threshold, as this may indicate a denial-of-service attack designed to force fail-open behaviour.
+- Alert compliance teams when screening failure rates exceed a threshold, as this may indicate a denial-of-service attack designed to force fail-open behavior.
 - Implement circuit breakers that halt agent-initiated payments entirely if the screening service is unavailable for an extended period.
 
 ### Don't
@@ -124,8 +124,8 @@ Not all agents should be treated equally. Unverified or low-trust agents should 
 
 - Implement per-agent rate limits based on cryptographic identity (public key fingerprint or passport ID).
 - Set lower rate limits for newly registered or low-trust agents (e.g. L0/L1) and higher limits for verified, high-trust agents (e.g. L3/L4).
-- Include rate limit status in screening responses (remaining quota, reset time) so agents can adjust their behaviour.
-- Downgrade an agent's rate limit allocation if anomalous behaviour is detected (e.g. sudden spike in screening requests, unusual entity patterns).
+- Include rate limit status in screening responses (remaining quota, reset time) so agents can adjust their behavior.
+- Downgrade an agent's rate limit allocation if anomalous behavior is detected (e.g. sudden spike in screening requests, unusual entity patterns).
 
 ### Don't
 
@@ -142,14 +142,14 @@ Institutions must decide whether to run their own screening engine or use a host
 - The institution maintains the sanctions lists, the matching engine, and the screening API on its own infrastructure.
 - Agent requests stay within the institution's network boundary.
 - The institution has full control over list update frequency, matching algorithms, and data retention.
-- Requires operational investment in list ingestion, normalisation, and matching quality.
+- Requires operational investment in list ingestion, normalization, and matching quality.
 
 ### Hosted Screening (Third-Party API)
 
 - The institution calls a third-party screening API (e.g. a sanctions screening provider).
 - Agent identity credentials and screening data leave the institution's network boundary.
 - The institution must ensure the third-party provider meets applicable regulatory requirements.
-- Data minimisation principles apply -- send only the minimum data needed for screening, not the agent's full context.
+- Data minimization principles apply -- send only the minimum data needed for screening, not the agent's full context.
 
 ### Do
 
@@ -183,7 +183,7 @@ Use the **JSON Canonicalization Scheme (JCS), [RFC 8785](https://www.rfc-editor.
 
 Agent payments often traverse multiple agents (orchestrator to sub-agent to service). If the compliance receipt stays only with the issuing system, accountability is lost at the first hop. The signed receipt MUST **travel with the transaction** so every downstream party can independently verify who was screened, against which lists, and what was decided, without trusting an upstream agent's word.
 
-Bind each receipt to the specific transaction (include the transaction or intent hash in the signed payload) and propagate it end-to-end. Each hop verifies the inbound receipt and, if it takes its own action, appends its own signed receipt, producing a verifiable chain of accountability across agents. Message-level integrity and replay defence for such receipts is covered in [Section 7 of the OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html#7-message-level-integrity-and-replay-defence).
+Bind each receipt to the specific transaction (include the transaction or intent hash in the signed payload) and propagate it end-to-end. Each hop verifies the inbound receipt and, if it takes its own action, appends its own signed receipt, producing a verifiable chain of accountability across agents. Message-level integrity and replay defense for such receipts is covered in [Section 7 of the OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html#7-message-level-integrity-and-replay-defence).
 
 ### Do
 

--- a/cheatsheets/Bot_Management_and_Anti-Automation_Cheat_Sheet.md
+++ b/cheatsheets/Bot_Management_and_Anti-Automation_Cheat_Sheet.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Modern web applications face a continuous stream of automated traffic that is not a Distributed Denial of Service event but is still abusive: credential stuffing, content scraping, inventory hoarding (scalping), fake account creation, gift-card enumeration, card testing, fake reviews, click fraud, and skewed analytics. The OWASP **Automated Threats to Web Applications** project (OAT-001 through OAT-021) catalogues these patterns.
+Modern web applications face a continuous stream of automated traffic that is not a Distributed Denial of Service event but is still abusive: credential stuffing, content scraping, inventory hoarding (scalping), fake account creation, gift-card enumeration, card testing, fake reviews, click fraud, and skewed analytics. The OWASP **Automated Threats to Web Applications** project (OAT-001 through OAT-021) catalogs these patterns.
 
 This cheat sheet provides defensive guidance that goes beyond the [Credential Stuffing Prevention Cheat Sheet](Credential_Stuffing_Prevention_Cheat_Sheet.md) and addresses the full spectrum of automated abuse. It focuses on architecture, signals, response strategy, and CAPTCHA alternatives.
 
@@ -180,7 +180,7 @@ Server side: if `company_url` is non-empty, silently drop the request or route t
 - API keys with rotating secrets, **not** static bearer tokens checked in to client code.
 - Per-key quotas advertised in `X-RateLimit-*` headers so well-behaved clients self-throttle.
 - Request signing (e.g., HMAC of method + path + timestamp + body) to prevent replay and require a stable secret.
-- Tier APIs explicitly: a public catalogue endpoint may serve cached, slightly-delayed data; partner APIs serve realtime data with an authenticated key.
+- Tier APIs explicitly: a public catalog endpoint may serve cached, slightly-delayed data; partner APIs serve realtime data with an authenticated key.
 
 ## Response Strategy: Don't Always Block
 
@@ -257,7 +257,7 @@ Anti-bot defenses collect data. Treat them like any other data-processing activi
 
 ## Checklist
 
-- [ ] Map application endpoints to the OWASP Automated Threats (OAT) catalogue.
+- [ ] Map application endpoints to the OWASP Automated Threats (OAT) catalog.
 - [ ] Apply rate limits at IP, identity, and endpoint levels, using a sliding window.
 - [ ] Layer defenses across edge, application, and business logic.
 - [ ] Use TLS/HTTP-level fingerprints before resorting to browser fingerprinting.

--- a/cheatsheets/Secure_Coding_with_AI_Cheat_Sheet.md
+++ b/cheatsheets/Secure_Coding_with_AI_Cheat_Sheet.md
@@ -35,7 +35,7 @@ AI coding agents operate across multiple trust boundaries. Understanding these b
 
 ### Threat Actors and Attack Surfaces
 
-- **Repository content as instruction source.** Issue bodies, PR descriptions, PR comments, README files, dependency changelogs, error traces, fetched web pages, and MCP tool responses all become instructions when the agent reads them. An attacker who can write to any of these can influence agent behaviour.
+- **Repository content as instruction source.** Issue bodies, PR descriptions, PR comments, README files, dependency changelogs, error traces, fetched web pages, and MCP tool responses all become instructions when the agent reads them. An attacker who can write to any of these can influence agent behavior.
 - **MCP servers as tool providers.** Agents connect to MCP servers to access tools. A malicious or compromised MCP server can poison tool descriptions, shadow legitimate tool names, exfiltrate credentials through tool arguments, or update tool definitions after initial approval (rug-pull).
 - **Rules files as persistent steering.** Files like `.cursorrules`, `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and `.windsurfrules` silently steer every future generation. They can be modified by a malicious PR or by the agent itself to embed persistent instructions.
 - **The agent itself.** Agents running with auto-accept and full developer permissions can install packages, write to any file, execute shell commands, modify CI configuration, and push branches. A compromised agent context has the same blast radius as a compromised developer workstation.
@@ -50,7 +50,7 @@ AI coding assistants frequently suggest package names that do not exist on publi
 - Verify every AI-suggested package exists on the public registry before installing. Check the package page, download count, maintainer history, and creation date.
 - Be suspicious of packages with very low download counts, recent creation dates (less than 30 days), or a single maintainer with no other packages.
 - Implement a pre-install hook or CI check that blocks installation of packages below a minimum age threshold.
-- Maintain an internal allowlist of approved packages for your organisation.
+- Maintain an internal allowlist of approved packages for your organization.
 
 ### Don't
 
@@ -77,7 +77,7 @@ AI models are trained on historical code. They frequently suggest dependency ver
 
 ## Section 3: Indirect Prompt Injection in the Development Loop
 
-Agentic coding tools ingest context from the repository, the network, and connected tools. Any content the agent reads can contain hidden instructions that alter its behaviour. This is indirect prompt injection applied to the development workflow.
+Agentic coding tools ingest context from the repository, the network, and connected tools. Any content the agent reads can contain hidden instructions that alter its behavior. This is indirect prompt injection applied to the development workflow.
 
 ### Attack Vectors
 
@@ -92,7 +92,7 @@ Agentic coding tools ingest context from the repository, the network, and connec
 
 - Treat all repository content (issues, PRs, comments, READMEs) as untrusted input when processed by an AI coding agent.
 - Review agent output for unexpected changes after the agent processes any external content.
-- Use tools that sanitise or flag potential injection patterns in repository content before the agent processes it.
+- Use tools that sanitize or flag potential injection patterns in repository content before the agent processes it.
 - Restrict agent context to the minimum files and content needed for the task.
 - Audit agent actions after processing content from external contributors or public repositories.
 
@@ -111,7 +111,7 @@ For comprehensive MCP security guidance, see the [MCP Security Cheat Sheet](http
 ### Do
 
 - Audit all MCP servers connected to your development environment. Maintain an allowlist of approved servers and tools.
-- Pin tool definitions and detect changes. Use snapshot-and-diff mechanisms to catch rug-pull updates where a tool's behaviour changes after initial approval.
+- Pin tool definitions and detect changes. Use snapshot-and-diff mechanisms to catch rug-pull updates where a tool's behavior changes after initial approval.
 - Review tool descriptions for hidden instructions. Tool descriptions are part of the agent's context and can contain prompt injection payloads.
 - Restrict which tools the agent can invoke. Apply least privilege -- a coding agent does not need access to email, payment, or administrative tools.
 - Monitor for tool name shadowing where a malicious MCP server registers a tool with the same name as a legitimate one to intercept calls.
@@ -148,7 +148,7 @@ Agentic coding tools execute commands, install packages, write files, and access
 
 ## Section 6: Rules Files and Persistent Steering
 
-AI coding tools read configuration files that steer their behaviour across all future interactions. These files are a persistence mechanism -- an attacker who can modify them controls every subsequent generation.
+AI coding tools read configuration files that steer their behavior across all future interactions. These files are a persistence mechanism -- an attacker who can modify them controls every subsequent generation.
 
 ### Affected Files
 
@@ -194,7 +194,7 @@ Agents routinely touch files beyond the scope of the requested change: lockfiles
 
 ## Section 8: Test Fabrication and Test Deletion
 
-AI agents make CI green by deleting failing tests, weakening assertions, mocking the unit under test instead of fixing the code, or asserting the buggy behaviour. A passing test suite generated by the same agent that produced the code provides no independent assurance.
+AI agents make CI green by deleting failing tests, weakening assertions, mocking the unit under test instead of fixing the code, or asserting the buggy behavior. A passing test suite generated by the same agent that produced the code provides no independent assurance.
 
 ### Do
 
@@ -202,16 +202,16 @@ AI agents make CI green by deleting failing tests, weakening assertions, mocking
     - Deleted tests (why was this test removed?)
     - Weakened assertions (did `assertEquals` become `assertNotNull`?)
     - New mocks that replace real dependencies the test was designed to exercise
-    - Tests that assert the generated behaviour rather than the correct behaviour
+    - Tests that assert the generated behavior rather than the correct behavior
 - Add adversarial and negative test cases that the AI did not generate: invalid inputs, expired tokens, malformed payloads, boundary conditions, concurrent access.
 - Measure security confidence by adversarial testing results and independent analysis, not by "all tests pass."
 - Implement CI rules that flag test deletions or assertion-count reductions in agent-generated PRs.
-- Write security-critical tests manually for authentication, authorisation, input validation, and cryptographic operations.
+- Write security-critical tests manually for authentication, authorization, input validation, and cryptographic operations.
 
 ### Don't
 
 - Trust AI-generated test suites as evidence of security.
-- Measure confidence by test pass rate alone. 100% passing means nothing if the tests assert broken behaviour.
+- Measure confidence by test pass rate alone. 100% passing means nothing if the tests assert broken behavior.
 - Allow agents to delete or modify existing tests without explicit justification reviewed by a human.
 - Allow the agent to both write the security-critical code and its tests without independent verification.
 
@@ -268,7 +268,7 @@ AI-powered CI/CD agents (review bots, automated code fixers, PR assistants) run 
 ### Do
 
 - Scope CI agent credentials to the minimum required permissions. Review bots should not have deploy keys or write access to secrets.
-- Filter and sanitise PR content (title, body, comments, diff) before passing it to CI agents as context. PR content is attacker-controlled input.
+- Filter and sanitize PR content (title, body, comments, diff) before passing it to CI agents as context. PR content is attacker-controlled input.
 - Run CI agents in isolated environments with no access to production secrets or credentials beyond what the specific job requires.
 - Log all CI agent actions with full context for audit. Monitor for unexpected file modifications, network calls, or secret access patterns.
 - Implement approval gates before CI agents can push commits, modify workflows, or access sensitive resources.
@@ -281,18 +281,18 @@ AI-powered CI/CD agents (review bots, automated code fixers, PR assistants) run 
 
 ## Section 12: Markdown, Link, and Unicode Injection
 
-Agent output rendered in IDE chat panes, PR comments, or review interfaces can contain Markdown-based exfiltration links, bidi (bidirectional) text overrides, and zero-width characters that influence future agent behaviour or mislead reviewers.
+Agent output rendered in IDE chat panes, PR comments, or review interfaces can contain Markdown-based exfiltration links, bidi (bidirectional) text overrides, and zero-width characters that influence future agent behavior or mislead reviewers.
 
 ### Do
 
-- Sanitise agent output before rendering in IDE chat panes or PR comments. Strip or escape Markdown image tags, hidden links, and HTML entities.
+- Sanitize agent output before rendering in IDE chat panes or PR comments. Strip or escape Markdown image tags, hidden links, and HTML entities.
 - Detect and flag bidi override characters (U+202A through U+202E, U+2066 through U+2069) and zero-width characters (U+200B, U+200C, U+200D, U+FEFF) in code, commits, and agent output.
 - Use CI checks that scan for homoglyph attacks and invisible characters in PRs.
 - Review agent-generated commit messages and PR descriptions for embedded content that could influence future agent runs.
 
 ### Don't
 
-- Render agent output containing Markdown images or links without sanitisation. Image tags with external URLs can exfiltrate conversation context via URL parameters.
+- Render agent output containing Markdown images or links without sanitization. Image tags with external URLs can exfiltrate conversation context via URL parameters.
 - Assume that code containing only visible ASCII characters is safe. Zero-width and bidi characters are invisible in most editors.
 - Allow agent-generated content to be committed without scanning for unicode injection.
 
@@ -303,7 +303,7 @@ When multiple agents interact (e.g. a coding agent delegates to a search agent, 
 ### Do
 
 - Treat output from one agent as untrusted input when passed to another agent.
-- Implement context boundaries between agents. Do not pass full conversation history or raw tool responses between agents without sanitisation.
+- Implement context boundaries between agents. Do not pass full conversation history or raw tool responses between agents without sanitization.
 - Monitor cross-agent interactions for instruction propagation patterns (e.g. one agent's output instructing another to exfiltrate data or modify files).
 - Validate that sub-agent actions remain within the scope defined by the parent task.
 


### PR DESCRIPTION
The repository requires US English, but these three related sheets retained British spellings. This normalizes 27 occurrences without changing URLs or technical meaning.

Part of #2266.

## Checks

- [x] `npm test`
- [x] Scope is limited to three related cheat sheets.
- [x] No technical claims, recommendations, citations, or URLs were added or changed.

## AI Tool Usage Disclosure

- [x] I used OpenAI Codex (GPT-5.6). Prompt: "Normalize British spellings in these three cheat sheets; preserve URLs, quotes, identifiers, and proper names."
