### PR TITLE
fix(HSTS): replace NBSP with ASCII spaces in header examples

### DIFF
--- a/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.md
+++ b/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.md
@@ -21,22 +21,22 @@ HSTS addresses the following threats:
 
 Simple example, using a long (2 years = 63072000 seconds) max-age. This example is dangerous since it lacks `includeSubDomains`:
 
-`Strict-Transport-Security: max-age=63072000`
+`Strict-Transport-Security: max-age=63072000`
 
 This example is useful if all present and future subdomains will be HTTPS. This is a more secure option but will block access to certain pages that can only be served over HTTP:
 
-`Strict-Transport-Security: max-age=63072000; includeSubDomains`
+`Strict-Transport-Security: max-age=63072000; includeSubDomains`
 
 This example is useful if all present and future subdomains will be HTTPS. In this example we set a very short max-age in case of mistakes during initial rollout:
 
-`Strict-Transport-Security: max-age=86400; includeSubDomains`
+`Strict-Transport-Security: max-age=86400; includeSubDomains`
 
 **Recommended:**
 
 - If the site owner would like their domain to be included in the [HSTS preload list](https://hstspreload.org) maintained by Chrome (and used by Firefox and Safari), then use the header below.
 - Sending the `preload` directive from your site can have **PERMANENT CONSEQUENCES** and prevent users from accessing your site and any of its subdomains if you find you need to switch back to HTTP. Please read the details at [preload removal](https://hstspreload.org/#removal) before sending the header with `preload`.
 
-`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
+`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
 
 The `preload` flag indicates the site owner's consent to have their domain preloaded. The site owner still needs to then go and submit the domain to the list.
 


### PR DESCRIPTION
## Summary
Minor fix: HSTS header examples used Unicode non-breaking spaces (`U+00A0`) after `Strict-Transport-Security:`. Copy-paste into configs can produce invalid/odd header values.

Replaced with ASCII spaces. Single-file PR per contributing guide.

## Test plan
- [ ] Examples still render correctly
- [ ] No `U+00A0` remains in the example header lines

—
Felipe Fernandes · Crystal Engineer / Agentic AI
White-hat / defensive only · https://github.com/felipeofdev-ai/secure-ship-kit