### PR TITLE
Update AJAX Security Cheat Sheet title to Web Frontend Security Cheat Sheet

### DIFF
--- a/CONTRIBUTOR-V1.md
+++ b/CONTRIBUTOR-V1.md
@@ -4,7 +4,7 @@ If you want to modify something regarding the mention made to you (typo/link to 
 
 Sorting applied on the name is an alphabetical one.
 
-## [AJAX Security Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/tree/master/cheatsheets/AJAX_Security_Cheat_Sheet.md)
+## [Asynchronous Web Communication Security Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/tree/master/cheatsheets/AJAX_Security_Cheat_Sheet.md)
 
 - Michael Eddington
 - Til Mas

--- a/Index.md
+++ b/Index.md
@@ -10,7 +10,7 @@
 
 [AI Agent Security Cheat Sheet](cheatsheets/AI_Agent_Security_Cheat_Sheet.md) ![Python](assets/Index_Python.svg)
 
-[AJAX Security Cheat Sheet](cheatsheets/AJAX_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg)
+[Asynchronous Web Communication Security Cheat Sheet](cheatsheets/AJAX_Security_Cheat_Sheet.md) ![Javascript](assets/Index_Javascript.svg) ![Json](assets/Index_Json.svg)
 
 [AML Sanctions AI Agent Payments Cheat Sheet](cheatsheets/AML_Sanctions_AI_Agent_Payments_Cheat_Sheet.md)
 

--- a/IndexProactiveControls.md
+++ b/IndexProactiveControls.md
@@ -42,7 +42,7 @@ This cheat sheet will help users of the [OWASP Top Ten Proactive Controls 2018](
 
 ## [C4. Encode and Escape Data](https://top10proactive.owasp.org/archive/2018/c4-encode-escape-data/)
 
-[AJAX Security Cheat Sheet (Client Side)](cheatsheets/AJAX_Security_Cheat_Sheet.md#client-side-javascript)
+[Asynchronous Web Communication Security Cheat Sheet (Client Side)](cheatsheets/AJAX_Security_Cheat_Sheet.md#client-side-javascript)
 
 [Cross Site Scripting Prevention Cheat Sheet](cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md)
 

--- a/cheatsheets/AJAX_Security_Cheat_Sheet.md
+++ b/cheatsheets/AJAX_Security_Cheat_Sheet.md
@@ -1,4 +1,4 @@
-# AJAX Security Cheat Sheet
+# Asynchronous Web Communication Security Cheat Sheet
 
 ## Introduction
 


### PR DESCRIPTION
This PR updates the page title as proposed in #1755. It replaces 'AJAX Security Cheat Sheet' with 'Asynchronous Web Communication Security Cheat Sheet' in the main cheat sheet and index files. Addresses #1755