### PR TITLE
ci: add Index.md drift check

### DIFF
--- a/.github/workflows/index-drift-check.yml
+++ b/.github/workflows/index-drift-check.yml
@@ -1,0 +1,34 @@
+name: Index Drift Check
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'cheatsheets/**'
+      - 'Index.md'
+      - 'scripts/Update_CheatSheets_Index.py'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Save committed Index.md
+        run: cp Index.md Index.md.committed
+
+      - name: Regenerate Index.md
+        run: cd scripts && python Update_CheatSheets_Index.py
+
+      - name: Check for drift
+        run: |
+          if ! diff -u Index.md.committed Index.md; then
+            echo "::error::Index.md is out of date. Run 'cd scripts && python Update_CheatSheets_Index.py' and commit the result."
+            exit 1
+          fi
+          echo "Index.md is up to date."

--- a/Index.md
+++ b/Index.md
@@ -1,10 +1,10 @@
 # Index Alphabetical
 
-**92** cheat sheets available.
+**120** cheat sheets available.
 
 *Icons beside the cheat sheet name indicate in which language(s) code snippet(s) are provided.*
 
-[A](Index.md#a) [B](Index.md#b) [C](Index.md#c) [D](Index.md#d) [E](Index.md#e) [F](Index.md#f) [G](Index.md#g) [H](Index.md#h) [I](Index.md#i) [J](Index.md#j) [K](Index.md#k) [L](Index.md#l) [M](Index.md#m) [N](Index.md#n) [O](Index.md#o) [P](Index.md#p) [Q](Index.md#q) [R](Index.md#r) [S](Index.md#s) [T](Index.md#t) [U](Index.md#u) [V](Index.md#v) [W](Index.md#w) [X](Index.md#x)
+[A](Index.md#a) [B](Index.md#b) [C](Index.md#c) [D](Index.md#d) [E](Index.md#e) [F](Index.md#f) [G](Index.md#g) [H](Index.md#h) [I](Index.md#i) [J](Index.md#j) [K](Index.md#k) [L](Index.md#l) [M](Index.md#m) [N](Index.md#n) [O](Index.md#o) [P](Index.md#p) [Q](Index.md#q) [R](Index.md#r) [S](Index.md#s) [T](Index.md#t) [U](Index.md#u) [V](Index.md#v) [W](Index.md#w) [X](Index.md#x) [Z](Index.md#z)
 
 ## A
 
@@ -12,17 +12,29 @@
 
 [Attack Surface Analysis Cheat Sheet](cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.md)
 
+[Authorization Regression Testing Cheat Sheet](cheatsheets/Authorization_Regression_Testing_Cheat_Sheet.md)
+
 [Authentication Cheat Sheet](cheatsheets/Authentication_Cheat_Sheet.md)
 
 [Authorization Cheat Sheet](cheatsheets/Authorization_Cheat_Sheet.md)
 
-[AJAX Security Cheat Sheet](cheatsheets/AJAX_Security_Cheat_Sheet.md) ![Json](assets/Index_Json.svg)
+[AJAX Security Cheat Sheet](cheatsheets/AJAX_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg)
+
+[Automotive Security Cheat Sheet](cheatsheets/Automotive_Security_Cheat_Sheet.md)
 
 [Abuse Case Cheat Sheet](cheatsheets/Abuse_Case_Cheat_Sheet.md)
 
 [Authorization Testing Automation Cheat Sheet](cheatsheets/Authorization_Testing_Automation_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg)
 
+[AML Sanctions AI Agent Payments Cheat Sheet](cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md)
+
+[AI Agent Security Cheat Sheet](cheatsheets/AI_Agent_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
+
 ## B
+
+[Browser Extension Vulnerabilities Cheat Sheet](cheatsheets/Browser_Extension_Vulnerabilities_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg)
+
+[Bot Management and Anti-Automation Cheat Sheet](cheatsheets/Bot_Management_and_Anti-Automation_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg) ![Python](assets/Index_Python.svg)
 
 [Bean Validation Cheat Sheet](cheatsheets/Bean_Validation_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg)
 
@@ -32,9 +44,11 @@
 
 [CI CD Security Cheat Sheet](cheatsheets/CI_CD_Security_Cheat_Sheet.md)
 
-[Cross-Site Request Forgery Prevention Cheat Sheet](cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md) ![Html](assets/Index_Html.svg)
+[Cross-Site Request Forgery Prevention Cheat Sheet](cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
 
 [Clickjacking Defense Cheat Sheet](cheatsheets/Clickjacking_Defense_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
+
+[Cookie Theft Mitigation Cheat Sheet](cheatsheets/Cookie_Theft_Mitigation_Cheat_Sheet.md)
 
 [Cross Site Scripting Prevention Cheat Sheet](cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md) ![Html](assets/Index_Html.svg)
 
@@ -64,13 +78,17 @@
 
 [DOM based XSS Prevention Cheat Sheet](cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
 
+[Drone Security Cheat Sheet](cheatsheets/Drone_Security_Cheat_Sheet.md)
+
+[Dependency Graph SBOM Cheat Sheet](cheatsheets/Dependency_Graph_SBOM_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
+
 [Denial of Service Cheat Sheet](cheatsheets/Denial_of_Service_Cheat_Sheet.md)
 
 [DOM Clobbering Prevention Cheat Sheet](cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
 
-[Drone Security Cheat Sheet](cheatsheets/Drone_Security_Cheat_Sheet.md)
-
 ## E
+
+[Email Validation and Verification Cheat Sheet](cheatsheets/Email_Validation_and_Verification_Cheat_Sheet.md)
 
 [Error Handling Cheat Sheet](cheatsheets/Error_Handling_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Csharp](assets/Index_Csharp.svg) ![Xml](assets/Index_Xml.svg)
 
@@ -84,11 +102,15 @@
 
 [GraphQL Cheat Sheet](cheatsheets/GraphQL_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Java](assets/Index_Java.svg)
 
+[gRPC Security Cheat Sheet](cheatsheets/gRPC_Security_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
+
+[GitHub Actions Security Cheat Sheet](cheatsheets/GitHub_Actions_Security_Cheat_Sheet.md)
+
 ## H
 
 [HTTP Headers Cheat Sheet](cheatsheets/HTTP_Headers_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Xml](assets/Index_Xml.svg) ![Php](assets/Index_Php.svg)
 
-[HTML5 Security Cheat Sheet](cheatsheets/HTML5_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Java](assets/Index_Java.svg) ![Html](assets/Index_Html.svg) ![Json](assets/Index_Json.svg) ![Shell](assets/Index_Shell.svg)
+[HTML5 Security Cheat Sheet](cheatsheets/HTML5_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
 
 [HTTP Strict Transport Security Cheat Sheet](cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.md)
 
@@ -108,9 +130,9 @@
 
 [Java Security Cheat Sheet](cheatsheets/Java_Security_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg)
 
-[JAAS Cheat Sheet](cheatsheets/JAAS_Cheat_Sheet.md) ![Java](assets/Index_Java.svg)
+[JSON Web Token Cheat Sheet](cheatsheets/JSON_Web_Token_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Python](assets/Index_Python.svg) ![Json](assets/Index_Json.svg)
 
-[JSON Web Token Cheat Sheet](cheatsheets/JSON_Web_Token_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Java](assets/Index_Java.svg) ![Json](assets/Index_Json.svg) ![Sql](assets/Index_Sql.svg)
+[JAAS Cheat Sheet](cheatsheets/JAAS_Cheat_Sheet.md) ![Java](assets/Index_Java.svg)
 
 ## K
 
@@ -124,15 +146,23 @@
 
 [Laravel Cheat Sheet](cheatsheets/Laravel_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Php](assets/Index_Php.svg) ![Sql](assets/Index_Sql.svg) ![Bash](assets/Index_Bash.svg)
 
-[LDAP Injection Prevention Cheat Sheet](cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md)
+[LDAP Injection Prevention Cheat Sheet](cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md) ![Java](assets/Index_Java.svg)
 
-[Logging Vocabulary Cheat Sheet](cheatsheets/Logging_Vocabulary_Cheat_Sheet.md)
+[Logging Vocabulary Cheat Sheet](cheatsheets/Logging_Vocabulary_Cheat_Sheet.md) ![Json](assets/Index_Json.svg)
+
+[LLM Prompt Injection Prevention Cheat Sheet](cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
+
+[Legacy Application Management Cheat Sheet](cheatsheets/Legacy_Application_Management_Cheat_Sheet.md)
 
 ## M
 
 [Microservices Security Cheat Sheet](cheatsheets/Microservices_Security_Cheat_Sheet.md)
 
+[Multi Tenant Security Cheat Sheet](cheatsheets/Multi_Tenant_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg) ![Sql](assets/Index_Sql.svg)
+
 [Mobile Application Security Cheat Sheet](cheatsheets/Mobile_Application_Security_Cheat_Sheet.md)
+
+[MCP Security Cheat Sheet](cheatsheets/MCP_Security_Cheat_Sheet.md)
 
 [Multifactor Authentication Cheat Sheet](cheatsheets/Multifactor_Authentication_Cheat_Sheet.md)
 
@@ -144,11 +174,13 @@
 
 [NodeJS Docker Cheat Sheet](cheatsheets/NodeJS_Docker_Cheat_Sheet.md)
 
-[NPM Security Cheat Sheet](cheatsheets/NPM_Security_Cheat_Sheet.md)
+[NPM Security Cheat Sheet](cheatsheets/NPM_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg) ![Bash](assets/Index_Bash.svg)
 
 [Nodejs Security Cheat Sheet](cheatsheets/Nodejs_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Bash](assets/Index_Bash.svg)
 
 [Network Segmentation Cheat Sheet](cheatsheets/Network_Segmentation_Cheat_Sheet.md)
+
+[NoSQL Security Cheat Sheet](cheatsheets/NoSQL_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
 
 ## O
 
@@ -172,25 +204,27 @@
 
 ## R
 
-[RAG Security Cheat Sheet](cheatsheets/RAG_Security_Cheat_Sheet.md)
-
 [REST Security Cheat Sheet](cheatsheets/REST_Security_Cheat_Sheet.md)
 
 [REST Assessment Cheat Sheet](cheatsheets/REST_Assessment_Cheat_Sheet.md)
+
+[RAG Security Cheat Sheet](cheatsheets/RAG_Security_Cheat_Sheet.md)
 
 [Ruby on Rails Cheat Sheet](cheatsheets/Ruby_on_Rails_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Ruby](assets/Index_Ruby.svg) ![Bash](assets/Index_Bash.svg)
 
 ## S
 
+[Secure AI Model Ops Cheat Sheet](cheatsheets/Secure_AI_Model_Ops_Cheat_Sheet.md)
+
+[Security Terminology Cheat Sheet](cheatsheets/Security_Terminology_Cheat_Sheet.md)
+
+[Secure Code Review Cheat Sheet](cheatsheets/Secure_Code_Review_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
+
 [Secure Product Design Cheat Sheet](cheatsheets/Secure_Product_Design_Cheat_Sheet.md)
 
 [Secure Cloud Architecture Cheat Sheet](cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.md)
 
-[Secure Coding with AI Cheat Sheet](cheatsheets/Secure_Coding_with_AI_Cheat_Sheet.md)
-
 [Securing Cascading Style Sheets Cheat Sheet](cheatsheets/Securing_Cascading_Style_Sheets_Cheat_Sheet.md)
-
-[Security Terminology Cheat Sheet](cheatsheets/Security_Terminology_Cheat_Sheet.md)
 
 [SQL Injection Prevention Cheat Sheet](cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Csharp](assets/Index_Csharp.svg) ![Vbnet](assets/Index_Vbnet.svg)
 
@@ -198,19 +232,29 @@
 
 [SAML Security Cheat Sheet](cheatsheets/SAML_Security_Cheat_Sheet.md)
 
+[Secure Coding with AI Cheat Sheet](cheatsheets/Secure_Coding_with_AI_Cheat_Sheet.md)
+
 [Session Management Cheat Sheet](cheatsheets/Session_Management_Cheat_Sheet.md)
 
-[Secrets Management Cheat Sheet](cheatsheets/Secrets_Management_Cheat_Sheet.md)
+[Software Supply Chain Security Cheat Sheet](cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.md)
+
+[Secrets Management Cheat Sheet](cheatsheets/Secrets_Management_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
 
 [Symfony Cheat Sheet](cheatsheets/Symfony_Cheat_Sheet.md) ![Php](assets/Index_Php.svg) ![Bash](assets/Index_Bash.svg)
 
+[Subdomain Takeover Prevention Cheat Sheet](cheatsheets/Subdomain_Takeover_Prevention_Cheat_Sheet.md)
+
+[Serverless FaaS Security Cheat Sheet](cheatsheets/Serverless_FaaS_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg) ![Json](assets/Index_Json.svg) ![Bash](assets/Index_Bash.svg)
+
 ## T
+
+[Third Party Payment Gateway Integration Cheat Sheet](cheatsheets/Third_Party_Payment_Gateway_Integration_Cheat_Sheet.md)
 
 [Transaction Authorization Cheat Sheet](cheatsheets/Transaction_Authorization_Cheat_Sheet.md)
 
 [TLS Cipher String Cheat Sheet](cheatsheets/TLS_Cipher_String_Cheat_Sheet.md)
 
-[Transport Layer Security Cheat Sheet](cheatsheets/Transport_Layer_Security_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
+[Transport Layer Security Cheat Sheet](cheatsheets/Transport_Layer_Security_Cheat_Sheet.md)
 
 [Transport Layer Protection Cheat Sheet](cheatsheets/Transport_Layer_Protection_Cheat_Sheet.md)
 
@@ -234,6 +278,8 @@
 
 ## W
 
+[WebSocket Security Cheat Sheet](cheatsheets/WebSocket_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg)
+
 [Web Service Security Cheat Sheet](cheatsheets/Web_Service_Security_Cheat_Sheet.md)
 
 ## X
@@ -245,3 +291,7 @@
 [XML Security Cheat Sheet](cheatsheets/XML_Security_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg) ![Bash](assets/Index_Bash.svg)
 
 [XS Leaks Cheat Sheet](cheatsheets/XS_Leaks_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
+
+## Z
+
+[Zero Trust Architecture Cheat Sheet](cheatsheets/Zero_Trust_Architecture_Cheat_Sheet.md)

--- a/Index.md
+++ b/Index.md
@@ -8,83 +8,83 @@
 
 ## A
 
+[AI Agent Security Cheat Sheet](cheatsheets/AI_Agent_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
+
+[AJAX Security Cheat Sheet](cheatsheets/AJAX_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg)
+
+[AML Sanctions AI Agent Payments Cheat Sheet](cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md)
+
+[Abuse Case Cheat Sheet](cheatsheets/Abuse_Case_Cheat_Sheet.md)
+
 [Access Control Cheat Sheet](cheatsheets/Access_Control_Cheat_Sheet.md)
 
 [Attack Surface Analysis Cheat Sheet](cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.md)
-
-[Authorization Regression Testing Cheat Sheet](cheatsheets/Authorization_Regression_Testing_Cheat_Sheet.md)
 
 [Authentication Cheat Sheet](cheatsheets/Authentication_Cheat_Sheet.md)
 
 [Authorization Cheat Sheet](cheatsheets/Authorization_Cheat_Sheet.md)
 
-[AJAX Security Cheat Sheet](cheatsheets/AJAX_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg)
-
-[Automotive Security Cheat Sheet](cheatsheets/Automotive_Security_Cheat_Sheet.md)
-
-[Abuse Case Cheat Sheet](cheatsheets/Abuse_Case_Cheat_Sheet.md)
+[Authorization Regression Testing Cheat Sheet](cheatsheets/Authorization_Regression_Testing_Cheat_Sheet.md)
 
 [Authorization Testing Automation Cheat Sheet](cheatsheets/Authorization_Testing_Automation_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg)
 
-[AML Sanctions AI Agent Payments Cheat Sheet](cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md)
-
-[AI Agent Security Cheat Sheet](cheatsheets/AI_Agent_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
+[Automotive Security Cheat Sheet](cheatsheets/Automotive_Security_Cheat_Sheet.md)
 
 ## B
 
-[Browser Extension Vulnerabilities Cheat Sheet](cheatsheets/Browser_Extension_Vulnerabilities_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg)
+[Bean Validation Cheat Sheet](cheatsheets/Bean_Validation_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg)
 
 [Bot Management and Anti-Automation Cheat Sheet](cheatsheets/Bot_Management_and_Anti-Automation_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg) ![Python](assets/Index_Python.svg)
 
-[Bean Validation Cheat Sheet](cheatsheets/Bean_Validation_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg)
+[Browser Extension Vulnerabilities Cheat Sheet](cheatsheets/Browser_Extension_Vulnerabilities_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg)
 
 [Business Logic Security Cheat Sheet](cheatsheets/Business_Logic_Security_Cheat_Sheet.md)
 
 ## C
 
-[CI CD Security Cheat Sheet](cheatsheets/CI_CD_Security_Cheat_Sheet.md)
-
-[Cross-Site Request Forgery Prevention Cheat Sheet](cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
-
-[Clickjacking Defense Cheat Sheet](cheatsheets/Clickjacking_Defense_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
-
-[Cookie Theft Mitigation Cheat Sheet](cheatsheets/Cookie_Theft_Mitigation_Cheat_Sheet.md)
-
-[Cross Site Scripting Prevention Cheat Sheet](cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md) ![Html](assets/Index_Html.svg)
-
 [C-Based Toolchain Hardening Cheat Sheet](cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md) ![C](assets/Index_C.svg) ![Bash](assets/Index_Bash.svg)
+
+[CI CD Security Cheat Sheet](cheatsheets/CI_CD_Security_Cheat_Sheet.md)
 
 [Choosing and Using Security Questions Cheat Sheet](cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.md)
 
+[Clickjacking Defense Cheat Sheet](cheatsheets/Clickjacking_Defense_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
+
 [Content Security Policy Cheat Sheet](cheatsheets/Content_Security_Policy_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
 
+[Cookie Theft Mitigation Cheat Sheet](cheatsheets/Cookie_Theft_Mitigation_Cheat_Sheet.md)
+
 [Credential Stuffing Prevention Cheat Sheet](cheatsheets/Credential_Stuffing_Prevention_Cheat_Sheet.md)
+
+[Cross-Site Request Forgery Prevention Cheat Sheet](cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
+
+[Cross Site Scripting Prevention Cheat Sheet](cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md) ![Html](assets/Index_Html.svg)
 
 [Cryptographic Storage Cheat Sheet](cheatsheets/Cryptographic_Storage_Cheat_Sheet.md)
 
 ## D
 
-[Deserialization Cheat Sheet](cheatsheets/Deserialization_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Csharp](assets/Index_Csharp.svg) ![Python](assets/Index_Python.svg)
-
-[Docker Security Cheat Sheet](cheatsheets/Docker_Security_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
-
-[Django Security Cheat Sheet](cheatsheets/Django_Security_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Python](assets/Index_Python.svg)
-
-[Django REST Framework Cheat Sheet](cheatsheets/Django_REST_Framework_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
-
-[Database Security Cheat Sheet](cheatsheets/Database_Security_Cheat_Sheet.md)
-
-[DotNet Security Cheat Sheet](cheatsheets/DotNet_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Csharp](assets/Index_Csharp.svg) ![Html](assets/Index_Html.svg) ![Xml](assets/Index_Xml.svg)
+[DOM Clobbering Prevention Cheat Sheet](cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
 
 [DOM based XSS Prevention Cheat Sheet](cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
 
-[Drone Security Cheat Sheet](cheatsheets/Drone_Security_Cheat_Sheet.md)
-
-[Dependency Graph SBOM Cheat Sheet](cheatsheets/Dependency_Graph_SBOM_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
+[Database Security Cheat Sheet](cheatsheets/Database_Security_Cheat_Sheet.md)
 
 [Denial of Service Cheat Sheet](cheatsheets/Denial_of_Service_Cheat_Sheet.md)
 
-[DOM Clobbering Prevention Cheat Sheet](cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
+[Dependency Graph SBOM Cheat Sheet](cheatsheets/Dependency_Graph_SBOM_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
+
+[Deserialization Cheat Sheet](cheatsheets/Deserialization_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Csharp](assets/Index_Csharp.svg) ![Python](assets/Index_Python.svg)
+
+[Django REST Framework Cheat Sheet](cheatsheets/Django_REST_Framework_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
+
+[Django Security Cheat Sheet](cheatsheets/Django_Security_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Python](assets/Index_Python.svg)
+
+[Docker Security Cheat Sheet](cheatsheets/Docker_Security_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
+
+[DotNet Security Cheat Sheet](cheatsheets/DotNet_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Csharp](assets/Index_Csharp.svg) ![Html](assets/Index_Html.svg) ![Xml](assets/Index_Xml.svg)
+
+[Drone Security Cheat Sheet](cheatsheets/Drone_Security_Cheat_Sheet.md)
 
 ## E
 
@@ -100,21 +100,23 @@
 
 ## G
 
+[GitHub Actions Security Cheat Sheet](cheatsheets/GitHub_Actions_Security_Cheat_Sheet.md)
+
 [GraphQL Cheat Sheet](cheatsheets/GraphQL_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Java](assets/Index_Java.svg)
 
 [gRPC Security Cheat Sheet](cheatsheets/gRPC_Security_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
 
-[GitHub Actions Security Cheat Sheet](cheatsheets/GitHub_Actions_Security_Cheat_Sheet.md)
-
 ## H
 
-[HTTP Headers Cheat Sheet](cheatsheets/HTTP_Headers_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Xml](assets/Index_Xml.svg) ![Php](assets/Index_Php.svg)
-
 [HTML5 Security Cheat Sheet](cheatsheets/HTML5_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
+
+[HTTP Headers Cheat Sheet](cheatsheets/HTTP_Headers_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Xml](assets/Index_Xml.svg) ![Php](assets/Index_Php.svg)
 
 [HTTP Strict Transport Security Cheat Sheet](cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.md)
 
 ## I
+
+[Infrastructure as Code Security Cheat Sheet](cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.md)
 
 [Injection Prevention Cheat Sheet](cheatsheets/Injection_Prevention_Cheat_Sheet.md) ![Java](assets/Index_Java.svg)
 
@@ -122,17 +124,15 @@
 
 [Input Validation Cheat Sheet](cheatsheets/Input_Validation_Cheat_Sheet.md) ![Java](assets/Index_Java.svg)
 
-[Infrastructure as Code Security Cheat Sheet](cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.md)
-
 [Insecure Direct Object Reference Prevention Cheat Sheet](cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.md)
 
 ## J
 
-[Java Security Cheat Sheet](cheatsheets/Java_Security_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg)
+[JAAS Cheat Sheet](cheatsheets/JAAS_Cheat_Sheet.md) ![Java](assets/Index_Java.svg)
 
 [JSON Web Token Cheat Sheet](cheatsheets/JSON_Web_Token_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Python](assets/Index_Python.svg) ![Json](assets/Index_Json.svg)
 
-[JAAS Cheat Sheet](cheatsheets/JAAS_Cheat_Sheet.md) ![Java](assets/Index_Java.svg)
+[Java Security Cheat Sheet](cheatsheets/Java_Security_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg)
 
 ## K
 
@@ -142,45 +142,45 @@
 
 ## L
 
-[Logging Cheat Sheet](cheatsheets/Logging_Cheat_Sheet.md)
-
-[Laravel Cheat Sheet](cheatsheets/Laravel_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Php](assets/Index_Php.svg) ![Sql](assets/Index_Sql.svg) ![Bash](assets/Index_Bash.svg)
-
 [LDAP Injection Prevention Cheat Sheet](cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md) ![Java](assets/Index_Java.svg)
-
-[Logging Vocabulary Cheat Sheet](cheatsheets/Logging_Vocabulary_Cheat_Sheet.md) ![Json](assets/Index_Json.svg)
 
 [LLM Prompt Injection Prevention Cheat Sheet](cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
 
+[Laravel Cheat Sheet](cheatsheets/Laravel_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Php](assets/Index_Php.svg) ![Sql](assets/Index_Sql.svg) ![Bash](assets/Index_Bash.svg)
+
 [Legacy Application Management Cheat Sheet](cheatsheets/Legacy_Application_Management_Cheat_Sheet.md)
+
+[Logging Cheat Sheet](cheatsheets/Logging_Cheat_Sheet.md)
+
+[Logging Vocabulary Cheat Sheet](cheatsheets/Logging_Vocabulary_Cheat_Sheet.md) ![Json](assets/Index_Json.svg)
 
 ## M
 
-[Microservices Security Cheat Sheet](cheatsheets/Microservices_Security_Cheat_Sheet.md)
-
-[Multi Tenant Security Cheat Sheet](cheatsheets/Multi_Tenant_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg) ![Sql](assets/Index_Sql.svg)
-
-[Mobile Application Security Cheat Sheet](cheatsheets/Mobile_Application_Security_Cheat_Sheet.md)
-
 [MCP Security Cheat Sheet](cheatsheets/MCP_Security_Cheat_Sheet.md)
-
-[Multifactor Authentication Cheat Sheet](cheatsheets/Multifactor_Authentication_Cheat_Sheet.md)
 
 [Mass Assignment Cheat Sheet](cheatsheets/Mass_Assignment_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Java](assets/Index_Java.svg) ![Html](assets/Index_Html.svg) ![Php](assets/Index_Php.svg)
 
+[Microservices Security Cheat Sheet](cheatsheets/Microservices_Security_Cheat_Sheet.md)
+
 [Microservices based Security Arch Doc Cheat Sheet](cheatsheets/Microservices_based_Security_Arch_Doc_Cheat_Sheet.md)
+
+[Mobile Application Security Cheat Sheet](cheatsheets/Mobile_Application_Security_Cheat_Sheet.md)
+
+[Multi Tenant Security Cheat Sheet](cheatsheets/Multi_Tenant_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg) ![Sql](assets/Index_Sql.svg)
+
+[Multifactor Authentication Cheat Sheet](cheatsheets/Multifactor_Authentication_Cheat_Sheet.md)
 
 ## N
 
-[NodeJS Docker Cheat Sheet](cheatsheets/NodeJS_Docker_Cheat_Sheet.md)
-
 [NPM Security Cheat Sheet](cheatsheets/NPM_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg) ![Bash](assets/Index_Bash.svg)
-
-[Nodejs Security Cheat Sheet](cheatsheets/Nodejs_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Bash](assets/Index_Bash.svg)
 
 [Network Segmentation Cheat Sheet](cheatsheets/Network_Segmentation_Cheat_Sheet.md)
 
 [NoSQL Security Cheat Sheet](cheatsheets/NoSQL_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
+
+[NodeJS Docker Cheat Sheet](cheatsheets/NodeJS_Docker_Cheat_Sheet.md)
+
+[Nodejs Security Cheat Sheet](cheatsheets/Nodejs_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Bash](assets/Index_Bash.svg)
 
 ## O
 
@@ -190,9 +190,9 @@
 
 ## P
 
-[Password Storage Cheat Sheet](cheatsheets/Password_Storage_Cheat_Sheet.md)
-
 [PHP Configuration Cheat Sheet](cheatsheets/PHP_Configuration_Cheat_Sheet.md)
+
+[Password Storage Cheat Sheet](cheatsheets/Password_Storage_Cheat_Sheet.md)
 
 [Pinning Cheat Sheet](cheatsheets/Pinning_Cheat_Sheet.md)
 
@@ -204,69 +204,69 @@
 
 ## R
 
-[REST Security Cheat Sheet](cheatsheets/REST_Security_Cheat_Sheet.md)
+[RAG Security Cheat Sheet](cheatsheets/RAG_Security_Cheat_Sheet.md)
 
 [REST Assessment Cheat Sheet](cheatsheets/REST_Assessment_Cheat_Sheet.md)
 
-[RAG Security Cheat Sheet](cheatsheets/RAG_Security_Cheat_Sheet.md)
+[REST Security Cheat Sheet](cheatsheets/REST_Security_Cheat_Sheet.md)
 
 [Ruby on Rails Cheat Sheet](cheatsheets/Ruby_on_Rails_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Ruby](assets/Index_Ruby.svg) ![Bash](assets/Index_Bash.svg)
 
 ## S
 
-[Secure AI Model Ops Cheat Sheet](cheatsheets/Secure_AI_Model_Ops_Cheat_Sheet.md)
-
-[Security Terminology Cheat Sheet](cheatsheets/Security_Terminology_Cheat_Sheet.md)
-
-[Secure Code Review Cheat Sheet](cheatsheets/Secure_Code_Review_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
-
-[Secure Product Design Cheat Sheet](cheatsheets/Secure_Product_Design_Cheat_Sheet.md)
-
-[Secure Cloud Architecture Cheat Sheet](cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.md)
-
-[Securing Cascading Style Sheets Cheat Sheet](cheatsheets/Securing_Cascading_Style_Sheets_Cheat_Sheet.md)
+[SAML Security Cheat Sheet](cheatsheets/SAML_Security_Cheat_Sheet.md)
 
 [SQL Injection Prevention Cheat Sheet](cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Csharp](assets/Index_Csharp.svg) ![Vbnet](assets/Index_Vbnet.svg)
 
-[Server Side Request Forgery Prevention Cheat Sheet](cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Python](assets/Index_Python.svg) ![Ruby](assets/Index_Ruby.svg) ![Bash](assets/Index_Bash.svg)
+[Secrets Management Cheat Sheet](cheatsheets/Secrets_Management_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
 
-[SAML Security Cheat Sheet](cheatsheets/SAML_Security_Cheat_Sheet.md)
+[Secure AI Model Ops Cheat Sheet](cheatsheets/Secure_AI_Model_Ops_Cheat_Sheet.md)
+
+[Secure Cloud Architecture Cheat Sheet](cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.md)
+
+[Secure Code Review Cheat Sheet](cheatsheets/Secure_Code_Review_Cheat_Sheet.md) ![Bash](assets/Index_Bash.svg)
 
 [Secure Coding with AI Cheat Sheet](cheatsheets/Secure_Coding_with_AI_Cheat_Sheet.md)
+
+[Secure Product Design Cheat Sheet](cheatsheets/Secure_Product_Design_Cheat_Sheet.md)
+
+[Securing Cascading Style Sheets Cheat Sheet](cheatsheets/Securing_Cascading_Style_Sheets_Cheat_Sheet.md)
+
+[Security Terminology Cheat Sheet](cheatsheets/Security_Terminology_Cheat_Sheet.md)
+
+[Server Side Request Forgery Prevention Cheat Sheet](cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Python](assets/Index_Python.svg) ![Ruby](assets/Index_Ruby.svg) ![Bash](assets/Index_Bash.svg)
+
+[Serverless FaaS Security Cheat Sheet](cheatsheets/Serverless_FaaS_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg) ![Json](assets/Index_Json.svg) ![Bash](assets/Index_Bash.svg)
 
 [Session Management Cheat Sheet](cheatsheets/Session_Management_Cheat_Sheet.md)
 
 [Software Supply Chain Security Cheat Sheet](cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.md)
 
-[Secrets Management Cheat Sheet](cheatsheets/Secrets_Management_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
+[Subdomain Takeover Prevention Cheat Sheet](cheatsheets/Subdomain_Takeover_Prevention_Cheat_Sheet.md)
 
 [Symfony Cheat Sheet](cheatsheets/Symfony_Cheat_Sheet.md) ![Php](assets/Index_Php.svg) ![Bash](assets/Index_Bash.svg)
 
-[Subdomain Takeover Prevention Cheat Sheet](cheatsheets/Subdomain_Takeover_Prevention_Cheat_Sheet.md)
-
-[Serverless FaaS Security Cheat Sheet](cheatsheets/Serverless_FaaS_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg) ![Json](assets/Index_Json.svg) ![Bash](assets/Index_Bash.svg)
-
 ## T
-
-[Third Party Payment Gateway Integration Cheat Sheet](cheatsheets/Third_Party_Payment_Gateway_Integration_Cheat_Sheet.md)
-
-[Transaction Authorization Cheat Sheet](cheatsheets/Transaction_Authorization_Cheat_Sheet.md)
 
 [TLS Cipher String Cheat Sheet](cheatsheets/TLS_Cipher_String_Cheat_Sheet.md)
 
-[Transport Layer Security Cheat Sheet](cheatsheets/Transport_Layer_Security_Cheat_Sheet.md)
-
-[Transport Layer Protection Cheat Sheet](cheatsheets/Transport_Layer_Protection_Cheat_Sheet.md)
-
 [Third Party Javascript Management Cheat Sheet](cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
+
+[Third Party Payment Gateway Integration Cheat Sheet](cheatsheets/Third_Party_Payment_Gateway_Integration_Cheat_Sheet.md)
 
 [Threat Modeling Cheat Sheet](cheatsheets/Threat_Modeling_Cheat_Sheet.md)
 
+[Transaction Authorization Cheat Sheet](cheatsheets/Transaction_Authorization_Cheat_Sheet.md)
+
+[Transport Layer Protection Cheat Sheet](cheatsheets/Transport_Layer_Protection_Cheat_Sheet.md)
+
+[Transport Layer Security Cheat Sheet](cheatsheets/Transport_Layer_Security_Cheat_Sheet.md)
+
 ## U
 
-[User Privacy Protection Cheat Sheet](cheatsheets/User_Privacy_Protection_Cheat_Sheet.md)
-
 [Unvalidated Redirects and Forwards Cheat Sheet](cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Csharp](assets/Index_Csharp.svg) ![Ruby](assets/Index_Ruby.svg) ![Php](assets/Index_Php.svg)
+
+[User Privacy Protection Cheat Sheet](cheatsheets/User_Privacy_Protection_Cheat_Sheet.md)
 
 ## V
 
@@ -286,9 +286,9 @@
 
 [XML External Entity Prevention Cheat Sheet](cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Csharp](assets/Index_Csharp.svg) ![Cpp](assets/Index_Cpp.svg) ![Php](assets/Index_Php.svg)
 
-[XSS Filter Evasion Cheat Sheet](cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Php](assets/Index_Php.svg)
-
 [XML Security Cheat Sheet](cheatsheets/XML_Security_Cheat_Sheet.md) ![Java](assets/Index_Java.svg) ![Xml](assets/Index_Xml.svg) ![Bash](assets/Index_Bash.svg)
+
+[XSS Filter Evasion Cheat Sheet](cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md) ![Html](assets/Index_Html.svg) ![Php](assets/Index_Php.svg)
 
 [XS Leaks Cheat Sheet](cheatsheets/XS_Leaks_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Html](assets/Index_Html.svg)
 

--- a/scripts/Update_CheatSheets_Index.py
+++ b/scripts/Update_CheatSheets_Index.py
@@ -34,7 +34,7 @@ cs_index_title_template = "# Index Alphabetical\n\n"
 # Scan all CS files
 index = {}
 cs_count = 0
-cheatsheets = [f.name for f in os.scandir("../cheatsheets") if f.is_file()]
+cheatsheets = sorted(f.name for f in os.scandir("../cheatsheets") if f.is_file())
 for cheatsheet in cheatsheets:
     letter = cheatsheet[0].upper()
     if letter not in index:


### PR DESCRIPTION
Closes #2273

The published website already regenerates `Index.md` at site-build time (`scripts/Generate_Site_mkDocs.sh` runs `Update_CheatSheets_Index.py` on every deploy), so this drift only affects the copy committed in the repo — which is what people browsing GitHub see. This PR keeps that committed copy honest:

- **Regenerates `Index.md`** to match the current contents of `cheatsheets/` (92 → 120 cheat sheets), so the check lands green.
- **Adds a standalone CI workflow** (`index-drift-check.yml`) that runs the existing `Update_CheatSheets_Index.py` on PRs touching `cheatsheets/**`, `Index.md`, or the script itself, and fails with an actionable error if the committed `Index.md` diverges from the regenerated output.

Deliberately does not build on #2247 — it runs the script as-is, per maintainer guidance in the issue.

Tested locally: passes on a freshly regenerated index; fails as expected when a cheat sheet is added without updating `Index.md`.