### PR TITLE
Vulnerable Dependency Management: add Case 5 on backporting a published fix to a pinned version

### DIFF
--- a/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
@@ -89,6 +89,7 @@ Prior to running the tests, 2 output paths are possible:
 - All tests succeed, and thus the update can be pushed to production.
 - One or several tests failed, several output paths are possible:
     - Failure is due to change in some function calls (_e.g._ signature, argument, package, etc.). The development team must update their code to fit the new library. Once that is done, re-run the tests.
+    - The fixed version cannot be adopted at all (_e.g._ the fix only ships in a new major version that breaks the application, or the vulnerable version is pinned by a transitive dependency). Apply [Case 5](#case-5), using [Case 2](#case-2) as an interim mitigation.
     - Technical incompatibility of the released dependency (_e.g._ require a more recent runtime version) which leads to the following actions:
     1. Raise the issue to the provider.
     2. Apply [Case 2](#case-2) while waiting for the provider's feedback.
@@ -224,6 +225,44 @@ Inform the provider about the vulnerability by sharing the post with them.
 **Step 2:**
 
 Using the information from the full disclosure post or the pentester's exploitation feedback, if the provider collaborates then apply [Case 2](#case-2), otherwise apply [Case 3](#case-3), and instead of analyzing the CVE information, the team needs to analyze the information from the full disclosure post/pentester's exploitation feedback.
+
+### Case 5
+
+#### Context
+
+A fixed version has been released by the provider, but the project cannot adopt it:
+
+- The fix only ships in a new major version that breaks the application code.
+- The vulnerable version is pinned by a [transitive dependency](https://en.wikipedia.org/wiki/Transitive_dependency) that has not been updated yet.
+- The version line in use is no longer maintained and the fix landed only on a newer line.
+
+This is not [Case 3](#case-3): the fix exists and is public, so nothing has to be invented, but it has to be moved onto the version line that the project can actually run. That practice is called _backporting_, and operating system vendors have handled the same problem this way for years. [Debian](https://www.debian.org/security/faq) states that "instead of upgrading to a new release we backport security fixes to the version that was shipped in the stable release", and [Red Hat](https://access.redhat.com/security/updates/backporting) defines backporting as "the action of taking a fix for a security flaw out of the most recent version of an upstream software package and applying that fix to an older version".
+
+#### Ideal condition of application of the approach
+
+The upstream fix can be identified (a commit, a patch file, or an advisory precise enough to locate the change), the source of the version in use is available, and automated tests exist for the application features using the dependency.
+
+#### Approach
+
+**Step 1:**
+
+Confirm that the upgrade is really blocked by attempting it on a testing environment as described in [Case 1](#case-1). Backporting is cheaper than a major upgrade in the short term and more expensive over the life of the project, so it must be a deliberate choice rather than the first reflex. Record the exact blocker (breaking API, transitive pin, unsupported runtime), because that is the condition to re-test later.
+
+**Step 2:**
+
+Isolate the security-relevant change from the rest of the upstream release. Fix commits are frequently bundled with refactoring, renaming and unrelated bugfixes that must not be carried over, and the fix may rely on internal functions that do not exist in the older line, in which case the same check has to be re-implemented instead of cherry-picked. Keep the patch minimal: the goal is to block the vulnerability without changing any existing legitimate behavior.
+
+**Step 3:**
+
+Verify the patch rather than assume it. A test reproducing the vulnerability must fail against the unpatched dependency and pass against the patched one, and both the dependency's own test suite and the application tests must still pass. Silencing the scanner or bumping a version string is not remediation.
+
+**Step 4:**
+
+Distribute the patched artifact so that every build resolves it: publish it to the internal registry or proxy that the build already trusts, instead of committing a locally built file into each project. Give it a version identifier that remains traceable to the upstream version it derives from, and record its provenance (source commit, CVE, who produced it) so that the next reader can audit it. Expect detection tools to keep flagging the dependency, because [looking at the version number of a package will not tell you whether a backported fix is present](https://access.redhat.com/security/updates/backporting); suppress the alert per CVE as described in the note of [Case 2](#case-2).
+
+**Step 5:**
+
+Treat the patch as a standing commitment and not a one-off task. Every new upstream release of the dependency has to be re-patched, and every new CVE affecting it adds another patch to carry. Before deciding to maintain patches in-house, size that recurring work against acquiring maintained backports from a provider whose business is producing them. Drop the backport as soon as the fixed version becomes adoptable: re-test the blocker recorded in step 1 at each dependency review, then go back to [Case 1](#case-1).
 
 ## Tools
 


### PR DESCRIPTION
Per [@jmanico's request in #2343](https://github.com/OWASP/CheatSheetSeries/issues/2343#issuecomment-5257409180), the proposal is split into small independent PRs so they can be picked and chosen. This is 1 of 3, and the only one that adds the new case.

**Scope:** one file, `cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md`.

- Adds `### Case 5` after Case 4: the provider has already released a fixed version, but the project cannot adopt it (breaking major release, transitive pin, unmaintained version line). Today the cheat sheet routes that reader to Case 2 (workaround) or Case 3 (write the patch yourself), and never names backporting the published fix, which is the practice that actually applies.
- Adds one bullet in Case 1, Step 2 pointing to Case 5 when the fixed version cannot be adopted at all.

Case 5 follows the existing Context / Ideal condition / Approach shape and covers when it applies, isolating the security change from bundled refactoring, verifying with a reproducer, distributing through the registry the build already trusts, the recurring maintenance the patch implies, and the exit criteria.

**Sources added** (both read, both support the quoted text):

- [Debian security FAQ](https://www.debian.org/security/faq) — "Instead of upgrading to a new release we backport security fixes to the version that was shipped in the stable release."
- [Red Hat backporting policy](https://access.redhat.com/security/updates/backporting) — defines backporting, and states that "just looking at the version number of a package will not tell them if they are vulnerable or not", which is why Step 4 tells readers to expect scanners to keep flagging the dependency.

**Disclosure:** I work at Seal Security, a vendor that sells backported patches. This PR deliberately names no vendors and recommends no product; it says to size in-house patch maintenance against buying it, without saying from whom. The vendor list from the issue is a separate PR that maintainers can reject independently of this one.

Related PRs from the same issue, both independent of this one and of each other: the Tools remediation entry, and the Case 3 verification criteria.

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md). (not applicable, existing cheat sheet)
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder. (no assets added)
- [x] All the images used are in the **PNG** format. (no images added)
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

Ran locally: `npm run lint-markdown` clean, `npx textlint` clean on the edited file, `markdown-link-check` reports no dead links among the added ones (the pre-existing `npmjs.com/package/npm-audit-html` link returns 403 on `master` as well and is untouched here).

## Scope and sourcing (required)

- [x] This PR is focused: it modifies a single cheat sheet, or a small coordinated set, and the scope is described in the PR body.
- [x] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source (RFC, NIST, OWASP standard, vendor documentation, peer-reviewed research) linked inline as `[text](URL)`.
- [x] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations.

This PR fixes issue #2343.

## AI Tool Usage Disclosure (required for all PRs)

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `Claude Opus 5 (via Claude Code)`
    and the prompt used is `https://github.com/OWASP/CheatSheetSeries/issues/2343 please handle jmanico's request. make sure to follow the repo's rules`. I have independently verified every citation and technical claim against the cited source.

The model was pointed at the issue and at `CONTRIBUTING.md`, `AGENTS.md` and `GUIDELINE.md`; it fetched each source page and I checked the quoted sentences against the live pages before committing.
