### PR TITLE
docs(CSP): note that prefetch-src was removed from CSP Level 3

### DIFF
--- a/cheatsheets/Content_Security_Policy_Cheat_Sheet.md
+++ b/cheatsheets/Content_Security_Policy_Cheat_Sheet.md
@@ -209,7 +209,7 @@ Most fetch directives have a certain [fallback list specified in w3](https://www
 - `img-src` specifies the URLs that images can be loaded from.
 - `manifest-src` specifies the URLs that application manifests may be loaded from.
 - `media-src` specifies the URLs from which video, audio and text track resources can be loaded from.
-- `prefetch-src` was an experimental directive for prefetch/prerender resource URLs. It was **removed from the CSP Level 3 specification** and is ignored by modern browsers — do not rely on it for defense. Constrain scripts, styles, and default fetches with the standard fetch directives instead.
+- `prefetch-src` was an experimental directive for prefetch/prerender resource URLs. It was __removed from the CSP Level 3 specification__ and is ignored by modern browsers — do not rely on it for defense. Constrain scripts, styles, and default fetches with the standard fetch directives instead.
 - `object-src` specifies the URLs from which plugins can be loaded from.
 - `script-src` specifies the locations from which a script can be executed from. It is a fallback directive for other script-like directives.
     - `script-src-elem` controls the location from which execution of script requests and blocks can occur.

--- a/cheatsheets/Content_Security_Policy_Cheat_Sheet.md
+++ b/cheatsheets/Content_Security_Policy_Cheat_Sheet.md
@@ -209,7 +209,7 @@ Most fetch directives have a certain [fallback list specified in w3](https://www
 - `img-src` specifies the URLs that images can be loaded from.
 - `manifest-src` specifies the URLs that application manifests may be loaded from.
 - `media-src` specifies the URLs from which video, audio and text track resources can be loaded from.
-- `prefetch-src` specifies the URLs from which resources can be prefetched from.
+- `prefetch-src` was an experimental directive for prefetch/prerender resource URLs. It was **removed from the CSP Level 3 specification** and is ignored by modern browsers — do not rely on it for defense. Constrain scripts, styles, and default fetches with the standard fetch directives instead.
 - `object-src` specifies the URLs from which plugins can be loaded from.
 - `script-src` specifies the locations from which a script can be executed from. It is a fallback directive for other script-like directives.
     - `script-src-elem` controls the location from which execution of script requests and blocks can occur.


### PR DESCRIPTION
﻿## Summary
Minor clarity fix on the Content Security Policy Cheat Sheet: `prefetch-src` was removed from CSP Level 3 and is ignored by modern browsers. The previous wording read as if it were an active defensive directive.

Single-file PR per contributing guide (minor fix, no issue required).

## Test plan
- [ ] Bullet for prefetch-src accurately reflects removal / non-reliance
- [ ] Surrounding fetch-directive list still reads cleanly

---
Felipe Fernandes · Crystal Engineer / Agentic AI
White-hat / defensive only · https://github.com/felipeofdev-ai/secure-ship-kit
