### PR TITLE
Remove non-compiling Java LDAP escaping example

### DIFF
--- a/cheatsheets/Injection_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/Injection_Prevention_Cheat_Sheet.md
@@ -164,73 +164,9 @@ Scanner module of tool like OWASP [ZAP](https://www.zaproxy.org/) have module to
 
 ##### Remediation
 
-###### Escape all variables using the right LDAP encoding function
+###### Use the right LDAP encoding function
 
-The main way LDAP stores names is based on DN ([distinguished name](https://ldapwiki.com/wiki/Distinguished%20Names)). You can think of this like a unique identifier. These are sometimes used to access resources, like a username.
-
-A DN might look like this
-
-```text
-cn=Richard Feynman, ou=Physics Department, dc=Caltech, dc=edu
-```
-
-or
-
-```text
-uid=inewton, ou=Mathematics Department, dc=Cambridge, dc=com
-```
-
-There are certain characters that are considered special characters in a DN. The exhaustive list is the following: `\ # + < > , ; " =` and leading or trailing spaces
-
-Each DN points to exactly 1 entry, which can be thought of sort of like a row in a RDBMS. For each entry, there will be 1 or more attributes which are analogous to RDBMS columns. If you are interested in searching through LDAP for users will certain attributes, you may do so with search filters. In a search filter, you can use standard boolean logic to get a list of users matching an arbitrary constraint. Search filters are written in Polish notation AKA prefix notation.
-
-Example:
-
-```text
-(&(ou=Physics)(| (manager=cn=Freeman Dyson,ou=Physics,dc=Caltech,dc=edu)
-(manager=cn=Albert Einstein,ou=Physics,dc=Princeton,dc=edu) ))
-```
-
-When building LDAP queries in application code, you MUST escape any untrusted data that is added to any LDAP query. There are two forms of LDAP escaping. Encoding for LDAP Search and Encoding for LDAP DN (distinguished name). The proper escaping depends on whether you are sanitizing input for a search filter, or you are using a DN as a username-like credential for accessing some resource.
-
-##### Example code - Java
-
-###### Safe Java for LDAP escaping Example
-
-```java
-public String escapeDN (String name) {
- //From RFC 2253 and the / character for JNDI
- final char[] META_CHARS = {'+', '"', '<', '>', ';', '/'};
- String escapedStr = new String(name);
- //Backslash is both a Java and an LDAP escape character,
- //so escape it first
- escapedStr = escapedStr.replaceAll("\\\\\\\\","\\\\\\\\");
- //Positional characters - see RFC 2253
- escapedStr = escapedStr.replaceAll("\^#","\\\\\\\\#");
- escapedStr = escapedStr.replaceAll("\^ | $","\\\\\\\\ ");
- for (int i=0 ; i < META_CHARS.length ; i++) {
-        escapedStr = escapedStr.replaceAll("\\\\" +
-                     META_CHARS[i],"\\\\\\\\" + META_CHARS[i]);
- }
- return escapedStr;
-}
-```
-
-Note, that the backslash character is a Java String literal and a regular expression escape character.
-
-```java
-public String escapeSearchFilter (String filter) {
- //From RFC 2254
- String escapedStr = new String(filter);
- escapedStr = escapedStr.replaceAll("\\\\\\\\","\\\\\\\\5c");
- escapedStr = escapedStr.replaceAll("\\\\\*","\\\\\\\\2a");
- escapedStr = escapedStr.replaceAll("\\\\(","\\\\\\\\28");
- escapedStr = escapedStr.replaceAll("\\\\)","\\\\\\\\29");
- escapedStr = escapedStr.replaceAll("\\\\" +
-               Character.toString('\\u0000'), "\\\\\\\\00");
- return escapedStr;
-}
-```
+LDAP distinguished names and LDAP search filters require different escaping rules, defined by [RFC 4514](https://datatracker.ietf.org/doc/html/rfc4514) and [RFC 4515](https://datatracker.ietf.org/doc/html/rfc4515), respectively. Avoid custom escaping code and use a library encoder for the correct context. See the [LDAP Injection Prevention Cheat Sheet](LDAP_Injection_Prevention_Cheat_Sheet.md) for current defenses and examples.
 
 #### XPath Injection
 


### PR DESCRIPTION
## Description

This PR removes a duplicated custom Java LDAP escaping example that does not compile and points readers to the dedicated LDAP guidance.

## Changes

- Remove the non-compiling custom Java escaping methods and duplicated background material
- Summarize the distinction between distinguished-name and search-filter escaping
- Link RFC 4514, RFC 4515, and the dedicated LDAP Injection Prevention Cheat Sheet

## Testing

- Reproduced the original Java compiler errors with javac 25.0.1
- Markdown lint passed
- Terminology lint passed
- Documentation-only change

## Scope and sourcing

This focused change modifies only Injection_Prevention_Cheat_Sheet.md. I reviewed RFC 4514, RFC 4515, and the linked OWASP LDAP guidance and verified the replacement text.

## AI Tool Usage Disclosure

I used OpenAI Codex (GPT-5) to assist with repository analysis, compilation testing, and drafting. The prompt asked for genuine, minimal OWASP documentation improvements and, after maintainer approval, a focused patch for issue #2357. I independently reproduced the compiler errors and reviewed each cited source before verifying the final change.

This PR fixes issue #2357.