### PR TITLE
Add mcp-slim-guard as recommended MCP security proxy

### DIFF
--- a/cheatsheets/MCP_Security_Cheat_Sheet.md
+++ b/cheatsheets/MCP_Security_Cheat_Sheet.md
@@ -104,7 +104,7 @@ Transport-layer security (TLS) protects data in transit but does not guarantee m
 - Treat each MCP server as an untrusted, independent security domain.
 - Prevent tool descriptions from one server from referencing or modifying the behavior of tools from another server.
 - Monitor for cross-server data flows (e.g., credentials from server A appearing in calls to server B).
-- Use an MCP proxy or gateway to enforce isolation policies between servers.
+- Use an MCP proxy or gateway to enforce isolation policies between servers. Open-source tools such as [mcp-slim-guard](https://github.com/lennney/mcp-slim-guard) can act as a drop-in security proxy providing SSRF protection, injection detection, tool allow/deny filtering, rate limiting, and audit logging across all connected servers.
 
 ### 9. Supply Chain Security
 
@@ -173,5 +173,6 @@ Transport-layer security (TLS) protects data in transit but does not guarantee m
 - [MCP Specification — Security Best Practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices)
 - [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 - [mcp-scan — Security Scanner for MCP Servers](https://github.com/invariantlabs-ai/mcp-scan)
+- [mcp-slim-guard — MCP Security Proxy with Compression](https://github.com/lennney/mcp-slim-guard)
 - [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/)
 - [IETF Internet-Draft: Secure MCP — Message Signing and Tool Integrity](https://datatracker.ietf.org/doc/draft-sharif-mcps-secure-mcp/)


### PR DESCRIPTION
## What

Add a concrete open-source tool reference (mcp-slim-guard) for the existing guidance in Section 8 that recommends using an MCP proxy or gateway for multi-server isolation.

## Why

The cheat sheet currently recommends `mcp-scan` (a detection tool) in multiple places. It does not yet recommend any proxy/gateway tool for the prevention guidance in Section 8 ("Use an MCP proxy or gateway to enforce isolation policies between servers").

[mcp-slim-guard](https://github.com/lennney/mcp-slim-guard) fills this gap:
- **MIT-licensed** open-source MCP security proxy
- **SSRF protection**: IP blacklist + domain whitelist
- **Injection detection**: 17 heuristic patterns (shell/SQL/NoSQL/prompt injection)
- **Tool allow/deny**: glob-based filtering, fail-closed by default
- **Rate limiting**: token bucket, per-tool configurable
- **Audit logging**: structured JSON with rotation + compression
- Already published on npm: `npx -y mcp-slim-guard start`

## Changes

- Section 8: extend "Use an MCP proxy or gateway" bullet with a concrete tool example
- References: add link to mcp-slim-guard repository

## Scope & sourcing

- [x] This PR is focused: it modifies a single cheat sheet (MCP_Security_Cheat_Sheet.md)
- [x] The tool referenced is MIT-licensed open-source software with public source code and documentation
- [x] No new technical claims are made — only a concrete tool reference for existing guidance

## AI Tool Usage Disclosure

- [x] I have used AI tools (DeepSeek V4 Pro) to assist with drafting this PR description. I have verified the contents and affirm the results.