### PR TITLE
fix: dead links and broken .NET formatting in XXE cheat sheet

### DIFF
--- a/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
+++ b/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-An *XML eXternal Entity injection* (XXE), which is now part of the [OWASP Top 10](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A4-XML_External_Entities_%28XXE%29) via the point **A4**, is attack against applications that parse XML input. This issue is referenced in the ID [611](https://cwe.mitre.org/data/definitions/611.html) in the [Common Weakness Enumeration](https://cwe.mitre.org/index.html) referential. An XXE attack occurs when untrusted XML input with a **reference to an external entity is processed by a weakly configured XML parser**, and this attack could be used to stage multiple incidents, including:
+An *XML eXternal Entity injection* (XXE), which is now part of the [OWASP Top 10](https://owasp.org/www-project-top-ten/2017/A4_2017-XML_External_Entities_%28XXE%29.html) via the point **A4**, is attack against applications that parse XML input. This issue is referenced in the ID [611](https://cwe.mitre.org/data/definitions/611.html) in the [Common Weakness Enumeration](https://cwe.mitre.org/index.html) referential. An XXE attack occurs when untrusted XML input with a **reference to an external entity is processed by a weakly configured XML parser**, and this attack could be used to stage multiple incidents, including:
 
 - A denial of service attack on the system
 - A [Server Side Request Forgery](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery) (SSRF) attack
@@ -65,7 +65,7 @@ Disabling [DTD](https://www.w3schools.com/xml/xml_dtd.asp)s also makes the parse
 
 ### libxml2
 
-The Enum [xmlParserOption](http://xmlsoft.org/html/libxml-parser.html#xmlParserOption) should not have the following options defined:
+The Enum [xmlParserOption](https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html) should not have the following options defined:
 
 - `XML_PARSE_NOENT`: Expands entities and substitutes them with replacement text
 - `XML_PARSE_DTDLOAD`: Load the external DTD
@@ -115,13 +115,13 @@ parser->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
 
 ## ColdFusion
 
-Per [this blog post](https://hoyahaxa.blogspot.com/2022/11/on-coldfusion-xxe-and-other-xml-attacks.html), both Adobe ColdFusion and Lucee have built-in mechanisms to disable support for external XML entities.
+Per [this blog post](https://www.hoyahaxa.com/2022/11/on-coldfusion-xxe-and-other-xml-attacks.html), both Adobe ColdFusion and Lucee have built-in mechanisms to disable support for external XML entities.
 
 ### Adobe ColdFusion
 
 As of ColdFusion 2018 Update 14 and ColdFusion 2021 Update 4, all native ColdFusion functions that process XML have a XML parser argument that disables support for external XML entities. Since there is no global setting that disables external entities, developers must ensure that every XML function call uses the correct security options.
 
-From the [documentation for the XmlParse() function](https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/xmlparse.html), you can disable XXE with the code below:
+From the [documentation for the XmlParse() function](https://guides.adobe.com/coldfusion/en/docs/cfml-reference/xmlparse.html), you can disable XXE with the code below:
 
 ```
 <cfset parseroptions = structnew()>
@@ -573,13 +573,13 @@ For DoS attacks using a direct DTD (such as the [Billion laughs attack](https://
 Previously, this information was based on some older articles which may not be 100% accurate including:
 
 - [James Jardine's excellent .NET XXE article](https://www.jardinesoftware.net/2016/05/26/xxe-and-net/).
-- [Guidance from Microsoft on how to prevent XXE and XML Denial of Service in .NET](http://msdn.microsoft.com/en-us/magazine/ee335713.aspx).
+- [Guidance from Microsoft on how to prevent XXE and XML Denial of Service in .NET](https://learn.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses).
 
 ### Overview of .NET Parser Safety Levels
 
-**Below is an overview of all supported .NET XML parsers and their default safety levels. More details about each parser are included after this list.
+**Below is an overview of all supported .NET XML parsers and their default safety levels. More details about each parser are included below.**
 
-**XDocument (LINQ to XML)
+#### XDocument (LINQ to XML) default safety levels
 
 This parser is protected from external entities at .NET Framework version 4.5.2 and protected from Billion Laughs at version 4.5.2 or greater, but it is uncertain if this parser is protected from Billion Laughs before version 4.5.2.
 
@@ -593,15 +593,15 @@ These parsers are not vulnerable to external entity attacks or Billion Laughs be
 
 ### ASP.NET
 
-ASP.NET applications ≥ .NET 4.5.2 must also ensure setting the `<httpRuntime targetFramework="..." />` in their `Web.config` to ≥4.5.2 or risk being vulnerable regardless or the actual .NET version. Omitting this tag will also result in unsafe-by-default behavior.
+ASP.NET applications ≥ .NET 4.5.2 must also ensure setting the `<httpRuntime targetFramework="..." />` in their `Web.config` to ≥4.5.2 or risk being vulnerable regardless of the actual .NET version. Omitting this tag will also result in unsafe-by-default behavior.
 
-For the purpose of understanding the above table, the `.NET Framework Version` for an ASP.NET applications is either the .NET version the application was build with or the httpRuntime's `targetFramework` (Web.config), **whichever is lower**.
+For the purpose of understanding the version thresholds above, the effective .NET Framework version for an ASP.NET application is either the .NET version the application was built with or the httpRuntime's `targetFramework` (Web.config), **whichever is lower**.
 
-This configuration tag should not be confused with a similar configuration tag: `<compilation targetFramework="..." />` or the assemblies / projects targetFramework, which are **not** sufficient for achieving secure-by-default behavior as advertised in the above table.
+This configuration tag should not be confused with a similar configuration tag: `<compilation targetFramework="..." />` or the assemblies / projects targetFramework, which are **not** sufficient for achieving secure-by-default behavior as described above.
 
 ### LINQ to XML
 
-**Both the `XElement` and `XDocument` objects in the `System.Xml.Linq` library are safe from XXE injection from external file and DoS attack by default.** `XElement` parses only the elements within the XML file, so DTDs are ignored altogether. `XDocument` has XmlResolver [disabled by default](https://docs.microsoft.com/en-us/dotnet/standard/linq/linq-xml-security) so it's safe from SSRF. While DTDs are [enabled by default](https://referencesource.microsoft.com/#System.Xml.Linq/System/Xml/Linq/XLinq.cs,71f4626a3d6f9bad), from Framework versions ≥4.5.2, it is **not** vulnerable to DoS as noted but it may be vulnerable in earlier Framework versions. For more information, see [Microsoft's guidance on how to prevent XXE and XML Denial of Service in .NET](http://msdn.microsoft.com/en-us/magazine/ee335713.aspx)
+**Both the `XElement` and `XDocument` objects in the `System.Xml.Linq` library are safe from XXE injection from external file and DoS attack by default.** `XElement` parses only the elements within the XML file, so DTDs are ignored altogether. `XDocument` has XmlResolver [disabled by default](https://learn.microsoft.com/en-us/dotnet/standard/linq/linq-xml-security) so it's safe from SSRF. While DTDs are [enabled by default](https://github.com/microsoft/referencesource/blob/main/System.Xml.Linq/System/Xml/Linq/XLinq.cs#L1986-L1993), from Framework versions ≥4.5.2, it is **not** vulnerable to DoS as noted but it may be vulnerable in earlier Framework versions. For more information, see [Microsoft's guidance on how to prevent XXE and XML Denial of Service in .NET](https://learn.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses)
 
 ### XmlDictionaryReader
 
@@ -631,7 +631,7 @@ The following example shows how it is made safe:
 
 **For .NET Framework version ≥4.5.2, this is safe by default**.
 
-`XmlDocument` can become unsafe if you create your own nonnull `XmlResolver` with default or unsafe settings. If you need to enable DTD processing, instructions on how to do so safely are described in detail in the [referenced MSDN article](https://msdn.microsoft.com/en-us/magazine/ee335713.aspx).
+`XmlDocument` can become unsafe if you create your own nonnull `XmlResolver` with default or unsafe settings. If you need to enable DTD processing, instructions on how to do so safely are described in detail in the [referenced MSDN article](https://learn.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses).
 
 ### XmlNodeReader
 
@@ -645,7 +645,7 @@ They are set by default to have their ProhibitDtd property set to false in .NET 
 
 Additionally, in .NET versions 4.5.2 and later, the `XmlReaderSettings` belonging to the `XmlReader` has its `XmlResolver` set to null by default, which provides an additional layer of safety.
 
-Therefore, `XmlReader` objects will only become unsafe in version 4.5.2 and up if both the `DtdProcessing` property is set to Parse and the `XmlReaderSetting`'s `XmlResolver` is set to a nonnull XmlResolver with default or unsafe settings. If you need to enable DTD processing, instructions on how to do so safely are described in detail in the [referenced MSDN article](https://msdn.microsoft.com/en-us/magazine/ee335713.aspx).
+Therefore, `XmlReader` objects will only become unsafe in version 4.5.2 and up if both the `DtdProcessing` property is set to Parse and the `XmlReaderSetting`'s `XmlResolver` is set to a nonnull XmlResolver with default or unsafe settings. If you need to enable DTD processing, instructions on how to do so safely are described in detail in the [referenced MSDN article](https://learn.microsoft.com/en-us/archive/msdn-magazine/2009/november/xml-denial-of-service-attacks-and-defenses).
 
 ### XmlTextReader
 
@@ -710,7 +710,7 @@ For .NET Framework version ≥4.5.2, XPathNavigator is **safe by default**.
 
 It is safe by default because the default parser of the `Transform()` methods is an `XmlReader`, which is safe by default (per above).
 
-[The source code for this method is here.](http://www.dotnetframework.org/default.aspx/4@0/4@0/DEVDIV_TFS/Dev10/Releases/RTMRel/ndp/fx/src/Xml/System/Xml/Xslt/XslCompiledTransform@cs/1305376/XslCompiledTransform@cs)
+[The source code for this method is here.](https://github.com/microsoft/referencesource/blob/main/System.Xml/System/Xml/Xslt/XslCompiledTransform.cs)
 
 Some of the `Transform()` methods accept an `XmlReader` or `IXPathNavigable` (e.g., `XmlDocument`) as an input, and if you pass in an unsafe XML Parser then the `Transform` will also be unsafe.
 
@@ -745,11 +745,11 @@ Per the 'NSXMLDocument External Entity Restriction API' section of this [page](h
 libxml_set_external_entity_loader(null);
 ```
 
-A description of how to abuse this in PHP is presented in a good [SensePost article](https://www.sensepost.com/blog/2014/revisting-xxe-and-abusing-protocols/) describing a cool PHP based XXE vulnerability that was fixed in Facebook.
+A description of how to abuse this in PHP is presented in a good [SensePost article](https://sensepost.com/blog/2014/revisting-xxe-and-abusing-protocols/) describing a cool PHP based XXE vulnerability that was fixed in Facebook.
 
 ## Python
 
-The Python 3 official documentation contains a section on [xml vulnerabilities](https://docs.python.org/3/library/xml.html#xml-vulnerabilities). As of the 1st January 2020 Python 2 is no longer supported, however the Python website still contains [some legacy documentation](https://docs.Python.org/2/library/xml.html#xml-vulnerabilities).
+The Python 3 official documentation contains a section on [xml vulnerabilities](https://docs.python.org/3/library/xml.html#xml-vulnerabilities). As of the 1st January 2020 Python 2 is no longer supported, however the Python website still contains [some legacy documentation](https://docs.python.org/2/library/xml.html#xml-vulnerabilities).
 
 The table below shows you which various XML parsing modules in Python 3 are vulnerable to certain XXE attacks.
 
@@ -761,7 +761,7 @@ The table below shows you which various XML parsing modules in Python 3 are vuln
 | DTD Retrieval             | Safe       | Safe       | Safe       | Safe       | Safe       |
 | Decompression Bomb        | Safe       | Safe       | Safe       | Safe       | Vulnerable |
 
-To protect your application from the applicable attacks, [two packages](https://docs.python.org/3/library/xml.html#the-defusedxml-and-defusedexpat-packages) exist to help you sanitize your input and protect your application against DDoS and remote attacks.
+To protect your application from the applicable attacks, the [defusedxml](https://github.com/tiran/defusedxml) package exists to help you sanitize your input and protect your application against DDoS and remote attacks.
 
 ## Semgrep Rules
 
@@ -771,46 +771,25 @@ To protect your application from the applicable attacks, [two packages](https://
 
 Below are the rules for different XML parsers in Java
 
-#### Digester
-
-Identifying XXE vulnerability in the `org.apache.commons.digester3.Digester` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-Digester](https://semgrep.dev/s/salecharohit:xxe-Digester)
-
 #### DocumentBuilderFactory
 
-Identifying XXE vulnerability in the `javax.xml.parsers.DocumentBuilderFactory` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-dbf](https://semgrep.dev/s/salecharohit:xxe-dbf)
-
-#### SAXBuilder
-
-Identifying XXE vulnerability in the `org.jdom2.input.SAXBuilder` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-saxbuilder](https://semgrep.dev/s/salecharohit:xxe-saxbuilder)
+Identifying XXE vulnerability in the `javax.xml.parsers.DocumentBuilderFactory` library.
+The official registry rule is [documentbuilderfactory-disallow-doctype-decl-missing](https://semgrep.dev/r/java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-missing.documentbuilderfactory-disallow-doctype-decl-missing).
 
 #### SAXParserFactory
 
-Identifying XXE vulnerability in the `javax.xml.parsers.SAXParserFactory` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-SAXParserFactory](https://semgrep.dev/s/salecharohit:xxe-SAXParserFactory)
-
-#### SAXReader
-
-Identifying XXE vulnerability in the `org.dom4j.io.SAXReader` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-SAXReader](https://semgrep.dev/s/salecharohit:xxe-SAXReader)
+Identifying XXE vulnerability in the `javax.xml.parsers.SAXParserFactory` library.
+The official registry rule is [saxparserfactory-disallow-doctype-decl-missing](https://semgrep.dev/r/java.lang.security.audit.xxe.saxparserfactory-disallow-doctype-decl-missing.saxparserfactory-disallow-doctype-decl-missing).
 
 #### XMLInputFactory
 
-Identifying XXE vulnerability in the `javax.xml.stream.XMLInputFactory` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-XMLInputFactory](https://semgrep.dev/s/salecharohit:xxe-XMLInputFactory)
-
-#### XMLReader
-
-Identifying XXE vulnerability in the `org.xml.sax.XMLReader` library
-Rule can be played here [https://semgrep.dev/s/salecharohit:xxe-XMLReader](https://semgrep.dev/s/salecharohit:xxe-XMLReader)
+Identifying XXE vulnerability in the `javax.xml.stream.XMLInputFactory` library.
+The official registry rule is [xmlinputfactory-possible-xxe](https://semgrep.dev/r/java.lang.security.xmlinputfactory-possible-xxe.xmlinputfactory-possible-xxe).
 
 ## References
 
-- [XXE by InfoSecInstitute](https://resources.infosecinstitute.com/identify-mitigate-xxe-vulnerabilities/)
-- [OWASP Top 10-2017 A4: XML External Entities (XXE)](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A4-XML_External_Entities_%28XXE%29)
-- [Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"](https://vsecurity.com//download/papers/XMLDTDEntityAttacks.pdf)
+- [OWASP Top 10-2017 A4: XML External Entities (XXE)](https://owasp.org/www-project-top-ten/2017/A4_2017-XML_External_Entities_%28XXE%29.html)
+- [Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"](https://dl.packetstormsecurity.net/papers/general/XMLDTDEntityAttacks.pdf)
 - [FindSecBugs XXE Detection](https://find-sec-bugs.github.io/bugs.htm#XXE_SAXPARSER)
 - [XXEbugFind Tool](https://github.com/ssexxe/XXEBugFind)
 - [Testing for XML Injection](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/07-Testing_for_XML_Injection.html)


### PR DESCRIPTION
## Summary

Fixes dead and moved links plus two rendering bugs in the XXE Prevention Cheat Sheet.
All changes are outside the `## Java` section, so this does not overlap with #2405.

`markdown-link-check` reports 8 dead links on `master` for this file; this PR takes it to 5.
The 5 remaining are pre-existing: 4 are inside `## Java` (removed by #2405), and the
GitLab one is a 406 user-agent block, not a dead page.

Some of these are invisible to CI because the target returns HTTP 200 while serving
nothing — the Semgrep playground returns an identical 200 shell for any id.

## Changes

**Dead, replaced or removed**

- `resources.infosecinstitute.com` and `vsecurity.com` no longer resolve. The first is
  removed; the second (Timothy Morgan's paper) is repointed to a live copy, verified by
  the PDF metadata.
- The Python `#the-defusedxml-and-defusedexpat-packages` anchor was removed upstream, so
  the link landed at the top of the page. Repointed to the defusedxml project.
- All seven `semgrep.dev/s/salecharohit:*` playground snippets have been deleted by their
  owner (`/api/registry/rules/...` returns 404). Three now point at the official public
  registry rules; four had no public equivalent (the official rules are team-tier), so
  those subsections were removed rather than pointed somewhere invented. Happy to restore
  them if you would rather keep the headings.

**Moved**

- MSDN Magazine is retired — the same article was cited 4× across two URL forms, two over
  plain `http://`; all now point at the `learn.microsoft.com` archive.
- `referencesource.microsoft.com` now blanket-redirects to a repo root, discarding file and
  line; repointed to the same code on GitHub.
- `dotnetframework.org` (plain http, mixed content), `xmlsoft.org` (libxml2 docs moved to
  GNOME GitLab Pages; https fails TLS validation), `helpx.adobe.com` → `guides.adobe.com`,
  `hoyahaxa.blogspot.com` → author's domain, `www.sensepost.com` → apex,
  `docs.Python.org` → lowercase, and the OWASP A4 link → canonical page (the old one served
  only a meta-refresh stub).

**Rendering bugs in the .NET section**

- Two unclosed `**` markers. One printed literal asterisks on the published page; the other
  was a lost `####` heading, so that parser group has been missing from the page TOC.
- Two references to "the above table" pointing at a table removed in Feb 2024, plus
  "regardless **or** the actual" and "was build with" in the same sentences.

## Testing

- `npm run lint-markdown` — pass
- `npm run lint-terminology` — pass
- `markdown-link-check` on this file — 8 dead before, 5 after (all pre-existing)

Every replacement URL was opened and confirmed to still support the claim it is attached to.
Where nothing suitable existed, the link was removed rather than guessed at.
