### PR TITLE
Remove unavailable NCSC password list links

### DIFF
--- a/cheatsheets/Authentication_Cheat_Sheet.md
+++ b/cheatsheets/Authentication_Cheat_Sheet.md
@@ -48,7 +48,6 @@ A key concern when using passwords for authentication is password strength. A "s
     - Alternatively, you can download the [Pwned Passwords](https://haveibeenpwned.com/Passwords) database [using this mechanism](https://github.com/HaveIBeenPwned/PwnedPasswordsDownloader?tab=readme-ov-file#what-is-haveibeenpwned-downloader) to host it yourself.
     - Other top password lists are available but there is no guarantee as to how updated they are:
         - [Various password lists](https://github.com/danielmiessler/SecLists/tree/master/Passwords) hosted by SecLists from Daniel Miessler.
-        - Static copy of the top 100,000 passwords from "Have I Been Pwned" hosted by NCSC in [text](https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt) and [JSON](https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.json) format.
 
 #### For more detailed information check
 


### PR DESCRIPTION
## Description

This PR removes a password-list entry from the Authentication Cheat Sheet whose two NCSC download links now return HTTP 404 responses. No replacement location for those NCSC-hosted files could be verified.

The surrounding section still links to the maintained Pwned Passwords service, its official downloader, and the SecLists password collection.

## Changes

- Removed the entry containing the unavailable NCSC text and JSON downloads.
- No security guidance or technical recommendations were changed.

## Testing

- `npm run lint-markdown`
- `npm run lint-terminology`
- `git diff --check`
- Ran `markdown-link-check` on the modified file. The removed NCSC URLs are no longer reported; the checker returned an unrelated HTTP 403 for an unchanged CISA URL.

Documentation-only change. No functional code changes.

## Contributor checklist

- [x] All modified Markdown follows the project format rules.
- [x] This PR modifies a single cheat sheet and addresses one unavailable external resource.
- [x] No assets or images were added or modified.
- [x] Both removed URLs were directly checked and returned HTTP 404.
- [x] No technical claims, recommendations, or threat assertions were added.

## AI Tool Usage Disclosure

- [x] I have used AI tools to generate the contents of this PR. I have verified the contents and I affirm the results. The LLM used is `OpenAI Codex (GPT-5)` and the prompt used was `Bu prompta göre repository'yi tamamen analiz et. Önce sadece rapor çıkar, değişiklik yapmadan bana gerçek PR adaylarını göster. Onaydan sonra patch hazırla.` I independently verified the removed NCSC URLs and confirmed that no replacement location could be found.
