### PR TITLE
Update Pwned Passwords API documentation link

### DIFF
--- a/cheatsheets/Credential_Stuffing_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Credential_Stuffing_Prevention_Cheat_Sheet.md
@@ -126,7 +126,7 @@ These techniques provide some level of security without resorting to user tracki
 
 [ASVS v4.0 Password Security Requirements](https://github.com/OWASP/ASVS/blob/master/4.0/en/0x11-V2-Authentication.md#v21-password-security-requirements) provision (2.1.7) on verifying new passwords presence in breached password datasets should be implemented.
 
-There are both commercial and free services that may be of use for validating passwords presence in prior breaches.  A well known free service for this is [Pwned Passwords](https://haveibeenpwned.com/Passwords). You can host a copy of the application yourself, or use the [API](https://haveibeenpwned.com/API/v2#PwnedPasswords).
+There are both commercial and free services that may be of use for validating passwords presence in prior breaches.  A well known free service for this is [Pwned Passwords](https://haveibeenpwned.com/Passwords). You can host a copy of the application yourself, or use the [API](https://haveibeenpwned.com/API/v3#PwnedPasswords).
 
 ### Notify users about unusual security events
 


### PR DESCRIPTION
## Description

This PR updates the Pwned Passwords API documentation link in the Credential Stuffing Prevention Cheat Sheet. The existing API v2 URL no longer resolves, while the official API v3 documentation contains the current Pwned Passwords guidance.

## Changes

- Updated the Pwned Passwords documentation link from API v2 to API v3.
- No security guidance or technical recommendations were changed.

## Testing

- `npm run lint-markdown`
- `npm run lint-terminology`
- `markdown-link-check -q -c markdown-link-check-config.json cheatsheets/Credential_Stuffing_Prevention_Cheat_Sheet.md`
- `git diff --check`

Documentation-only change. No functional code changes.

## Contributor checklist

- [x] All modified Markdown follows the project format rules.
- [x] This PR modifies a single cheat sheet and addresses one broken documentation link.
- [x] No assets or images were added or modified.
- [x] The updated link uses the official HIBP API documentation and was opened and reviewed.
- [x] No technical claims, recommendations, or threat assertions were added.

## AI Tool Usage Disclosure

- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `OpenAI Codex (GPT-5)` and the prompt used was `Bu prompta göre repository'yi tamamen analiz et. Önce sadece rapor çıkar, değişiklik yapmadan bana gerçek PR adaylarını göster. Onaydan sonra patch hazırla.` I independently verified the updated link against the official HIBP API v3 documentation.
