### PR TITLE
Vulnerable Dependency Management: state what verifies a self-made patch in Case 3

### DIFF
--- a/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
@@ -202,6 +202,14 @@ If possible, create a unit test that mimics the vulnerability in order to ensure
 
 If you have a set of automated unit or integration or functional or security tests that exists for the application then run them to verify that the patch does not impact the stability of the application.
 
+A patch written in-house does not get the benefit of the doubt that an upstream release gets, so hold it to an explicit bar before considering the vulnerability handled:
+
+- The test reproducing the vulnerability fails against the unpatched dependency and passes against the patched one. A test that passes in both cases proves nothing about the patch.
+- The tests of the dependency itself still pass, which catches behavior that the patch broke but the application does not exercise directly.
+- The alert raised by the detection tool is suppressed per [CVE](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) only once the two points above hold. Suppressing the alert, or changing a version string so that the tool stops matching it, records a fix but does not make one.
+
+Expect the tool to keep flagging the dependency even after a correct patch, because [looking at the version number of a package will not tell you whether the fix is present](https://access.redhat.com/security/updates/backporting). That is a reporting problem to be handled with a scoped suppression, not a reason to change the patch.
+
 ### Case 4
 
 #### Context


### PR DESCRIPTION
Per [@jmanico's request in #2343](https://github.com/OWASP/CheatSheetSeries/issues/2343#issuecomment-5257409180), the proposal is split into small independent PRs so they can be picked and chosen. This is 3 of 3, the smallest one, and it stands on its own even if the other two are rejected.

**Scope:** one file, `cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md`, additions to Case 3, Step 3 only.

Case 3 sends the reader off to write the patch themselves, then says to create a test "in order to ensure that the patch is effective" without saying what effective means. That is the step where a self-made patch quietly fails: the reproducer never actually exercised the flaw, the dependency's own test suite was never run, or the scanner alert was suppressed and the suppression became the record of a fix. The addition states the bar in three bullets and adds one paragraph explaining that a correct patch will still be flagged by detection tools, so that readers do not treat a persistent alert as evidence that the patch failed.

**Source added** (read; supports the sentence it is attached to):

- [Red Hat backporting policy](https://access.redhat.com/security/updates/backporting) — "just looking at the version number of a package will not tell them if they are vulnerable or not", and the same page notes that scanners produce "false positives as the tools do not take into account backported security fixes".

The existing note in Case 2 already tells readers to scope a suppression to a single CVE; this only ties that note to the verification step rather than restating it.

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md). (not applicable, existing cheat sheet)
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder. (no assets added)
- [x] All the images used are in the **PNG** format. (no images added)
- [x] Any references to websites have been formatted as `[TEXT](URL)`
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!).
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

Ran locally: `npm run lint-markdown` clean, `npx textlint` clean on the edited file, and `markdown-link-check` returns `[✓]` for the added link (the one failure, `npmjs.com/package/npm-audit-html`, returns 403 on `master` too and is untouched here).

## Scope and sourcing (required)

- [x] This PR is focused: it modifies a single cheat sheet, or a small coordinated set, and the scope is described in the PR body.
- [x] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source (RFC, NIST, OWASP standard, vendor documentation, peer-reviewed research) linked inline as `[text](URL)`.
- [x] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations.

This PR fixes issue #2343.

## AI Tool Usage Disclosure (required for all PRs)

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `Claude Opus 5 (via Claude Code)`
    and the prompt used is `https://github.com/OWASP/CheatSheetSeries/issues/2343 please handle jmanico's request. make sure to follow the repo's rules`. I have independently verified every citation and technical claim against the cited source.

**Disclosure:** I work at Seal Security, a vendor in this space. This PR names no vendors and recommends no product.
