### PR TITLE
Fix broken link details in PR comments

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -28,16 +28,29 @@ jobs:
     - name: Run link check
       run: npm run link-check
     - name: Show broken links
+      id: brokenlinks
       if: failure()
       run: |
-        cat log | awk -v RS="FILE:" 'match($0, /(\S*\.md).*\[✖\].*(\d*\slinks\schecked\.)(.*)/, arr ) { print "FILE:"arr[1] arr[3] > "brokenlinks"}'
+        awk '
+          /^FILE:/ { file=$0; in_errors=0; file_printed=0; next }
+          /^[[:space:]]*ERROR:/ { in_errors=1; next }
+          in_errors && /^[[:space:]]*\[✖\]/ {
+            if (!file_printed) { print file; file_printed=1 }
+            print
+          }
+        ' log > brokenlinks
         rm -f err log
-        cat brokenlinks
-        links=`cat brokenlinks`
-        links="${links//'%'/'%25'}"
-        links="${links//$'\n'/'%0A'}"
-        links="${links//$'\r'/'%0D'}"
-        echo ::set-output name=links::**Following links are broken:** %0A$links
+        if [[ -s brokenlinks ]]; then
+          cat brokenlinks
+          {
+            echo 'links<<EOF'
+            echo '**Following links are broken:**'
+            cat brokenlinks
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+        else
+          echo 'links=Link check failed, but no broken-link details could be extracted.' >> "$GITHUB_OUTPUT"
+        fi
     - name: Send comment to PR with broken links
       if: failure() && github.event_name == 'pull_request'
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1


### PR DESCRIPTION
## Description

The Markdown Link Check workflow detects broken links, but its failure-reporting step cannot reliably pass the extracted details to the PR comment action.

## Root cause

- The output-producing step had no id even though the next step referenced steps.brokenlinks.outputs.links.
- The parser used the non-portable three-argument form of awk match(), which is not supported by every awk implementation used on Ubuntu runners.
- The expression expected the plural text links checked and did not handle output containing exactly one checked link.
- The workflow used the deprecated ::set-output command.

## Changes

- Give the extraction step the brokenlinks id.
- Parse markdown-link-check error blocks using portable awk syntax.
- Write multiline comment content through GITHUB_OUTPUT.
- Provide a fallback message if the link check fails without extractable details.

## Testing

- Verified the parser with representative one-file and multi-file markdown-link-check failure output.
- Verified the workflow parses as YAML.
- git diff --check passed.

## AI Tool Usage Disclosure

I used OpenAI Codex (GPT-5) to assist with repository analysis, diagnosis, and drafting this fix. The prompt asked to find a reproducible bug in the repository system and prepare a focused contribution. I independently inspected the workflow, reproduced the awk portability failure locally, compared the parser against real markdown-link-check output, and verified the final diff.