### PR TITLE
Remove leftover TODO marker from OS Command Injection Defense Cheat Sheet

### DIFF
--- a/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md
+++ b/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.md
@@ -62,8 +62,6 @@ If there are available libraries or APIs for the language you use, this is the p
 
 ### Defense option 2: Escape values added to OS commands specific to each OS
 
-**TODO: To enhance.**
-
 For examples, see [escapeshellarg()](https://www.php.net/manual/en/function.escapeshellarg.php) in PHP.
 
 The `escapeshellarg()` surrounds the user input in single quotes, so if the malformed user input is something like `& echo "hello"`, the final output will be like `calc '& echo "hello"'` which will be parsed as a single argument to the command `calc`.


### PR DESCRIPTION
## Description

This PR removes a leftover TODO marker from the OS Command Injection Defense Cheat Sheet. The section already contains guidance and an example, so the marker no longer reflects its current content.

## Changes

- Removed the stale `TODO: To enhance.` marker.
- No security guidance or technical content was changed.

## Testing

- `npm test`
- `git diff --check`

Documentation-only change. No functional code changes.

## Contributor checklist

- [x] All modified Markdown follows the project format rules.
- [x] This PR modifies a single cheat sheet and addresses one focused documentation issue.
- [x] No assets or images were added or modified.
- [x] No website references were added or modified.
- [x] No technical claims, recommendations, threat assertions, or citations were added.
- [x] The existing documentation content was reviewed and the stale marker was verified against the file history.

## AI Tool Usage Disclosure

- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `OpenAI Codex (GPT-5)` and the prompt used was `Bu prompta göre repository'yi tamamen analiz et. Önce sadece rapor çıkar, değişiklik yapmadan bana gerçek PR adaylarını göster. Onaydan sonra patch hazırla.` I independently reviewed the final diff. No citations or technical claims were added or modified.
