### PR TITLE
Vulnerable Dependency Management: add remediation and maintained backports to the Tools section

### DIFF
--- a/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
@@ -260,20 +260,13 @@ It's important to ensure, during the selection process of a vulnerable dependenc
 
 ### Remediation and maintained backports
 
-The tools above detect vulnerable dependencies, they do not fix them. When the fixed version cannot be adopted, the patch still has to come from somewhere: either the development team maintains it or someone else does. The sources below maintain patches for versions that upstream no longer fixes.
+The tools above detect vulnerable dependencies, they do not fix them. When the fixed version cannot be adopted, the patch still has to come from somewhere: either the development team maintains it or someone else does.
 
-Judge such a source on the same criteria as a detection tool, plus:
+Linux distribution security teams are the reference model for the second option. [Debian](https://www.debian.org/security/faq) and [Red Hat](https://access.redhat.com/security/updates/backporting) both backport security fixes into the version shipped in the stable release instead of upgrading it. When the dependency is consumed as an operating system package, take the distribution's patched build rather than maintaining a private patch.
+
+Language ecosystem packages are rarely covered that way, so the choice there is between maintaining the patch in-house and paying someone to maintain it. Judge either option on the same criteria as a detection tool, plus:
 
 - Coverage of the ecosystems, version lines and severities the project depends on, with a published response time.
 - Publication of the patch itself and of its provenance, so that the change can be reviewed instead of being trusted blindly.
 - Delivery as a compatible artifact through a registry or proxy that the build already uses, so that no manifest rewrite is required.
 - A documented way out, so that leaving the source does not mean re-patching everything from scratch.
-
-- Free
-    - Linux distribution security teams are the reference model here: [Debian](https://www.debian.org/security/faq) and [Red Hat](https://access.redhat.com/security/updates/backporting) both backport security fixes into the version shipped in the stable release instead of upgrading it. When the dependency is consumed as an operating system package, take the distribution's patched build rather than maintaining a private patch.
-- Commercial
-    - [Seal Security](https://seal.security): backported patches published as sealed versions built from the version in use.
-    - [HeroDevs](https://www.herodevs.com/support): maintained drop-in replacements for end-of-life open source versions.
-    - [Chainguard](https://www.chainguard.dev/unchained/chainguard-libraries-for-python-now-generally-available-with-cve-remediation-and-malware-protection): backported patches for selected critical and high severity vulnerabilities in its library builds.
-
-This list is not exhaustive and coverage changes quickly, so verify it against the project's own ecosystems and version lines.

--- a/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
@@ -272,8 +272,8 @@ Judge such a source on the same criteria as a detection tool, plus:
 - Free
     - Linux distribution security teams are the reference model here: [Debian](https://www.debian.org/security/faq) and [Red Hat](https://access.redhat.com/security/updates/backporting) both backport security fixes into the version shipped in the stable release instead of upgrading it. When the dependency is consumed as an operating system package, take the distribution's patched build rather than maintaining a private patch.
 - Commercial
+    - [Seal Security](https://docs.sealsecurity.io/introduction/what-is-seal): backported patches published as sealed versions built from the version in use.
     - [HeroDevs](https://www.herodevs.com/support): maintained drop-in replacements for end-of-life open source versions.
     - [Chainguard](https://www.chainguard.dev/unchained/chainguard-libraries-for-python-now-generally-available-with-cve-remediation-and-malware-protection): backported patches for selected critical and high severity vulnerabilities in its library builds.
-    - [Seal Security](https://docs.sealsecurity.io/introduction/what-is-seal): backported patches published as sealed versions built from the version in use.
 
 This list is not exhaustive and coverage changes quickly, so verify it against the project's own ecosystems and version lines.

--- a/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
@@ -272,7 +272,7 @@ Judge such a source on the same criteria as a detection tool, plus:
 - Free
     - Linux distribution security teams are the reference model here: [Debian](https://www.debian.org/security/faq) and [Red Hat](https://access.redhat.com/security/updates/backporting) both backport security fixes into the version shipped in the stable release instead of upgrading it. When the dependency is consumed as an operating system package, take the distribution's patched build rather than maintaining a private patch.
 - Commercial
-    - [Seal Security](https://docs.sealsecurity.io/introduction/what-is-seal): backported patches published as sealed versions built from the version in use.
+    - [Seal Security](https://seal.security): backported patches published as sealed versions built from the version in use.
     - [HeroDevs](https://www.herodevs.com/support): maintained drop-in replacements for end-of-life open source versions.
     - [Chainguard](https://www.chainguard.dev/unchained/chainguard-libraries-for-python-now-generally-available-with-cve-remediation-and-malware-protection): backported patches for selected critical and high severity vulnerabilities in its library builds.
 

--- a/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
@@ -257,3 +257,23 @@ It's important to ensure, during the selection process of a vulnerable dependenc
         - [Full support](https://renovatebot.com/docs/) for many languages and package manager.
     - [Requires.io](https://requires.io/) (allow to detect old dependencies - open source and free option available):
         - [Full support](https://requires.io/features/): Python only.
+
+### Remediation and maintained backports
+
+The tools above detect vulnerable dependencies, they do not fix them. When the fixed version cannot be adopted, the patch still has to come from somewhere: either the development team maintains it or someone else does. The sources below maintain patches for versions that upstream no longer fixes.
+
+Judge such a source on the same criteria as a detection tool, plus:
+
+- Coverage of the ecosystems, version lines and severities the project depends on, with a published response time.
+- Publication of the patch itself and of its provenance, so that the change can be reviewed instead of being trusted blindly.
+- Delivery as a compatible artifact through a registry or proxy that the build already uses, so that no manifest rewrite is required.
+- A documented way out, so that leaving the source does not mean re-patching everything from scratch.
+
+- Free
+    - Linux distribution security teams are the reference model here: [Debian](https://www.debian.org/security/faq) and [Red Hat](https://access.redhat.com/security/updates/backporting) both backport security fixes into the version shipped in the stable release instead of upgrading it. When the dependency is consumed as an operating system package, take the distribution's patched build rather than maintaining a private patch.
+- Commercial
+    - [HeroDevs](https://www.herodevs.com/support): maintained drop-in replacements for end-of-life open source versions.
+    - [Chainguard](https://www.chainguard.dev/unchained/chainguard-libraries-for-python-now-generally-available-with-cve-remediation-and-malware-protection): backported patches for selected critical and high severity vulnerabilities in its library builds.
+    - [Seal Security](https://docs.sealsecurity.io/introduction/what-is-seal): backported patches published as sealed versions built from the version in use.
+
+This list is not exhaustive and coverage changes quickly, so verify it against the project's own ecosystems and version lines.


### PR DESCRIPTION
Per [@jmanico's request in #2343](https://github.com/OWASP/CheatSheetSeries/issues/2343#issuecomment-5257409180), the proposal is split into small independent PRs so they can be picked and chosen. This is 2 of 3.

**Updated:** the commercial vendor list has been removed [at @jmanico's request](https://github.com/OWASP/CheatSheetSeries/pull/2359#issuecomment-5269677489). This PR now names no vendors and links only Debian and Red Hat.

**Scope:** one file, `cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md`, one new H3 at the end of the existing `## Tools` section.

The Tools section is detection-only today, so it stops being useful at the moment the reader needs it most: a vulnerable dependency has been found and the fixed version cannot be adopted. The new subsection says that the patch then has to come from somewhere, gives the Linux distribution security teams as the model for how that is done, states that language ecosystem packages are rarely covered that way, and lists the criteria to judge either option on (coverage and response time, published patch and provenance, delivery as a compatible artifact through the existing registry, a documented exit path).

**Sources added** (both read; each supports the sentence it is attached to):

- [Debian security FAQ](https://www.debian.org/security/faq) — "Instead of upgrading to a new release we backport security fixes to the version that was shipped in the stable release."
- [Red Hat backporting policy](https://access.redhat.com/security/updates/backporting) — "the action of taking a fix for a security flaw out of the most recent version of an upstream software package and applying that fix to an older version".

**Disclosure:** I work at Seal Security, a vendor that sells backported patches. That is why the commercial list was the part of this proposal I flagged as most reasonable to cut, and it is now gone.

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md). (not applicable, existing cheat sheet)
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder. (no assets added)
- [x] All the images used are in the **PNG** format. (no images added)
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

Ran locally: `npm run lint-markdown` clean, `npx textlint` clean on the edited file, and `markdown-link-check` returns `[✓]` for both added links. Two failures are reported, `npmjs.com/package/npm-audit-html` and `whitehatsec.com/glossary/content/false-positive`; both return 403 on `master` as well and neither is touched here.

## Scope and sourcing (required)

- [x] This PR is focused: it modifies a single cheat sheet, or a small coordinated set, and the scope is described in the PR body.
- [x] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source (RFC, NIST, OWASP standard, vendor documentation, peer-reviewed research) linked inline as `[text](URL)`.
- [x] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations.

This PR fixes issue #2343.

## AI Tool Usage Disclosure (required for all PRs)

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `Claude Opus 5 (via Claude Code)`
    and the prompt used is `https://github.com/OWASP/CheatSheetSeries/issues/2343 please handle jmanico's request. make sure to follow the repo's rules`. I have independently verified every citation and technical claim against the cited source.

The model was pointed at the issue and at `CONTRIBUTING.md`, `AGENTS.md` and `GUIDELINE.md`; both source pages above were fetched and the quoted sentences checked against the live pages before committing.
