### PR TITLE
Qualify SameSite cookie guidance

### DIFF
--- a/cheatsheets/Session_Management_Cheat_Sheet.md
+++ b/cheatsheets/Session_Management_Cheat_Sheet.md
@@ -134,9 +134,9 @@ See also: [HttpOnly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#S
 
 ### SameSite Attribute
 
-The `SameSite` attribute prevents the browser from sending the cookie on cross-site requests, mitigating cross-origin leakage and providing CSRF defense. Session cookies must explicitly set `SameSite=Strict` (preferred) or `SameSite=Lax`. Never use `SameSite=None` without `Secure`, and do not rely on the browser-default value, which varies across browsers and versions.
+The `SameSite` attribute controls whether browsers send a cookie with cross-site requests. `SameSite=Strict` excludes cross-site requests, while `SameSite=Lax` permits top-level cross-site navigations that use safe HTTP methods. Treat `SameSite` as [defense in depth against CSRF](Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md#samesite-cookie-attribute), not as a replacement for a CSRF token. Session cookies must explicitly set `SameSite=Strict` (preferred) or `SameSite=Lax`. Never use `SameSite=None` without `Secure`, and do not rely on the browser-default value, which varies across browsers and versions.
 
-See also: [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies)
+See also: [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value)
 
 ### Cookie Name Prefixes
 


### PR DESCRIPTION
## Description

This PR makes the SameSite guidance precise about cross-site cookie behavior and its role in CSRF defense.

## Changes

- Distinguish Strict behavior from the safe top-level navigation exception allowed by Lax
- Describe SameSite as defense in depth rather than a replacement for CSRF tokens
- Update the MDN link to the current SameSite section

## Testing

- Markdown lint passed
- Terminology lint passed
- Documentation-only change

## Scope and sourcing

This surgical change is limited to the SameSite subsection of Session_Management_Cheat_Sheet.md. I reviewed the linked OWASP and MDN guidance and verified that it supports the revised text.

## AI Tool Usage Disclosure

I used OpenAI Codex (GPT-5) to assist with repository analysis and drafting. The prompt asked for genuine, minimal OWASP documentation improvements and, after maintainer approval, a brief surgical patch for issue #2356. I independently reviewed the cited OWASP and MDN sources and verified the final change.

This PR fixes issue #2356.