### PR TITLE
fix: correct AES-512 to AES-256 in DotNet Security Cheat Sheet

### DIFF
--- a/cheatsheets/DotNet_Security_Cheat_Sheet.md
+++ b/cheatsheets/DotNet_Security_Cheat_Sheet.md
@@ -165,7 +165,7 @@ DO: Enforce passwords with a minimum complexity that will survive a dictionary a
 
 #### Encryption
 
-DO: Use a strong encryption algorithm such as AES-512 where personally identifiable data needs to be restored to it's original format.
+DO: Use a strong encryption algorithm such as AES-256 where personally identifiable data needs to be restored to its original format.
 
 DO: Protect encryption keys more than any other asset. Find more information about storing encryption keys at rest in the
   [Key Management Cheat Sheet](Key_Management_Cheat_Sheet.md#storage).


### PR DESCRIPTION
## Summary

Fix incorrect AES algorithm name and grammar error in DotNet Security Cheat Sheet.

## Changes

- Corrected `AES-512` to `AES-256` (AES only supports key sizes of 128, 192, and 256 bits; AES-512 does not exist)
- Fixed grammar: `it's` → `its` (possessive form)

## Impact

This prevents developers from attempting to use a non-existent encryption algorithm, which could lead to implementation errors or security vulnerabilities.

---

I apologize for any inconvenience and appreciate your time reviewing this contribution.

Note: Local environment limitations - relying on CI/CD for markdown validation.
