### PR TITLE
docs(disclosure): clarify RFC 9116 required security.txt fields

### DIFF
--- a/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md
@@ -70,7 +70,7 @@ The first step in reporting a vulnerability is finding the appropriate person to
 Where there is no clear disclosure policy, the following areas may provide contact details:
 
 - Bug bounty programs such as [BugCrowd](https://bugcrowd.com/programs), [HackerOne](https://hackerone.com/directory/programs), [huntr.dev](https://huntr.dev/bounties), [Open Bug Bounty](https://www.openbugbounty.org) or [Standoff](https://bugbounty.standoff365.com).
-- A [security.txt](https://securitytxt.org) file on the website at `/.well-known/security.txt` as per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html#name-location-of-the-securitytxt).
+- A [security.txt](https://securitytxt.org) file on the website at `/.well-known/security.txt` as per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html#name-location-of-the-securitytxt). At minimum include the required Contact and Expires fields; optional fields such as Preferred-Languages, Canonical, Policy, and Hiring improve routing for ethical researchers.
 - An existing issue tracking system.
 - Generic email addresses such as `security@` or `abuse@`.
 - The generic "Contact Us" page on the website.
@@ -188,7 +188,7 @@ The most important step in the process is providing a way for security researche
 - A dedicated security contact on the "Contact Us" page.
 - Dedicated instructions for reporting security issues on a bug tracker.
 - The common `security@` email address.
-- A [security.txt](https://securitytxt.org) file on the website at `/.well-known/security.txt` as per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html#name-location-of-the-securitytxt).
+- A [security.txt](https://securitytxt.org) file on the website at `/.well-known/security.txt` as per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html#name-location-of-the-securitytxt). At minimum include the required Contact and Expires fields; optional fields such as Preferred-Languages, Canonical, Policy, and Hiring improve routing for ethical researchers.
 - Using third party [bug bounty](#bug-bounty-programs) program.
 
 It is also important to ensure that frontline staff (such as those who monitor the main contact address, web chat and phone lines) are aware of how to handle reports of security issues, and who to escalate these reports to within the organization.


### PR DESCRIPTION
﻿## Summary
Minor clarification on the Vulnerability Disclosure Cheat Sheet: RFC 9116 requires `Contact` and `Expires` in security.txt. The previous bullets only linked the file location.

Also notes useful optional fields (`Preferred-Languages`, `Canonical`, `Policy`, `Hiring`) for routing ethical researchers.

Single-file PR per contributing guide.

## Test plan
- [ ] Both security.txt mentions updated consistently
- [ ] Wording stays defensive / disclosure-focused

---
Felipe Fernandes · Crystal Engineer / Agentic AI
White-hat / defensive only · https://github.com/felipeofdev-ai/secure-ship-kit
