### PR TITLE
Fix IBM data breach report link in Logging Vocabulary Cheat Sheet

### DIFF
--- a/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
+++ b/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
@@ -10,7 +10,7 @@ In addition to the millions of dollars lost due to breaches the report finds tha
 
 ![IBM Cost of Data Breach Report 2025](../assets/cost-of-breach-2025.png)
 
-> IBM Cost of a Data Breach Study 2025, Fig.4, pg.12, [https://www.ibm.com/reports/data-breach]
+> [IBM Cost of a Data Breach Report 2025](https://www.ibm.com/forms/mkt-asset-31c90), Fig.4, pg.12
 
 This logging standard would seek to define specific keywords which, when applied consistently across software, would allow groups to simply monitor for these events terms across all applications and respond quickly in the event of attack.
 


### PR DESCRIPTION
## Description

This PR fixes the malformed IBM Cost of a Data Breach Report citation in the Application Logging Vocabulary Cheat Sheet. The existing single-bracket URL is not valid Markdown, and the linked landing page now presents a newer report.

## Changes

- Replaced the malformed URL with a descriptive Markdown link.
- Linked to IBM's official 2025 report page so the citation continues to match the referenced figure.
- No security guidance or technical recommendations were changed.

## Testing

- `npm run lint-markdown`
- `npm run lint-terminology`
- `markdown-link-check -q -c markdown-link-check-config.json cheatsheets/Logging_Vocabulary_Cheat_Sheet.md`
- `git diff --check`

Documentation-only change. No functional code changes.

## Contributor checklist

- [x] All modified Markdown follows the project format rules.
- [x] This PR modifies a single cheat sheet and addresses one citation-format issue.
- [x] No assets or images were added or modified.
- [x] The updated citation uses an official IBM source that was opened and reviewed.
- [x] No technical claims, recommendations, or threat assertions were added.

## AI Tool Usage Disclosure

- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `OpenAI Codex (GPT-5)` and the prompt used was `Bu prompta göre repository'yi tamamen analiz et. Önce sadece rapor çıkar, değişiklik yapmadan bana gerçek PR adaylarını göster. Onaydan sonra patch hazırla.` I independently verified the updated citation against IBM's official 2025 report page.
