### PR TITLE
Vulnerable Dependency Management: remove discontinued Requires.io from Tools

### DIFF
--- a/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
+++ b/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md
@@ -302,8 +302,6 @@ It's important to ensure, during the selection process of a vulnerable dependenc
         - [Full support](https://jfrog.com/integration/) for many languages and package manager.
     - [Renovate](https://renovatebot.com) (allow to detect old dependencies):
         - [Full support](https://renovatebot.com/docs/) for many languages and package manager.
-    - [Requires.io](https://requires.io/) (allow to detect old dependencies - open source and free option available):
-        - [Full support](https://requires.io/features/): Python only.
 
 ### Remediation and maintained backports
 


### PR DESCRIPTION
**Scope:** one file, `cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md`, deletion only — the two Requires.io lines in Tools > Commercial.

Requires.io has been discontinued. The `requires.io` domain now serves a domain-parking page, so both links in the entry (the product page and `requires.io/features/`) no longer point to the tool. The entry has been in the sheet since 2019 (6dc5252). No replacement is added: the neighboring Renovate entry already covers detection of outdated dependencies.

**Disclosure:** I work at Seal Security, a vendor in this space. This change names no vendor and only removes a dead link.

Please make sure that for your contribution:

- [x] In case of a new Cheat Sheet, you have used the [Cheat Sheet template](../templates/New_CheatSheet.md). (not applicable, existing cheat sheet)
- [x] All the markdown files do not raise any validation policy violation, see the [policy](https://github.com/OWASP/CheatSheetSeries/actions?query=workflow%3A%22Markdown+Link+Check%22).
- [x] All the markdown files follow these [format rules](../CONTRIBUTING.md#markdown).
- [x] All your assets are stored in the **assets** folder. (no assets added)
- [x] All the images used are in the **PNG** format. (no images added)
- [x] Any references to websites have been formatted as `[TEXT](URL)` (none added)
- [x] You verified/tested the effectiveness of your contribution (e.g., the defensive code proposed is really an effective remediation? Please verify it works!). (verified the removed links are dead: `https://requires.io/` redirects to a parking lander)
- [x] The CI build of your PR pass, see the build status [here](https://github.com/OWASP/CheatSheetSeries/actions).

## Scope and sourcing (required)

- [x] This PR is focused: it modifies a single cheat sheet, or a small coordinated set, and the scope is described in the PR body.
- [x] Every technical claim, recommendation, or threat assertion added in this PR is supported by a primary source (RFC, NIST, OWASP standard, vendor documentation, peer-reviewed research) linked inline as `[text](URL)`. (deletion only, no claims added)
- [x] I have read each source I cite and confirm it actually supports the claim. I have not relied on summaries, hearsay, or model-generated citations. (no sources cited; the dead links were checked live before removal)

Ran locally on the edited file: `markdownlint` clean, `textlint` clean.

This PR fixes issue #2388.

## AI Tool Usage Disclosure (required for all PRs)

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `Claude Fable 5 (via Claude Code)`
    and the prompt used is `since requires.io is no longer a thing, let's create an issue and a PR to remove it`. I have independently verified that requires.io no longer hosts the service before removing the entry.
