### PR TITLE
fix: make markdown link checks fail closed

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -26,34 +26,21 @@ jobs:
     - name: Install dependencies
       run: npm ci --ignore-scripts
     - name: Run link check
+      id: link_check
       run: npm run link-check
-    - name: Show broken links
-      id: brokenlinks
-      if: failure()
-      run: |
-        awk '
-          /^FILE:/ { file=$0; in_errors=0; file_printed=0; next }
-          /^[[:space:]]*ERROR:/ { in_errors=1; next }
-          in_errors && /^[[:space:]]*\[✖\]/ {
-            if (!file_printed) { print file; file_printed=1 }
-            print
-          }
-        ' log > brokenlinks
-        rm -f err log
-        if [[ -s brokenlinks ]]; then
-          cat brokenlinks
-          {
-            echo 'links<<EOF'
-            echo '**Following links are broken:**'
-            cat brokenlinks
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-        else
-          echo 'links=Link check failed, but no broken-link details could be extracted.' >> "$GITHUB_OUTPUT"
-        fi
-    - name: Send comment to PR with broken links
-      if: failure() && github.event_name == 'pull_request'
+    - name: Prepare link check diagnostics
+      id: link_check_diagnostics
+      if: always()
+      env:
+        LINK_CHECK_EVENT_NAME: ${{ github.event_name }}
+        LINK_CHECK_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+        LINK_CHECK_OUTCOME: ${{ steps.link_check.outcome }}
+        LINK_CHECK_REPOSITORY: ${{ github.repository }}
+      run: node scripts/Prepare_Link_Check_Diagnostics.js
+    - name: Send comment with unexpected broken links
+      if: always() && steps.link_check_diagnostics.outputs.should_comment == 'true'
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
-        message: ${{ steps.brokenlinks.outputs.links }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        message: '**Following unexpected links are broken:**'
+        file-path: link-check-unexpected.md
+        github-token: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,17 +112,17 @@ Follow these steps:
 
 2. Ensure that the markdown file you have created/modified do not have any dead links. You can verify that by using this [plugin](https://www.npmjs.com/package/markdown-link-check). If you cannot use this plugin then, verify that all the links you have changed or added are valid before pushing.
     1. Install [NodeJS](https://nodejs.org/en/download/) to install NPM.
-    2. Install the validation plugin via the command `npm install -g markdown-link-check`
+    2. Install the repository's locked dependencies with `npm ci --ignore-scripts`.
     3. Use this command (from the repository root folder) on your markdown file to verify the presence of any dead links:
 
 ```bash
-markdown-link-check -c .markdownlinkcheck.json [MD_FILE]
+npx --no-install markdown-link-check -c markdown-link-check-config.json [MD_FILE]
 ```
 
 The should produce output similar to the below. Any identified dead links are shown using a red cross instead of a green tick before the link.
 
 ```bash
-$ markdown-link-check -c .markdownlinkcheck.json cheatsheets/Transaction_Authorization_Cheat_Sheet.md
+$ npx --no-install markdown-link-check -c markdown-link-check-config.json cheatsheets/Transaction_Authorization_Cheat_Sheet.md
 FILE: cheatsheets/Transaction_Authorization_Cheat_Sheet.md
 [✓] https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm
 [✓] https://en.wikipedia.org/wiki/Chip_Authentication_Program

--- a/link-check-known-failures.json
+++ b/link-check-known-failures.json
@@ -1,12 +1,16 @@
 {
-  "schemaVersion": 1,
-  "generatedFrom": {
-    "baseCommit": "e5420b90672011aa84d3e5de3c3e38f704a5033d",
-    "workflowRunId": 34185231643,
-    "workflowJobId": 101932122278,
-    "workflowUrl": "https://github.com/OWASP/CheatSheetSeries/actions/runs/34185231643/job/101932122278"
-  },
-  "failures": [
+  "schemaVersion": 2,
+  "batches": [
+    {
+      "generatedFrom": {
+        "attemptCount": 1,
+        "checkedHead": "daae48ab4c94803f0250ff9beb5e4f815091e259",
+        "contentBaseCommit": "e5420b90672011aa84d3e5de3c3e38f704a5033d",
+        "workflowRunId": 34185231643,
+        "workflowJobId": 101932122278,
+        "workflowUrl": "https://github.com/OWASP/CheatSheetSeries/actions/runs/34185231643/job/101932122278"
+      },
+      "failures": [
     {
       "file": "cheatsheets/Abuse_Case_Cheat_Sheet.md",
       "url": "https://www.synopsys.com/blogs/software-security/abuse-cases-can-drive-security-requirements.html",
@@ -846,6 +850,55 @@
       "file": "cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md",
       "url": "http://help.dottoro.com/ljfvvdnm.php",
       "observedStatus": 404
+    }
+      ]
+    },
+    {
+      "generatedFrom": {
+        "attemptCount": 3,
+        "checkedHead": "47a37a9226052e03a516a536e9431813e23878b9",
+        "contentBaseCommit": "e5420b90672011aa84d3e5de3c3e38f704a5033d",
+        "workflowRunId": 34228838406,
+        "workflowJobId": 102069549060,
+        "workflowUrl": "https://github.com/OWASP/CheatSheetSeries/actions/runs/34228838406/job/102069549060"
+      },
+      "failures": [
+        {
+          "file": "cheatsheets/Cryptographic_Storage_Cheat_Sheet.md",
+          "url": "https://azure.microsoft.com/en-gb/services/key-vault/",
+          "observedStatuses": [0, 0, 0]
+        },
+        {
+          "file": "cheatsheets/Denial_of_Service_Cheat_Sheet.md",
+          "url": "https://www.baeldung.com/cs/distributed-systems-prevent-single-point-failure",
+          "observedStatuses": [403, 403, 403]
+        },
+        {
+          "file": "cheatsheets/Deserialization_Cheat_Sheet.md",
+          "url": "https://macrosec.tech/index.php/2021/06/29/exploiting-insecuredeserialization-bugs-found-in-the-wild-python-pickles.",
+          "observedStatuses": [409, 409, 409]
+        },
+        {
+          "file": "cheatsheets/Error_Handling_Cheat_Sheet.md",
+          "url": "https://www.baeldung.com/exception-handling-for-rest-with-spring",
+          "observedStatuses": [403, 403, 403]
+        },
+        {
+          "file": "cheatsheets/Mass_Assignment_Cheat_Sheet.md",
+          "url": "https://www.baeldung.com/jackson-field-serializable-deserializable-or-not",
+          "observedStatuses": [403, 403, 403]
+        },
+        {
+          "file": "cheatsheets/Secrets_Management_Cheat_Sheet.md",
+          "url": "https://azure.microsoft.com/en-us/services/azure-dedicated-hsm/",
+          "observedStatuses": [0, 0, 0]
+        },
+        {
+          "file": "cheatsheets/Subdomain_Takeover_Prevention_Cheat_Sheet.md",
+          "url": "https://crt.sh",
+          "observedStatuses": [502, 502, 502]
+        }
+      ]
     }
   ]
 }

--- a/link-check-known-failures.json
+++ b/link-check-known-failures.json
@@ -1,0 +1,851 @@
+{
+  "schemaVersion": 1,
+  "generatedFrom": {
+    "baseCommit": "e5420b90672011aa84d3e5de3c3e38f704a5033d",
+    "workflowRunId": 34185231643,
+    "workflowJobId": 101932122278,
+    "workflowUrl": "https://github.com/OWASP/CheatSheetSeries/actions/runs/34185231643/job/101932122278"
+  },
+  "failures": [
+    {
+      "file": "cheatsheets/Abuse_Case_Cheat_Sheet.md",
+      "url": "https://www.synopsys.com/blogs/software-security/abuse-cases-can-drive-security-requirements.html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Authorization_Cheat_Sheet.md",
+      "url": "https://dzone.com/articles/simple-attribute-based-access-control-with-spring",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Authorization_Cheat_Sheet.md",
+      "url": "https://resources.infosecinstitute.com/information-and-asset-classification/",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Authorization_Cheat_Sheet.md",
+      "url": "https://us-cert.cisa.gov/bsi/articles/knowledge/principles/least-privilege",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Authorization_Cheat_Sheet.md",
+      "url": "https://www.veracode.com/sites/default/files/pdf/resources/sossreports/state-of-software-security-volume-10-veracode-report.pdf",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://archive.codeplex.com/?p=safeint",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-exploit-guard/customize-exploit-protection",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-exploit-guard/exploit-protection",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://gcc.gnu.org/onlinedocs/gcc/Spec-Files.html",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://groups.google.com/g/fa.linux.kernel/c/jjk_K4HOemQ/",
+      "observedStatus": 429
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://linux.die.net/man/5/elf",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://lists.gnu.org/archive/html/autoconf/2012-12/msg00038.html",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://pdfs.semanticscholar.org/9d92/fa9eaa6ca12888d303deffe8bc392b85c09f.pdf",
+      "observedStatus": 202
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/questions/14927033/boost-hardening-guide-preprocessor-macros",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://www.conifersystems.com/whitepapers/gnu-make/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/C-Based_Toolchain_Hardening_Cheat_Sheet.md",
+      "url": "https://www.schneier.com/academic/paperfiles/paper-ssl-revised.pdf",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/CI_CD_Security_Cheat_Sheet.md",
+      "url": "https://azure.microsoft.com/mediahandler/files/resourcefiles/3-ways-to-mitigate-risk-using-private-package-feeds/3%20Ways%20to%20Mitigate%20Risk%20When%20Using%20Private%20Package%20Feeds%20-%20v1.0.pdf",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/CI_CD_Security_Cheat_Sheet.md",
+      "url": "https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/CI_CD_Security_Cheat_Sheet.md",
+      "url": "https://dzone.com/articles/jenkins-log-monitoring-with-elk",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/CI_CD_Security_Cheat_Sheet.md",
+      "url": "https://www.akeyless.io/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/CI_CD_Security_Cheat_Sheet.md",
+      "url": "https://www.hashicorp.com/products/vault",
+      "observedStatus": 429
+    },
+    {
+      "file": "cheatsheets/Content_Security_Policy_Cheat_Sheet.md",
+      "url": "https://report-uri.com/home/hash",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Content_Security_Policy_Cheat_Sheet.md",
+      "url": "https://www.appsecmonkey.com/blog/content-security-policy-header/",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://security.stackexchange.com/a/22936",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/a/30539335",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/a/8656417",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/questions/22397072/are-there-any-browsers-that-set-the-origin-header-to-null-for-privacy-sensitiv",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/questions/6880659/in-what-cases-will-http-referer-be-empty",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/XSS_Experimental_Minimal_Encoding_Rules",
+      "observedStatus": 500
+    },
+    {
+      "file": "cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.md",
+      "url": "http://jtidy.sourceforge.net/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Database_Security_Cheat_Sheet.md",
+      "url": "https://dev.mysql.com/doc/connector-net/en/connector-net-programming-authentication-windows-native.html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Database_Security_Cheat_Sheet.md",
+      "url": "https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_file",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Database_Security_Cheat_Sheet.md",
+      "url": "https://dev.mysql.com/doc/refman/8.0/en/security-guidelines.html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Denial_of_Service_Cheat_Sheet.md",
+      "url": "https://www.esecurityplanet.com/networks/types-of-ddos-attacks/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Denial_of_Service_Cheat_Sheet.md",
+      "url": "https://www.ibm.com/docs/en/baw/23.x?topic=issues-best-practices-high-jvm-cpu-utilization",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Deserialization_Cheat_Sheet.md",
+      "url": "http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/#websphere",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Deserialization_Cheat_Sheet.md",
+      "url": "https://bitbucket.org/snakeyaml/snakeyaml/wiki/CVE-2022-1471",
+      "observedStatus": 202
+    },
+    {
+      "file": "cheatsheets/Docker_Security_Cheat_Sheet.md",
+      "url": "https://docs.docker.com/engine/security/selinux/",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/DotNet_Security_Cheat_Sheet.md",
+      "url": "http://windowsupdate.microsoft.com/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/DotNet_Security_Cheat_Sheet.md",
+      "url": "https://github.com/microsoft/code-with-engineering-playbook/blob/main/docs/observability/README.md",
+      "observedStatus": 429
+    },
+    {
+      "file": "cheatsheets/Drone_Security_Cheat_Sheet.md",
+      "url": "https://devzone.nordicsemi.com/f/nordic-q-a/17165/ble-just-works-pairing",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Drone_Security_Cheat_Sheet.md",
+      "url": "https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/encrypting-block-devices-using-luks_security-hardening",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Error_Handling_Cheat_Sheet.md",
+      "url": "https://exceptionnotfound.net/the-asp-net-web-api-exception-handling-pipeline-a-guided-tour/",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Error_Handling_Cheat_Sheet.md",
+      "url": "https://www.toptal.com/java/spring-boot-rest-api-error-handling",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/File_Upload_Cheat_Sheet.md",
+      "url": "https://security.stackexchange.com/a/8625/118367",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://about.gitlab.com/blog/2019/07/03/security-release-gitlab-12-dot-0-dot-3-released/#authorization-issues-in-graphql",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://foundation.graphql.org/",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa1-broken-object-level-authorization.md",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa3-excessive-data-exposure.md",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa5-broken-function-level-authorization.md",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://github.com/OWASP/API-Security/blob/master/2019/en/src/0xa8-injection.md",
+      "observedStatus": 429
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://lab.wallarm.com/graphql-batching-attack/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://lab.wallarm.com/why-and-how-to-disable-introspection-query-for-graphql-apis/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://linuxhint.com/linux_ulimit_command/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://nordicapis.com/security-points-to-consider-before-implementing-graphql/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/a/53277955/1200388",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://vulners.com/hackerone/H1:435066",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://vulners.com/myhack58/MYHACK58:62201994269",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://www.apollographql.com/blog/query-batching-in-apollo-63acfd859862/",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://www.apollographql.com/blog/securing-your-graphql-api-from-malicious-queries-16130a324a6b",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://www.cloudflare.com/learning/ddos/glossary/denial-of-service/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/GraphQL_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/graphql-depth-limit",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/HTML5_Security_Cheat_Sheet.md",
+      "url": "https://sqlite.org/wasm/doc/trunk/about.md",
+      "observedStatus": 503
+    },
+    {
+      "file": "cheatsheets/HTTP_Headers_Cheat_Sheet.md",
+      "url": "https://blog.mozilla.org/security/2016/08/26/mitigating-mime-confusion-attacks-in-firefox/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/HTTP_Headers_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/helmet",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.md",
+      "url": "https://dzone.com/articles/infrastructure-as-code-security",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.md",
+      "url": "https://securityboulevard.com/2020/04/shifting-cloud-security-left-with-infrastructure-as-code/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Injection_Prevention_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/Automated_Audit_using_SQLMap",
+      "observedStatus": 500
+    },
+    {
+      "file": "cheatsheets/JAAS_Cheat_Sheet.md",
+      "url": "https://jaasbook.wordpress.com/2009/09/27/intro/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Java_Security_Cheat_Sheet.md",
+      "url": "https://arxiv.org/ftp/arxiv/papers/1506/1506.04082.pdf",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Java_Security_Cheat_Sheet.md",
+      "url": "https://ckarande.gitbooks.io/owasp-nodegoat-tutorial/content/tutorial/a1_-_sql_and_nosql_injection.html",
+      "observedStatus": 401
+    },
+    {
+      "file": "cheatsheets/Java_Security_Cheat_Sheet.md",
+      "url": "https://crypto.stackexchange.com/a/66500",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Key_Management_Cheat_Sheet.md",
+      "url": "https://media.defense.gov/2025/May/30/2003728741/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS.PDF",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Kubernetes_Security_Cheat_Sheet.md",
+      "url": "https://blog.styra.com/blog/open-policy-agent-authorization-for-the-cloud",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Kubernetes_Security_Cheat_Sheet.md",
+      "url": "https://glasnostic.com/blog/service-mesh-istio-limits-and-benefits-part-1",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Kubernetes_Security_Cheat_Sheet.md",
+      "url": "https://techbeacon.com/enterprise-it/hackers-guide-kubernetes-security",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Kubernetes_Security_Cheat_Sheet.md",
+      "url": "https://www.magalix.com/blog/introducing-policy-as-code-the-open-policy-agent-opa",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md",
+      "url": "https://wiki.sei.cmu.edu/confluence/spaces/flyingpdf/pdfpageexport.action?pageId=88487534",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.md",
+      "url": "https://atlas.mitre.org/techniques/AML.T0051",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Logging_Cheat_Sheet.md",
+      "url": "https://owasp.org/www-project-security-logging/",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Mass_Assignment_Cheat_Sheet.md",
+      "url": "http://flexjson.sourceforge.net/#Serialization",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Mass_Assignment_Cheat_Sheet.md",
+      "url": "http://json-lib.sourceforge.net/advanced.html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Mass_Assignment_Cheat_Sheet.md",
+      "url": "https://code.tutsplus.com/tutorials/mass-assignment-rails-and-you--net-31695",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Mass_Assignment_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/a/27986860",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Mass_Assignment_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/mongoose-mass-assign",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Microservices_based_Security_Arch_Doc_Cheat_Sheet.md",
+      "url": "https://gist.github.com/vladgolubev/80c5523336ddec3859c0e90d9a070882",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Mobile_Application_Security_Cheat_Sheet.md",
+      "url": "https://owasp.org/www-project-mobile-top-10/2023-risks/m1-insecure-authentication-authorization.html",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Mobile_Application_Security_Cheat_Sheet.md",
+      "url": "https://support.apple.com/guide/iphone/change-siri-accessibility-settings-iphaff1d606/ios.",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Multifactor_Authentication_Cheat_Sheet.md",
+      "url": "https://fidoalliance.org/fido2/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Multifactor_Authentication_Cheat_Sheet.md",
+      "url": "https://fidoalliance.org/specifications/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Multifactor_Authentication_Cheat_Sheet.md",
+      "url": "https://www.enisa.europa.eu/publications/handbook-on-security-of-personal-data-processing/@@download/fullReport",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/NPM_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/sharp",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/NodeJS_Docker_Cheat_Sheet.md",
+      "url": "https://www.fastify.io/docs/latest/Server/",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/Security_by_Design_Principles",
+      "observedStatus": 500
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/acl",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/bunyan",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/csurf",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/express-mongo-sanitize",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/helmet",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/hpp",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/mongoose",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/nocache",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/pino",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/raw-body",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/sanitize-html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/svg-captcha",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/toobusy-js",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/validator",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Nodejs_Security_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/winston",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Password_Storage_Cheat_Sheet.md",
+      "url": "Cryptographic_Storage_Cheat_Sheet.html#secure-random-number-generation",
+      "observedStatus": 400
+    },
+    {
+      "file": "cheatsheets/Password_Storage_Cheat_Sheet.md",
+      "url": "https://security.stackexchange.com/questions/39849/does-bcrypt-have-a-maximum-password-length",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Password_Storage_Cheat_Sheet.md",
+      "url": "https://soatok.blog/2024/11/27/beyond-bcrypt/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Password_Storage_Cheat_Sheet.md",
+      "url": "https://tobtu.com/minimum-password-settings/",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Pinning_Cheat_Sheet.md",
+      "url": "https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md",
+      "observedStatus": 429
+    },
+    {
+      "file": "cheatsheets/Pinning_Cheat_Sheet.md",
+      "url": "https://github.com/dialogs/electron-ssl-pinning",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Pinning_Cheat_Sheet.md",
+      "url": "https://square.github.io/okhttp/3.x/okhttp/okhttp3/CertificatePinner.html",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Pinning_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/Data_Validation",
+      "observedStatus": 500
+    },
+    {
+      "file": "cheatsheets/RAG_Security_Cheat_Sheet.md",
+      "url": "https://genai.owasp.org/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Ruby_on_Rails_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/questions/4251284/raw-vs-html-safe-vs-h-to-unescape-html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/SAML_Security_Cheat_Sheet.md",
+      "url": "http://www.webtrust.org/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/Category:OWASP_Code_Review_Project",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/Reviewing_Code_for_SQL_Injection",
+      "observedStatus": 500
+    },
+    {
+      "file": "cheatsheets/Secrets_Management_Cheat_Sheet.md",
+      "url": "https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Secrets_Management_Cheat_Sheet.md",
+      "url": "https://xebia.com/from-build-to-run-pointers-on-secure-deployment/",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Secrets_Management_Cheat_Sheet.md",
+      "url": "https://xebia.com/ten-pitfalls-you-should-look-out-for-in-aws-iam/",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.md",
+      "url": "https://www.iso.org/standard/27001",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Secure_Code_Review_Cheat_Sheet.md",
+      "url": "https://wiki.sei.cmu.edu/confluence/display/seccode",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Secure_Code_Review_Cheat_Sheet.md",
+      "url": "https://www.iso.org/standard/44378.html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Secure_Coding_with_AI_Cheat_Sheet.md",
+      "url": "https://genai.owasp.org/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Securing_Cascading_Style_Sheets_Cheat_Sheet.md",
+      "url": "https://www.scmagazine.com/news/vulnerability-management/style-sheet-vulnerability-allowed-attacker-to-hijack-linkedin-pages",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://stackoverflow.com/a/26987741",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://www.cyber.gov.au/acsc/view-all-content/publications/implementing-network-segmentation-and-segregation",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://www.mwrinfosecurity.com/our-thinking/making-the-case-for-network-segregation",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/ip-address",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/is-valid-domain",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Session_Management_Cheat_Sheet.md",
+      "url": "https://media.blackhat.com/bh-eu-11/Raul_Siles/BlackHat_EU_2011_Siles_SAP_Session-Slides.pdf",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Session_Management_Cheat_Sheet.md",
+      "url": "https://media.blackhat.com/bh-eu-11/Raul_Siles/BlackHat_EU_2011_Siles_SAP_Session-WP.pdf",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.md",
+      "url": "https://media.defense.gov/2022/Sep/01/2003068942/-1/-1/0/ESF_SECURING_THE_SOFTWARE_SUPPLY_CHAIN_DEVELOPERS.PDF",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.md",
+      "url": "https://www.sqreen.com/web-application-security/what-is-dast",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.md",
+      "url": "https://www.sqreen.com/web-application-security/what-is-sast",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.md",
+      "url": "https://www.veracode.com/sites/default/files/pdf/resources/whitepapers/what-is-rasp.pdf",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Third_Party_Payment_Gateway_Integration_Cheat_Sheet.md",
+      "url": "https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/10-Business_Logic_Testing/10-Test-Payment-Functionality",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Third_Party_Payment_Gateway_Integration_Cheat_Sheet.md",
+      "url": "https://www.payway.com/blog/carding-explained-how-to-stop-a-silent-threat-to-your-business",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Threat_Modeling_Cheat_Sheet.md",
+      "url": "https://safecode.org/wp-content/uploads/2017/05/SAFECode_TM_Whitepaper.pdf",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Transaction_Authorization_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/OWASP_Anti-Malware_-_Knowledge_Base",
+      "observedStatus": 500
+    },
+    {
+      "file": "cheatsheets/Transaction_Authorization_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/OWASP_Anti-Malware_Project_-_Awareness_Program",
+      "observedStatus": 500
+    },
+    {
+      "file": "cheatsheets/Transport_Layer_Security_Cheat_Sheet.md",
+      "url": "https://cryptcheck.fr/",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/Transport_Layer_Security_Cheat_Sheet.md",
+      "url": "https://www.immuniweb.com/ssl/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md",
+      "url": "http://googlewebmastercentral.blogspot.com/2009/01/open-redirect-urls-is-your-site-being.html",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/User_Privacy_Protection_Cheat_Sheet.md",
+      "url": "https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/01-Testing_for_Weak_SSL_TLS_Ciphers_Insufficient_Transport_Layer_Protection.html",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/User_Privacy_Protection_Cheat_Sheet.md",
+      "url": "https://wiki.owasp.org/index.php/Guide_to_Cryptography",
+      "observedStatus": 500
+    },
+    {
+      "file": "cheatsheets/Virtual_Patching_Cheat_Sheet.md",
+      "url": "https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/modsecurity-advanced-topic-of-the-week-automated-virtual-patching-using-owasp-zed-attack-proxy",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md",
+      "url": "https://github.com/disclose/disclose/tree/master/terms",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md",
+      "url": "https://huntr.dev/bounties",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md",
+      "url": "https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure",
+      "observedStatus": 404
+    },
+    {
+      "file": "cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md",
+      "url": "https://www.openbugbounty.org",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md",
+      "url": "https://www.npmjs.com/package/npm-audit-html",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.md",
+      "url": "https://www.whitehatsec.com/glossary/content/false-positive",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/Web_Service_Security_Cheat_Sheet.md",
+      "url": "https://www.ws-attacks.org/XML_Entity_Expansion",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md",
+      "url": "http://stackoverflow.com/questions/14307442/is-it-safe-to-use-xmldecoder-to-read-document-files",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md",
+      "url": "http://www.cvedetails.com/cve/CVE-2014-6517/",
+      "observedStatus": 403
+    },
+    {
+      "file": "cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md",
+      "url": "https://gitlab.gnome.org/GNOME/libxml2/commit/4629ee02ac649c27f9c0cf98ba017c6b5526070f",
+      "observedStatus": 406
+    },
+    {
+      "file": "cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md",
+      "url": "https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-t-z/xmlparse.html",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md",
+      "url": "https://pivotal.io/security/cve-2013-4152",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md",
+      "url": "https://pivotal.io/security/cve-2013-7315",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md",
+      "url": "https://resources.infosecinstitute.com/identify-mitigate-xxe-vulnerabilities/",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md",
+      "url": "https://vsecurity.com//download/papers/XMLDTDEntityAttacks.pdf",
+      "observedStatus": 0
+    },
+    {
+      "file": "cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.md",
+      "url": "http://help.dottoro.com/ljfvvdnm.php",
+      "observedStatus": 404
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.1",
       "license": "CC-BY-SA-4.0",
       "devDependencies": {
+        "markdown-link-check": "3.14.2",
         "markdownlint-cli": "^0.49.1",
         "textlint": "^15.8.0",
         "textlint-filter-rule-comments": "^1.2.2",
@@ -130,6 +131,58 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@oozcitak/dom": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-2.0.2.tgz",
+      "integrity": "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/url": "^3.0.0",
+        "@oozcitak/util": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-2.0.2.tgz",
+      "integrity": "sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/util": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-3.0.0.tgz",
+      "integrity": "sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/util": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-10.0.0.tgz",
+      "integrity": "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0"
       }
     },
     "node_modules/@textlint/ast-node-types": {
@@ -340,6 +393,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -387,6 +447,16 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/ajv": {
       "version": "8.20.0",
@@ -438,6 +508,19 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -447,6 +530,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bail": {
       "version": "1.0.5",
@@ -468,6 +558,23 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/boundary": {
       "version": "2.0.0",
@@ -514,6 +621,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -557,6 +677,50 @@
         "node": "*"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -595,6 +759,46 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
+      "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/debug": {
@@ -646,6 +850,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/degenerator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
+      "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "quickjs-wasi": "^2.2.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -680,12 +902,85 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -711,6 +1006,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/extend": {
@@ -854,6 +1205,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-uri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
+      "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.3.1",
+        "data-uri-to-buffer": "8.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -912,6 +1278,92 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-link-extractor": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/html-link-extractor/-/html-link-extractor-1.0.5.tgz",
+      "integrity": "sha512-ADd49pudM157uWHwHQPUSX4ssMsvR/yHIswOR5CUfBdK9g9ZYGMhVSE6KZVHJ6kCkR0gH4htsfzU6zECDNVwyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio": "^1.0.0-rc.10"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
@@ -943,6 +1395,29 @@
       "license": "ISC",
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {
@@ -1018,6 +1493,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-relative-url": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-4.1.0.tgz",
+      "integrity": "sha512-vhIXKasjAuxS7n+sdv7pJQykEAgS+YU8VBQOENXwo/VZpOHDgBBsIbHo7zFKaWBjYWF4qxERdhbPRRtFAeJKfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-absolute-url": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/js-tokens": {
@@ -1138,6 +1629,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/link-check": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/link-check/-/link-check-5.6.0.tgz",
+      "integrity": "sha512-oTHNw9+pgFvXqgTM3vWYOMkf4Pv5mywUr2L6EYkiRiVtpGrDXs8wV+kGP3bxBRwnC7gD3b9IRBu1dx/Tm1MFDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-relative-url": "^4.1.0",
+        "ms": "^2.1.3",
+        "needle": "^3.5.0",
+        "node-email-verifier": "^4.0.0",
+        "proxy-agent": "^8.0.2"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
@@ -1219,6 +1724,212 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-link-check": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.14.2.tgz",
+      "integrity": "sha512-DPJ+itd3D5fcfXD5s1i53lugH0Z/h80kkQxlYCBh8tFwEZGhyVgDcLl0rnKlWssAVDAmSmcbePpHpMEY+JcMMQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "async": "^3.2.6",
+        "chalk": "^5.6.2",
+        "commander": "^14.0.2",
+        "link-check": "^5.5.1",
+        "markdown-link-extractor": "^4.0.3",
+        "needle": "^3.3.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "xmlbuilder2": "^4.0.0"
+      },
+      "bin": {
+        "markdown-link-check": "markdown-link-check"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-check/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-link-check/node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/markdown-link-extractor": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-4.0.4.tgz",
+      "integrity": "sha512-Dw9saacqF4u1EjUm3O+f0ZTBM/o7l1IrdHS8z1KSFX2coECIcJTZbltICMKx6QwHBKlzMQXgtWYnIHX71WHZMw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "html-link-extractor": "^1.0.5",
+        "marked": "^18.0.7"
       }
     },
     "node_modules/markdown-table": {
@@ -1353,6 +2064,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.12.tgz",
+      "integrity": "sha512-LEm4ga2YeI2T3GVHj9b0BaDPPk93LLTHMFeMyQbNIzPxc8vCI0y/scy0ZA6z6lXKyT9j9Nhl/OC6ZYKYGuFScA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/md5": {
@@ -3184,6 +3908,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/needle": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+      "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
     "node_modules/neotraverse": {
       "version": "0.6.18",
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
@@ -3192,6 +3933,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-email-verifier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-email-verifier/-/node-email-verifier-4.0.0.tgz",
+      "integrity": "sha512-W3ktpVPscUx43WSTm1Vf797cMQMsGwp0JO08ksRaZG8A8wcRUd/XAihL78FwYl2rfABa1m1nIsBtqOMxY9uekA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3",
+        "validator": "^13.15.20"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/normalize-package-data": {
@@ -3207,6 +3972,19 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/optionator": {
@@ -3225,6 +4003,43 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "get-uri": "8.0.1",
+        "http-proxy-agent": "9.1.0",
+        "https-proxy-agent": "9.1.0",
+        "pac-resolver": "9.0.1",
+        "quickjs-wasi": "^2.2.0",
+        "socks-proxy-agent": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
+      "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "7.0.1",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "quickjs-wasi": "^2.2.0"
       }
     },
     "node_modules/parse-entities": {
@@ -3263,6 +4078,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-scurry": {
@@ -3326,6 +4194,74 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "9.1.0",
+        "https-proxy-agent": "9.1.0",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "9.1.0",
+        "proxy-from-env": "^2.0.0",
+        "socks-proxy-agent": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -3353,6 +4289,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
       "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/quickjs-wasi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
+      "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3502,6 +4445,23 @@
         "run-con": "cli.js"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -3533,6 +4493,17 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
@@ -3544,6 +4515,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+      "integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/spdx-correct": {
@@ -3770,6 +4782,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3802,6 +4821,16 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -3926,6 +4955,16 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vfile": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
@@ -3982,6 +5021,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3990,6 +5053,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xmlbuilder2": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-4.0.3.tgz",
+      "integrity": "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/dom": "^2.0.2",
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/util": "^10.0.0",
+        "js-yaml": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -4,18 +4,20 @@
   "description": "OWASP CSS Project",
   "main": "index.js",
   "devDependencies": {
+    "markdown-link-check": "3.14.2",
     "markdownlint-cli": "^0.49.1",
     "textlint": "^15.8.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-terminology": "^5.2.12"
   },
   "scripts": {
-    "test": "npm run lint-markdown && npm run lint-terminology",
+    "test": "npm run lint-markdown && npm run lint-terminology && npm run test:link-check",
+    "test:link-check": "node --test tests/link-check/*.test.js",
     "lint-terminology": "textlint ./cheatsheets/",
     "lint-terminology-fix": "textlint --fix ./cheatsheets/",
     "lint-markdown": "markdownlint ./ -c .markdownlint.json --ignore node_modules --ignore cheatsheets_excluded",
     "lint-markdown-fix": "markdownlint --fix ./ -c .markdownlint.json --ignore node_modules --ignore cheatsheets_excluded",
-    "link-check": "find  cheatsheets -name \\*.md -exec markdown-link-check -c markdown-link-check-config.json 1> log 2> err {} \\; && if [ -e err ] && grep -q  \"ERROR:\" err ; then exit 113  ; else echo -e \"All good\"; fi"
+    "link-check": "bash scripts/Apply_Link_Check.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "scripts": {
     "test": "npm run lint-markdown && npm run lint-terminology && npm run test:link-check",
-    "test:link-check": "node --test tests/link-check/*.test.js",
+    "test:link-check": "node --test tests/link-check/apply-link-check.test.js tests/link-check/workflow-diagnostics.test.js",
     "lint-terminology": "textlint ./cheatsheets/",
     "lint-terminology-fix": "textlint --fix ./cheatsheets/",
     "lint-markdown": "markdownlint ./ -c .markdownlint.json --ignore node_modules --ignore cheatsheets_excluded",
     "lint-markdown-fix": "markdownlint --fix ./ -c .markdownlint.json --ignore node_modules --ignore cheatsheets_excluded",
-    "link-check": "bash scripts/Apply_Link_Check.sh"
+    "link-check": "node scripts/Check_Markdown_Links.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/Apply_Link_Check.sh
+++ b/scripts/Apply_Link_Check.sh
@@ -1,62 +1,7 @@
 #!/bin/bash
-# Script in charge of auditing the released cheatsheets MD files
-# in order to detect dead links
+# Compatibility wrapper for auditing the released cheat sheet Markdown files.
 
-set -u
+set -eu
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(cd -- "$script_dir/.." && pwd)"
-checker="${MARKDOWN_LINK_CHECK_BIN:-$repo_root/node_modules/.bin/markdown-link-check}"
-config="${MARKDOWN_LINK_CHECK_CONFIG:-$repo_root/markdown-link-check-config.json}"
-target_dir="${MARKDOWN_LINK_CHECK_TARGET:-$repo_root/cheatsheets}"
-log_file="${MARKDOWN_LINK_CHECK_LOG:-$repo_root/log}"
-
-report_failure() {
-    printf '%s\n' "$1" >&2
-    printf '%s\n' "$1" >> "$log_file"
-}
-
-if ! : > "$log_file"; then
-    printf '[!] Cannot write link-check log: %s\n' "$log_file" >&2
-    exit 1
-fi
-
-if [[ ! -x "$checker" ]]; then
-    report_failure "[!] Link checker executable is unavailable: $checker"
-    exit 127
-fi
-
-if [[ ! -f "$config" ]]; then
-    report_failure "[!] Link checker configuration is unavailable: $config"
-    exit 1
-fi
-
-if [[ ! -d "$target_dir" ]]; then
-    report_failure "[!] Link-check target directory is unavailable: $target_dir"
-    exit 1
-fi
-
-file_list="$(mktemp "${TMPDIR:-/tmp}/markdown-link-check.XXXXXX")" || {
-    report_failure "[!] Cannot create the link-check file list."
-    exit 1
-}
-trap 'rm -f "$file_list"' EXIT
-
-if ! find "$target_dir" -type f -name '*.md' -print0 > "$file_list"; then
-    report_failure "[!] Cannot enumerate Markdown files under: $target_dir"
-    exit 1
-fi
-
-failures=0
-while IFS= read -r -d '' markdown_file; do
-    if ! "$checker" -c "$config" "$markdown_file" >> "$log_file" 2>&1; then
-        failures=$((failures + 1))
-    fi
-done < "$file_list"
-
-if (( failures > 0 )); then
-    printf '[!] Link validator failed for %d Markdown file(s).\n' "$failures" >&2
-    exit 1
-fi
-
-printf '[+] No error found by the link validator.\n'
+exec node "$script_dir/Check_Markdown_Links.js"

--- a/scripts/Apply_Link_Check.sh
+++ b/scripts/Apply_Link_Check.sh
@@ -1,14 +1,62 @@
 #!/bin/bash
 # Script in charge of auditing the released cheatsheets MD files
 # in order to detect dead links
-cd ../cheatsheets
-find . -name \*.md -exec markdown-link-check -c ../.markdownlinkcheck.json {} \; 1>../link-check-result.out 2>&1
-errors=`grep -c "ERROR:" ../link-check-result.out`
-content=`cat ../link-check-result.out`
-if [[ $errors != "0" ]]
-then
-    echo "[!] Error(s) found by the Links validator: $errors CS have dead links !"
-    exit $errors
-else
-    echo "[+] No error found by the Links validator."
+
+set -u
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+checker="${MARKDOWN_LINK_CHECK_BIN:-$repo_root/node_modules/.bin/markdown-link-check}"
+config="${MARKDOWN_LINK_CHECK_CONFIG:-$repo_root/markdown-link-check-config.json}"
+target_dir="${MARKDOWN_LINK_CHECK_TARGET:-$repo_root/cheatsheets}"
+log_file="${MARKDOWN_LINK_CHECK_LOG:-$repo_root/log}"
+
+report_failure() {
+    printf '%s\n' "$1" >&2
+    printf '%s\n' "$1" >> "$log_file"
+}
+
+if ! : > "$log_file"; then
+    printf '[!] Cannot write link-check log: %s\n' "$log_file" >&2
+    exit 1
 fi
+
+if [[ ! -x "$checker" ]]; then
+    report_failure "[!] Link checker executable is unavailable: $checker"
+    exit 127
+fi
+
+if [[ ! -f "$config" ]]; then
+    report_failure "[!] Link checker configuration is unavailable: $config"
+    exit 1
+fi
+
+if [[ ! -d "$target_dir" ]]; then
+    report_failure "[!] Link-check target directory is unavailable: $target_dir"
+    exit 1
+fi
+
+file_list="$(mktemp "${TMPDIR:-/tmp}/markdown-link-check.XXXXXX")" || {
+    report_failure "[!] Cannot create the link-check file list."
+    exit 1
+}
+trap 'rm -f "$file_list"' EXIT
+
+if ! find "$target_dir" -type f -name '*.md' -print0 > "$file_list"; then
+    report_failure "[!] Cannot enumerate Markdown files under: $target_dir"
+    exit 1
+fi
+
+failures=0
+while IFS= read -r -d '' markdown_file; do
+    if ! "$checker" -c "$config" "$markdown_file" >> "$log_file" 2>&1; then
+        failures=$((failures + 1))
+    fi
+done < "$file_list"
+
+if (( failures > 0 )); then
+    printf '[!] Link validator failed for %d Markdown file(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf '[+] No error found by the link validator.\n'

--- a/scripts/Check_Markdown_Links.js
+++ b/scripts/Check_Markdown_Links.js
@@ -1,0 +1,532 @@
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+// One initial observation plus at most two immediate confirmations.
+const NETWORK_ATTEMPT_LIMIT = 3;
+
+function resolvedPath(environmentName, defaultPath) {
+  return path.resolve(process.env[environmentName] || defaultPath);
+}
+
+const paths = {
+  baseline: resolvedPath(
+    "MARKDOWN_LINK_CHECK_BASELINE",
+    path.join(repoRoot, "link-check-known-failures.json"),
+  ),
+  checker: resolvedPath(
+    "MARKDOWN_LINK_CHECK_BIN",
+    path.join(
+      repoRoot,
+      "node_modules",
+      "markdown-link-check",
+      "markdown-link-check",
+    ),
+  ),
+  config: resolvedPath(
+    "MARKDOWN_LINK_CHECK_CONFIG",
+    path.join(repoRoot, "markdown-link-check-config.json"),
+  ),
+  known: resolvedPath(
+    "MARKDOWN_LINK_CHECK_KNOWN",
+    path.join(repoRoot, "link-check-known-debt.md"),
+  ),
+  raw: resolvedPath("MARKDOWN_LINK_CHECK_LOG", path.join(repoRoot, "log")),
+  target: resolvedPath(
+    "MARKDOWN_LINK_CHECK_TARGET",
+    path.join(repoRoot, "cheatsheets"),
+  ),
+  unexpected: resolvedPath(
+    "MARKDOWN_LINK_CHECK_UNEXPECTED",
+    path.join(repoRoot, "link-check-unexpected.md"),
+  ),
+};
+
+function tupleKey(file, url) {
+  return `${file}\0${url}`;
+}
+
+function isNetworkUrl(url) {
+  return /^https?:\/\//i.test(url);
+}
+
+function exactKeys(value, expected) {
+  const actual = Object.keys(value).sort();
+  return (
+    actual.length === expected.length &&
+    expected.every((key, index) => key === actual[index])
+  );
+}
+
+function validateBaseline(value) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !exactKeys(value, ["failures", "generatedFrom", "schemaVersion"])
+  ) {
+    throw new Error("baseline must contain only schemaVersion, generatedFrom, and failures");
+  }
+  if (value.schemaVersion !== 1) {
+    throw new Error("baseline schemaVersion must be 1");
+  }
+
+  const provenance = value.generatedFrom;
+  if (
+    !provenance ||
+    typeof provenance !== "object" ||
+    Array.isArray(provenance) ||
+    !exactKeys(provenance, [
+      "baseCommit",
+      "workflowJobId",
+      "workflowRunId",
+      "workflowUrl",
+    ]) ||
+    !/^[0-9a-f]{40}$/.test(provenance.baseCommit) ||
+    !Number.isSafeInteger(provenance.workflowRunId) ||
+    provenance.workflowRunId <= 0 ||
+    !Number.isSafeInteger(provenance.workflowJobId) ||
+    provenance.workflowJobId <= 0 ||
+    provenance.workflowUrl !==
+      `https://github.com/OWASP/CheatSheetSeries/actions/runs/${provenance.workflowRunId}/job/${provenance.workflowJobId}`
+  ) {
+    throw new Error("baseline generatedFrom provenance is malformed");
+  }
+  if (!Array.isArray(value.failures)) {
+    throw new Error("baseline failures must be an array");
+  }
+
+  const byKey = new Map();
+  let previousKey = null;
+  for (const [index, failure] of value.failures.entries()) {
+    if (
+      !failure ||
+      typeof failure !== "object" ||
+      Array.isArray(failure) ||
+      !exactKeys(failure, ["file", "observedStatus", "url"])
+    ) {
+      throw new Error(`baseline failure ${index} has an invalid shape`);
+    }
+    if (
+      typeof failure.file !== "string" ||
+      !failure.file.startsWith("cheatsheets/") ||
+      !failure.file.endsWith(".md") ||
+      path.posix.normalize(failure.file) !== failure.file ||
+      failure.file.includes("\\") ||
+      typeof failure.url !== "string" ||
+      failure.url.length === 0 ||
+      /[\r\n]/.test(failure.url) ||
+      !Number.isInteger(failure.observedStatus) ||
+      failure.observedStatus < 0 ||
+      failure.observedStatus > 599
+    ) {
+      throw new Error(`baseline failure ${index} is malformed`);
+    }
+
+    const key = tupleKey(failure.file, failure.url);
+    if (byKey.has(key)) {
+      throw new Error(`baseline contains a duplicate tuple: ${failure.file} ${failure.url}`);
+    }
+    if (previousKey !== null && key < previousKey) {
+      throw new Error("baseline failures must be sorted by file and URL");
+    }
+    previousKey = key;
+    byKey.set(key, failure);
+  }
+
+  return { byKey, provenance };
+}
+
+function readJson(file, description) {
+  let contents;
+  try {
+    contents = fs.readFileSync(file, "utf8");
+  } catch (error) {
+    throw new Error(`${description} is unavailable: ${file} (${error.message})`);
+  }
+  try {
+    const parsed = JSON.parse(contents);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("root value must be an object");
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`${description} is malformed: ${file} (${error.message})`);
+  }
+}
+
+function enumerateMarkdownFiles(directory) {
+  const files = [];
+  const visit = (current) => {
+    const entries = fs
+      .readdirSync(current, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        files.push(entryPath);
+      }
+    }
+  };
+  visit(directory);
+  return files;
+}
+
+function logicalFileName(markdownFile) {
+  const relative = path.relative(paths.target, markdownFile);
+  if (
+    relative.length === 0 ||
+    relative.startsWith("..") ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(`enumerated file escaped the target directory: ${markdownFile}`);
+  }
+  return path.posix.join("cheatsheets", relative.split(path.sep).join("/"));
+}
+
+function parseCanonicalFailures(output, markdownFile) {
+  const lines = output.split(/\r?\n/);
+  const fileHeaders = lines
+    .filter((line) => line.startsWith("FILE: "))
+    .map((line) => path.resolve(line.slice("FILE: ".length).trim()));
+  if (
+    fileHeaders.length !== 1 ||
+    fileHeaders[0] !== path.resolve(markdownFile)
+  ) {
+    throw new Error("nonzero checker result lacks the expected FILE header");
+  }
+
+  const errorLines = lines.filter((line) =>
+    /^\s*ERROR:\s+\d+\s+dead links? found!\s*$/.test(line),
+  );
+  if (errorLines.length !== 1) {
+    throw new Error("nonzero checker result lacks a canonical ERROR count");
+  }
+  const expectedCount = Number(errorLines[0].match(/ERROR:\s+(\d+)\s+/)[1]);
+  const failures = [];
+  for (const line of lines) {
+    const match = line.match(
+      /^\s*\[✖\]\s+(.+?)\s+→\s+Status:\s+(\d+)\s*$/,
+    );
+    if (match) {
+      failures.push({ url: match[1], status: Number(match[2]) });
+    }
+  }
+  if (failures.length !== expectedCount) {
+    throw new Error(
+      `canonical ERROR count is ${expectedCount}, but ${failures.length} detailed failures were present`,
+    );
+  }
+  return failures;
+}
+
+function validateCanonicalSuccess(output, markdownFile) {
+  const lines = output.split(/\r?\n/);
+  const fileHeaders = lines
+    .filter((line) => line.startsWith("FILE: "))
+    .map((line) => path.resolve(line.slice("FILE: ".length).trim()));
+  if (
+    fileHeaders.length !== 1 ||
+    fileHeaders[0] !== path.resolve(markdownFile)
+  ) {
+    throw new Error("successful checker result lacks the expected FILE header");
+  }
+  const checkedLines = lines.filter((line) =>
+    /^\s*\d+\s+links? checked\.\s*$/.test(line),
+  );
+  if (checkedLines.length !== 1) {
+    throw new Error("successful checker result lacks a canonical checked-link count");
+  }
+  if (/^\s*ERROR:/m.test(output) || /\[✖\].*Status:/m.test(output)) {
+    throw new Error("checker reported canonical failures with exit status 0");
+  }
+}
+
+function markdownRows(title, rows, marker) {
+  if (rows.length === 0) {
+    return "";
+  }
+  const grouped = new Map();
+  for (const row of rows) {
+    if (!grouped.has(row.file)) {
+      grouped.set(row.file, []);
+    }
+    grouped.get(row.file).push(row);
+  }
+
+  const lines = [`## ${title}`, ""];
+  for (const [file, fileRows] of grouped) {
+    lines.push(`    FILE: ${file}`);
+    for (const row of fileRows) {
+      const provenance =
+        row.observedStatus === undefined
+          ? ""
+          : `; baseline observed ${row.observedStatus}`;
+      const attempts = row.attempts ? `; attempts: ${row.attempts}` : "";
+      lines.push(
+        `      [${marker}] ${row.url} → Status: ${row.status}${provenance}${attempts}`,
+      );
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function writeOutputs({ known, recovered, transient, unexpected }) {
+  const knownText = [
+    markdownRows("Known Markdown link failures", known, "known"),
+    markdownRows("Recovered or stale baseline entries", recovered, "recovered"),
+    markdownRows(
+      "Transient unbaselined network failures recovered on confirmation",
+      transient,
+      "transient",
+    ),
+  ].join("");
+  const unexpectedText = markdownRows(
+    "Unexpected Markdown link failures",
+    unexpected,
+    "✖",
+  );
+
+  fs.writeFileSync(paths.known, knownText);
+  fs.writeFileSync(paths.unexpected, unexpectedText);
+}
+
+function runCheckerAttempt(markdownFile, file, attempt) {
+  fs.appendFileSync(
+    paths.raw,
+    `\n===== FILE: ${file}; attempt ${attempt}/${NETWORK_ATTEMPT_LIMIT} =====\n`,
+  );
+  const result = spawnSync(
+    process.execPath,
+    [paths.checker, "-c", paths.config, markdownFile],
+    { encoding: "utf8" },
+  );
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  fs.appendFileSync(paths.raw, output.endsWith("\n") ? output : `${output}\n`);
+
+  let message;
+  if (result.error || result.signal || !Number.isInteger(result.status)) {
+    message = `${file}: checker could not complete (${result.error?.message || result.signal || "unknown process result"})`;
+  } else if (result.status === 0) {
+    try {
+      validateCanonicalSuccess(output, markdownFile);
+      return { failures: [] };
+    } catch (error) {
+      message = `${file}: ${error.message}`;
+    }
+  } else if (result.status !== 1) {
+    message = `${file}: checker exited with unexpected status ${result.status}`;
+  } else {
+    try {
+      return { failures: parseCanonicalFailures(output, markdownFile) };
+    } catch (error) {
+      message = `${file}: ${error.message} (exit ${result.status})`;
+    }
+  }
+
+  fs.appendFileSync(paths.raw, `[!] ${message}\n`);
+  return { internal: message };
+}
+
+function attemptHistory(canonicalAttempts, file, baseline) {
+  const histories = new Map();
+  for (const [attemptIndex, failures] of canonicalAttempts.entries()) {
+    const current = new Map();
+    for (const failure of failures) {
+      const key = tupleKey(file, failure.url);
+      if (!baseline.byKey.has(key)) {
+        current.set(key, failure);
+      }
+    }
+    for (const history of histories.values()) {
+      const failure = current.get(history.key);
+      history.values.push(failure ? failure.status : "recovered");
+    }
+    for (const [key, failure] of current) {
+      if (!histories.has(key)) {
+        histories.set(key, {
+          file,
+          key,
+          url: failure.url,
+          values: [
+            ...Array(attemptIndex).fill("not failing"),
+            failure.status,
+          ],
+        });
+      }
+    }
+  }
+  return histories;
+}
+
+function formatAttemptHistory(values) {
+  return values.map((value, index) => `${index + 1}=${value}`).join(", ");
+}
+
+function main() {
+  const distinctOutputs = new Set([paths.raw, paths.known, paths.unexpected]);
+  if (distinctOutputs.size !== 3) {
+    console.error("[!] Raw, known-debt, and unexpected output paths must be distinct.");
+    return 1;
+  }
+  const protectedInputs = new Set([paths.baseline, paths.checker, paths.config]);
+  if ([...distinctOutputs].some((output) => protectedInputs.has(output))) {
+    console.error("[!] Diagnostic output paths must not overwrite checker inputs.");
+    return 1;
+  }
+  try {
+    for (const output of distinctOutputs) {
+      fs.writeFileSync(output, "");
+    }
+  } catch (error) {
+    console.error(`[!] Cannot initialize link-check diagnostics: ${error.message}`);
+    return 1;
+  }
+
+  const internal = [];
+  const known = [];
+  const unexpected = [];
+  let baseline;
+
+  try {
+    fs.accessSync(paths.checker, fs.constants.R_OK);
+  } catch (error) {
+    internal.push(`Link checker executable is unavailable: ${paths.checker}`);
+  }
+  try {
+    readJson(paths.config, "Link checker configuration");
+  } catch (error) {
+    internal.push(error.message);
+  }
+  try {
+    baseline = validateBaseline(readJson(paths.baseline, "Known-failure baseline"));
+  } catch (error) {
+    internal.push(error.message);
+  }
+  try {
+    if (!fs.statSync(paths.target).isDirectory()) {
+      throw new Error("not a directory");
+    }
+  } catch (error) {
+    internal.push(`Link-check target directory is unavailable: ${paths.target}`);
+  }
+
+  if (internal.length > 0) {
+    fs.appendFileSync(
+      paths.raw,
+      `${internal.map((message) => `[!] ${message}`).join("\n")}\n`,
+    );
+    writeOutputs({ known, recovered: [], transient: [], unexpected });
+    console.error(`[!] Link validator could not start: ${internal.join("; ")}`);
+    return 1;
+  }
+
+  let markdownFiles;
+  try {
+    markdownFiles = enumerateMarkdownFiles(paths.target);
+  } catch (error) {
+    internal.push(`Cannot enumerate Markdown files under ${paths.target}: ${error.message}`);
+    fs.appendFileSync(paths.raw, `[!] ${internal[0]}\n`);
+    writeOutputs({ known, recovered: [], transient: [], unexpected });
+    console.error(`[!] ${internal[0]}`);
+    return 1;
+  }
+
+  const assessedFailuresByFile = new Map();
+  const transient = [];
+  for (const markdownFile of markdownFiles) {
+    const file = logicalFileName(markdownFile);
+    const canonicalAttempts = [];
+    let assessment = null;
+    for (let attempt = 1; attempt <= NETWORK_ATTEMPT_LIMIT; attempt += 1) {
+      const result = runCheckerAttempt(markdownFile, file, attempt);
+      if (result.internal) {
+        internal.push(result.internal);
+        assessment = null;
+        break;
+      }
+      canonicalAttempts.push(result.failures);
+      assessment = result.failures;
+      const unbaselinedNetworkFailures = result.failures.filter(
+        (failure) =>
+          isNetworkUrl(failure.url) &&
+          !baseline.byKey.has(tupleKey(file, failure.url)),
+      );
+      if (
+        unbaselinedNetworkFailures.length === 0 ||
+        attempt === NETWORK_ATTEMPT_LIMIT
+      ) {
+        break;
+      }
+    }
+    if (assessment === null) {
+      continue;
+    }
+
+    const finalFailures = new Map();
+    for (const failure of assessment) {
+      const key = tupleKey(file, failure.url);
+      finalFailures.set(key, failure);
+      const baselineFailure = baseline.byKey.get(key);
+      if (baselineFailure) {
+        known.push({
+          file,
+          url: failure.url,
+          status: failure.status,
+          observedStatus: baselineFailure.observedStatus,
+        });
+      }
+    }
+    assessedFailuresByFile.set(file, finalFailures);
+
+    const histories = attemptHistory(canonicalAttempts, file, baseline);
+    for (const history of histories.values()) {
+      const finalFailure = finalFailures.get(history.key);
+      const row = {
+        file,
+        url: history.url,
+        status: finalFailure
+          ? finalFailure.status
+          : history.values.findLast((value) => Number.isInteger(value)),
+        attempts: formatAttemptHistory(history.values),
+      };
+      if (isNetworkUrl(history.url) && !finalFailure) {
+        transient.push({ ...row, status: "recovered" });
+      } else {
+        unexpected.push(row);
+      }
+    }
+  }
+
+  const recovered = [];
+  for (const [key, failure] of baseline.byKey) {
+    const assessedFailures = assessedFailuresByFile.get(failure.file);
+    if (assessedFailures && !assessedFailures.has(key)) {
+      recovered.push({
+        file: failure.file,
+        url: failure.url,
+        status: "not failing",
+        observedStatus: failure.observedStatus,
+      });
+    }
+  }
+
+  writeOutputs({ known, recovered, transient, unexpected });
+  if (unexpected.length > 0 || internal.length > 0) {
+    console.error(
+      `[!] Link validator found ${unexpected.length} unexpected link failure(s) and ${internal.length} internal failure(s).`,
+    );
+    return 1;
+  }
+
+  console.log(
+    `[+] No unexpected link failures; ${known.length} known failure(s) remain, ${recovered.length} baseline row(s) are recovered or stale, and ${transient.length} transient network failure(s) recovered on confirmation.`,
+  );
+  return 0;
+}
+
+process.exitCode = main();

--- a/scripts/Check_Markdown_Links.js
+++ b/scripts/Check_Markdown_Links.js
@@ -64,78 +64,118 @@ function validateBaseline(value) {
     !value ||
     typeof value !== "object" ||
     Array.isArray(value) ||
-    !exactKeys(value, ["failures", "generatedFrom", "schemaVersion"])
+    !exactKeys(value, ["batches", "schemaVersion"])
   ) {
-    throw new Error("baseline must contain only schemaVersion, generatedFrom, and failures");
+    throw new Error("baseline must contain only schemaVersion and batches");
   }
-  if (value.schemaVersion !== 1) {
-    throw new Error("baseline schemaVersion must be 1");
+  if (value.schemaVersion !== 2) {
+    throw new Error("baseline schemaVersion must be 2");
   }
-
-  const provenance = value.generatedFrom;
-  if (
-    !provenance ||
-    typeof provenance !== "object" ||
-    Array.isArray(provenance) ||
-    !exactKeys(provenance, [
-      "baseCommit",
-      "workflowJobId",
-      "workflowRunId",
-      "workflowUrl",
-    ]) ||
-    !/^[0-9a-f]{40}$/.test(provenance.baseCommit) ||
-    !Number.isSafeInteger(provenance.workflowRunId) ||
-    provenance.workflowRunId <= 0 ||
-    !Number.isSafeInteger(provenance.workflowJobId) ||
-    provenance.workflowJobId <= 0 ||
-    provenance.workflowUrl !==
-      `https://github.com/OWASP/CheatSheetSeries/actions/runs/${provenance.workflowRunId}/job/${provenance.workflowJobId}`
-  ) {
-    throw new Error("baseline generatedFrom provenance is malformed");
-  }
-  if (!Array.isArray(value.failures)) {
-    throw new Error("baseline failures must be an array");
+  if (!Array.isArray(value.batches) || value.batches.length === 0) {
+    throw new Error("baseline batches must be a nonempty array");
   }
 
   const byKey = new Map();
-  let previousKey = null;
-  for (const [index, failure] of value.failures.entries()) {
+  for (const [batchIndex, batch] of value.batches.entries()) {
     if (
-      !failure ||
-      typeof failure !== "object" ||
-      Array.isArray(failure) ||
-      !exactKeys(failure, ["file", "observedStatus", "url"])
+      !batch ||
+      typeof batch !== "object" ||
+      Array.isArray(batch) ||
+      !exactKeys(batch, ["failures", "generatedFrom"])
     ) {
-      throw new Error(`baseline failure ${index} has an invalid shape`);
-    }
-    if (
-      typeof failure.file !== "string" ||
-      !failure.file.startsWith("cheatsheets/") ||
-      !failure.file.endsWith(".md") ||
-      path.posix.normalize(failure.file) !== failure.file ||
-      failure.file.includes("\\") ||
-      typeof failure.url !== "string" ||
-      failure.url.length === 0 ||
-      /[\r\n]/.test(failure.url) ||
-      !Number.isInteger(failure.observedStatus) ||
-      failure.observedStatus < 0 ||
-      failure.observedStatus > 599
-    ) {
-      throw new Error(`baseline failure ${index} is malformed`);
+      throw new Error(`baseline batch ${batchIndex} has an invalid shape`);
     }
 
-    const key = tupleKey(failure.file, failure.url);
-    if (byKey.has(key)) {
-      throw new Error(`baseline contains a duplicate tuple: ${failure.file} ${failure.url}`);
+    const provenance = batch.generatedFrom;
+    if (
+      !provenance ||
+      typeof provenance !== "object" ||
+      Array.isArray(provenance) ||
+      !exactKeys(provenance, [
+        "attemptCount",
+        "checkedHead",
+        "contentBaseCommit",
+        "workflowJobId",
+        "workflowRunId",
+        "workflowUrl",
+      ]) ||
+      !Number.isSafeInteger(provenance.attemptCount) ||
+      provenance.attemptCount <= 0 ||
+      !/^[0-9a-f]{40}$/.test(provenance.checkedHead) ||
+      !/^[0-9a-f]{40}$/.test(provenance.contentBaseCommit) ||
+      !Number.isSafeInteger(provenance.workflowRunId) ||
+      provenance.workflowRunId <= 0 ||
+      !Number.isSafeInteger(provenance.workflowJobId) ||
+      provenance.workflowJobId <= 0 ||
+      provenance.workflowUrl !==
+        `https://github.com/OWASP/CheatSheetSeries/actions/runs/${provenance.workflowRunId}/job/${provenance.workflowJobId}`
+    ) {
+      throw new Error(`baseline batch ${batchIndex} provenance is malformed`);
     }
-    if (previousKey !== null && key < previousKey) {
-      throw new Error("baseline failures must be sorted by file and URL");
+    if (!Array.isArray(batch.failures)) {
+      throw new Error(`baseline batch ${batchIndex} failures must be an array`);
     }
-    previousKey = key;
-    byKey.set(key, failure);
+
+    let previousKey = null;
+    for (const [failureIndex, failure] of batch.failures.entries()) {
+      const expectedKeys =
+        provenance.attemptCount === 1
+          ? ["file", "observedStatus", "url"]
+          : ["file", "observedStatuses", "url"];
+      if (
+        !failure ||
+        typeof failure !== "object" ||
+        Array.isArray(failure) ||
+        !exactKeys(failure, expectedKeys)
+      ) {
+        throw new Error(
+          `baseline batch ${batchIndex} failure ${failureIndex} has an invalid shape`,
+        );
+      }
+      const observedStatuses =
+        provenance.attemptCount === 1
+          ? [failure.observedStatus]
+          : failure.observedStatuses;
+      if (
+        typeof failure.file !== "string" ||
+        !failure.file.startsWith("cheatsheets/") ||
+        !failure.file.endsWith(".md") ||
+        path.posix.normalize(failure.file) !== failure.file ||
+        failure.file.includes("\\") ||
+        typeof failure.url !== "string" ||
+        failure.url.length === 0 ||
+        /[\r\n]/.test(failure.url) ||
+        !Array.isArray(observedStatuses) ||
+        observedStatuses.length !== provenance.attemptCount ||
+        observedStatuses.some(
+          (status) =>
+            !Number.isInteger(status) || status < 0 || status > 599,
+        )
+      ) {
+        throw new Error(`baseline batch ${batchIndex} failure ${failureIndex} is malformed`);
+      }
+
+      const key = tupleKey(failure.file, failure.url);
+      if (byKey.has(key)) {
+        throw new Error(
+          `baseline contains a duplicate tuple: ${failure.file} ${failure.url}`,
+        );
+      }
+      if (previousKey !== null && key < previousKey) {
+        throw new Error(
+          `baseline batch ${batchIndex} failures must be sorted by file and URL`,
+        );
+      }
+      previousKey = key;
+      byKey.set(key, {
+        file: failure.file,
+        url: failure.url,
+        observedStatus: observedStatuses.at(-1),
+      });
+    }
   }
 
-  return { byKey, provenance };
+  return { byKey };
 }
 
 function readJson(file, description) {
@@ -280,7 +320,7 @@ function writeOutputs({ known, recovered, transient, unexpected }) {
     markdownRows("Known Markdown link failures", known, "known"),
     markdownRows("Recovered or stale baseline entries", recovered, "recovered"),
     markdownRows(
-      "Transient unbaselined network failures recovered on confirmation",
+      "Transient unbaselined network failures",
       transient,
       "transient",
     ),
@@ -494,8 +534,12 @@ function main() {
           : history.values.findLast((value) => Number.isInteger(value)),
         attempts: formatAttemptHistory(history.values),
       };
-      if (isNetworkUrl(history.url) && !finalFailure) {
-        transient.push({ ...row, status: "recovered" });
+      const persistentNetworkFailure =
+        isNetworkUrl(history.url) &&
+        history.values.length === NETWORK_ATTEMPT_LIMIT &&
+        history.values.every(Number.isInteger);
+      if (isNetworkUrl(history.url) && !persistentNetworkFailure) {
+        transient.push({ ...row, status: "not persistent" });
       } else {
         unexpected.push(row);
       }
@@ -524,7 +568,7 @@ function main() {
   }
 
   console.log(
-    `[+] No unexpected link failures; ${known.length} known failure(s) remain, ${recovered.length} baseline row(s) are recovered or stale, and ${transient.length} transient network failure(s) recovered on confirmation.`,
+    `[+] No unexpected link failures; ${known.length} known failure(s) remain, ${recovered.length} baseline row(s) are recovered or stale, and ${transient.length} network failure(s) were not persistent across every observation.`,
   );
   return 0;
 }

--- a/scripts/Prepare_Link_Check_Diagnostics.js
+++ b/scripts/Prepare_Link_Check_Diagnostics.js
@@ -1,0 +1,84 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+function resolvedPath(environmentName, defaultPath) {
+  return path.resolve(process.env[environmentName] || defaultPath);
+}
+
+function readIfPresent(file) {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+function countRows(contents, marker) {
+  const pattern = new RegExp(`^\\s+\\[${marker}\\]`);
+  return contents
+    .split(/\r?\n/)
+    .filter((line) => pattern.test(line)).length;
+}
+
+function main() {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!summaryPath || !outputPath) {
+    throw new Error("GITHUB_STEP_SUMMARY and GITHUB_OUTPUT are required");
+  }
+
+  const knownPath = resolvedPath(
+    "MARKDOWN_LINK_CHECK_KNOWN",
+    path.join(repoRoot, "link-check-known-debt.md"),
+  );
+  const unexpectedPath = resolvedPath(
+    "MARKDOWN_LINK_CHECK_UNEXPECTED",
+    path.join(repoRoot, "link-check-unexpected.md"),
+  );
+  const known = readIfPresent(knownPath);
+  const unexpected = readIfPresent(unexpectedPath);
+  const outcome = process.env.LINK_CHECK_OUTCOME;
+  const failed = outcome !== "success";
+
+  let summary;
+  if (failed) {
+    summary = unexpected.trim()
+      ? `# Markdown link check failed\n\n${unexpected}`
+      : [
+          "# Markdown link check failed",
+          "",
+          "The checker failed before actionable diagnostics could be recovered.",
+          "Inspect the raw **Run link check** step output.",
+          "",
+        ].join("\n");
+  } else {
+    if (unexpected.trim()) {
+      throw new Error("unexpected diagnostics exist despite a successful link check");
+    }
+    const knownCount = countRows(known, "known");
+    const recoveredCount = countRows(known, "recovered");
+    const transientCount = countRows(known, "transient");
+    summary = [
+      "# Markdown link check passed",
+      "",
+      `No unexpected failures were found. ${knownCount} exact known-failure tuple(s) remain; ${recoveredCount} baseline row(s) are recovered or stale; ${transientCount} unbaselined network failure(s) recovered on confirmation.`,
+      "",
+    ].join("\n");
+  }
+
+  fs.appendFileSync(summaryPath, summary);
+  const shouldComment =
+    failed &&
+    unexpected.trim().length > 0 &&
+    process.env.LINK_CHECK_EVENT_NAME === "pull_request" &&
+    process.env.LINK_CHECK_HEAD_REPOSITORY ===
+      process.env.LINK_CHECK_REPOSITORY;
+  fs.appendFileSync(outputPath, `should_comment=${shouldComment}\n`);
+}
+
+main();

--- a/scripts/Prepare_Link_Check_Diagnostics.js
+++ b/scripts/Prepare_Link_Check_Diagnostics.js
@@ -66,7 +66,7 @@ function main() {
     summary = [
       "# Markdown link check passed",
       "",
-      `No unexpected failures were found. ${knownCount} exact known-failure tuple(s) remain; ${recoveredCount} baseline row(s) are recovered or stale; ${transientCount} unbaselined network failure(s) recovered on confirmation.`,
+      `No unexpected failures were found. ${knownCount} exact known-failure tuple(s) remain; ${recoveredCount} baseline row(s) are recovered or stale; ${transientCount} unbaselined network failure(s) were not persistent across every observation.`,
       "",
     ].join("\n");
   }

--- a/tests/link-check/apply-link-check.test.js
+++ b/tests/link-check/apply-link-check.test.js
@@ -9,66 +9,154 @@ const repoRoot = path.resolve(__dirname, "../..");
 const realChecker = path.join(
   repoRoot,
   "node_modules",
-  ".bin",
+  "markdown-link-check",
   "markdown-link-check",
 );
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const provenance = {
+  baseCommit: "e5420b90672011aa84d3e5de3c3e38f704a5033d",
+  workflowRunId: 34185231643,
+  workflowJobId: 101932122278,
+  workflowUrl:
+    "https://github.com/OWASP/CheatSheetSeries/actions/runs/34185231643/job/101932122278",
+};
 
-function runLinkCheck(t, { checker = realChecker, files }) {
+function baseline(failures = []) {
+  return { schemaVersion: 1, generatedFrom: provenance, failures };
+}
+
+function writeFiles(root, files) {
+  for (const [name, contents] of Object.entries(files)) {
+    const file = path.join(root, name);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents);
+  }
+}
+
+function createChecker(t, source) {
+  const checkerRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "cheatsheet-fake-checker-"),
+  );
+  const checker = path.join(checkerRoot, "checker.js");
+  t.after(() => fs.rmSync(checkerRoot, { recursive: true, force: true }));
+  fs.writeFileSync(checker, source);
+  return checker;
+}
+
+function canonicalChecker(t) {
+  return createChecker(
+    t,
+    [
+      'const fs = require("node:fs");',
+      'const path = require("node:path");',
+      "const file = process.argv.at(-1);",
+      "let attemptIndex = 0;",
+      "if (process.env.FAKE_CHECKER_INVOCATIONS) {",
+      "  const previous = fs.existsSync(process.env.FAKE_CHECKER_INVOCATIONS)",
+      '    ? fs.readFileSync(process.env.FAKE_CHECKER_INVOCATIONS, "utf8").split(/\\r?\\n/)',
+      "    : [];",
+      "  attemptIndex = previous.filter((entry) => entry === file).length;",
+      '  fs.appendFileSync(process.env.FAKE_CHECKER_INVOCATIONS, `${file}\\n`);',
+      "}",
+      'const byFile = JSON.parse(process.env.FAKE_CHECKER_FAILURES || "{}");',
+      'const attemptsByFile = JSON.parse(process.env.FAKE_CHECKER_ATTEMPTS || "{}");',
+      "const attempts = attemptsByFile[path.basename(file)];",
+      "const attempt = Array.isArray(attempts) && attempts.length > 0",
+      "  ? attempts[Math.min(attemptIndex, attempts.length - 1)]",
+      "  : null;",
+      'if (attempt && attempt.internal === "crash") {',
+      '  process.stderr.write("planned checker crash\\n");',
+      "  process.exit(42);",
+      "}",
+      "const failures = Array.isArray(attempt) ? attempt : (byFile[path.basename(file)] || []);",
+      'console.log(`FILE: ${file}`);',
+      "for (const failure of failures) {",
+      '  console.log(`  [✖] ${failure.url}`);',
+      "}",
+      'console.log(`\\n  ${failures.length} links checked.\\n`);',
+      "if (failures.length > 0) {",
+      '  console.log(`  ERROR: ${failures.length} dead link${failures.length === 1 ? "" : "s"} found!`);',
+      "  for (const failure of failures) {",
+      '    console.log(`  [✖] ${failure.url} → Status: ${failure.status}`);',
+      "  }",
+      "  process.exitCode = 1;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+}
+
+function runLinkCheck(
+  t,
+  {
+    baselineContents = JSON.stringify(baseline()),
+    checker = realChecker,
+    configContents = "{}\n",
+    env = {},
+    files = { "valid.md": "# Valid\n" },
+    missingBaseline = false,
+    missingConfig = false,
+  } = {},
+) {
   const fixtureRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), "cheatsheet-link-check-"),
   );
   const targetDir = path.join(fixtureRoot, "cheatsheets");
   const config = path.join(fixtureRoot, "markdown-link-check-config.json");
-  const log = path.join(fixtureRoot, "log");
+  const baselinePath = path.join(fixtureRoot, "link-check-known-failures.json");
+  const raw = path.join(fixtureRoot, "raw.log");
+  const known = path.join(fixtureRoot, "known.md");
+  const unexpected = path.join(fixtureRoot, "unexpected.md");
 
   t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
   fs.mkdirSync(targetDir);
-  fs.writeFileSync(config, "{}\n");
-  for (const [name, content] of Object.entries(files)) {
-    fs.writeFileSync(path.join(targetDir, name), content);
+  writeFiles(targetDir, files);
+  if (!missingConfig) {
+    fs.writeFileSync(config, configContents);
+  }
+  if (!missingBaseline) {
+    fs.writeFileSync(baselinePath, `${baselineContents}\n`);
   }
 
-  const result = spawnSync("npm", ["run", "link-check", "--silent"], {
+  const result = spawnSync(npmCommand, ["run", "link-check", "--silent"], {
     cwd: repoRoot,
     encoding: "utf8",
     env: {
       ...process.env,
+      ...env,
+      MARKDOWN_LINK_CHECK_BASELINE: baselinePath,
       MARKDOWN_LINK_CHECK_BIN: checker,
       MARKDOWN_LINK_CHECK_CONFIG: config,
-      MARKDOWN_LINK_CHECK_LOG: log,
+      MARKDOWN_LINK_CHECK_KNOWN: known,
+      MARKDOWN_LINK_CHECK_LOG: raw,
       MARKDOWN_LINK_CHECK_TARGET: targetDir,
+      MARKDOWN_LINK_CHECK_UNEXPECTED: unexpected,
     },
   });
 
+  const read = (file) => (fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "");
   return {
     ...result,
-    log: fs.existsSync(log) ? fs.readFileSync(log, "utf8") : "",
+    baselinePath,
+    known: read(known),
+    raw: read(raw),
     targetDir,
+    unexpected: read(unexpected),
   };
 }
 
-function createFailingChecker(t) {
-  const fixtureRoot = fs.mkdtempSync(
-    path.join(os.tmpdir(), "cheatsheet-failing-checker-"),
+test("the committed baseline has exact reviewed provenance and tuples", () => {
+  const value = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "link-check-known-failures.json"), "utf8"),
   );
-  const checker = path.join(fixtureRoot, "markdown-link-check");
-  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
-  fs.writeFileSync(
-    checker,
-    [
-      "#!/bin/bash",
-      'printf \'FILE: %s\\n\' "$3"',
-      'if [[ "$3" == *failing.md ]]; then',
-      '  printf \'checker crashed for %s\\n\' "$3" >&2',
-      "  exit 42",
-      "fi",
-      'printf \'[✓] local fixture\\n\'',
-      "",
-    ].join("\n"),
-    { mode: 0o755 },
+  assert.deepEqual(value.generatedFrom, provenance);
+  assert.equal(value.failures.length, 168);
+  assert.equal(new Set(value.failures.map(({ file }) => file)).size, 62);
+  assert.equal(
+    new Set(value.failures.map(({ file, url }) => `${file}\0${url}`)).size,
+    168,
   );
-  return checker;
-}
+});
 
 test("a valid local-link fixture exits zero", (t) => {
   const result = runLinkCheck(t, {
@@ -79,48 +167,426 @@ test("a valid local-link fixture exits zero", (t) => {
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /No error found by the link validator/);
-  assert.match(result.log, /FILE: .*valid\.md/);
+  assert.match(result.stdout, /No unexpected link failures/);
+  assert.match(result.raw, /FILE: .*valid\.md/);
+  assert.equal(result.unexpected, "");
 });
 
-test("a broken local link exits nonzero and leaves workflow diagnostics", (t) => {
+test("a broken local link exits nonzero with only unexpected diagnostics", (t) => {
   const result = runLinkCheck(t, {
-    files: {
-      "broken.md": "# Broken\n\n[Missing target](missing.md)\n",
-    },
+    files: { "broken.md": "# Broken\n\n[Missing target](missing.md)\n" },
   });
 
   assert.notEqual(result.status, 0);
   assert.doesNotMatch(result.stdout, /All good/);
-  assert.match(result.log, /FILE: .*broken\.md/);
-  assert.match(result.log, /ERROR:/);
-  assert.match(result.log, /\[✖\] missing\.md/);
+  assert.match(result.raw, /ERROR:/);
+  assert.equal(result.known, "");
+  assert.match(result.unexpected, /FILE: cheatsheets\/broken\.md/);
+  assert.match(result.unexpected, /\[✖\] missing\.md → Status: 400/);
 });
 
-test("a missing checker exits nonzero and cannot report success", (t) => {
-  const result = runLinkCheck(t, {
-    checker: path.join(os.tmpdir(), "missing-markdown-link-check"),
-    files: { "valid.md": "# Valid\n" },
-  });
-
-  assert.notEqual(result.status, 0);
-  assert.doesNotMatch(result.stdout, /All good/);
-  assert.match(result.stderr, /Link checker executable is unavailable/);
-  assert.match(result.log, /Link checker executable is unavailable/);
-});
-
-test("any failing per-file invocation makes the command fail", (t) => {
-  const checker = createFailingChecker(t);
+test("an unbaselined non-network failure is not retried", (t) => {
+  const checker = canonicalChecker(t);
+  const invocationLog = path.join(
+    os.tmpdir(),
+    `link-check-local-${process.pid}-${Date.now()}`,
+  );
+  t.after(() => fs.rmSync(invocationLog, { force: true }));
   const result = runLinkCheck(t, {
     checker,
-    files: {
-      "failing.md": "# Failing\n",
-      "valid.md": "# Valid\n",
+    env: {
+      FAKE_CHECKER_FAILURES: JSON.stringify({
+        "local.md": [{ url: "missing.md", status: 400 }],
+      }),
+      FAKE_CHECKER_INVOCATIONS: invocationLog,
     },
+    files: { "local.md": "# Local\n" },
   });
 
   assert.notEqual(result.status, 0);
-  assert.doesNotMatch(result.stdout, /All good/);
-  assert.match(result.log, /checker crashed for .*failing\.md/);
-  assert.match(result.log, /FILE: .*valid\.md/);
+  assert.equal(fs.readFileSync(invocationLog, "utf8").trim().split(/\r?\n/).length, 1);
+  assert.match(result.raw, /attempt 1\/3/);
+  assert.doesNotMatch(result.raw, /attempt 2\/3/);
+});
+
+test("an exact known tuple is nonblocking and separately reported", (t) => {
+  const result = runLinkCheck(t, {
+    baselineContents: JSON.stringify(
+      baseline([
+        {
+          file: "cheatsheets/known.md",
+          url: "missing.md",
+          observedStatus: 404,
+        },
+      ]),
+    ),
+    files: { "known.md": "# Known\n\n[Missing target](missing.md)\n" },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.known, /\[known\] missing\.md → Status: 400; baseline observed 404/);
+  assert.equal(result.unexpected, "");
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(result.baselinePath, "utf8")).failures,
+    [
+      {
+        file: "cheatsheets/known.md",
+        url: "missing.md",
+        observedStatus: 404,
+      },
+    ],
+  );
+});
+
+test("the same URL in a different file remains fatal", (t) => {
+  const result = runLinkCheck(t, {
+    baselineContents: JSON.stringify(
+      baseline([
+        {
+          file: "cheatsheets/known.md",
+          url: "missing.md",
+          observedStatus: 400,
+        },
+      ]),
+    ),
+    files: { "different.md": "# Different\n\n[Missing target](missing.md)\n" },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.unexpected, /FILE: cheatsheets\/different\.md/);
+  assert.doesNotMatch(result.known, /\[recovered\] missing\.md/);
+});
+
+test("an exact baseline row is recovered only after its file is assessed", (t) => {
+  const result = runLinkCheck(t, {
+    baselineContents: JSON.stringify(
+      baseline([
+        {
+          file: "cheatsheets/assessed.md",
+          url: "missing.md",
+          observedStatus: 400,
+        },
+      ]),
+    ),
+    files: { "assessed.md": "# Assessed\n" },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.known, /\[recovered\] missing\.md/);
+  assert.match(result.known, /Status: not failing/);
+});
+
+test("a different URL on a known domain remains fatal", (t) => {
+  const checker = canonicalChecker(t);
+  const result = runLinkCheck(t, {
+    checker,
+    baselineContents: JSON.stringify(
+      baseline([
+        {
+          file: "cheatsheets/domain.md",
+          url: "https://example.invalid/old",
+          observedStatus: 404,
+        },
+      ]),
+    ),
+    env: {
+      FAKE_CHECKER_FAILURES: JSON.stringify({
+        "domain.md": [{ url: "https://example.invalid/new", status: 404 }],
+      }),
+    },
+    files: { "domain.md": "# Domain\n" },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.unexpected, /https:\/\/example\.invalid\/new/);
+  assert.doesNotMatch(result.unexpected, /example\.invalid\/old/);
+});
+
+for (const status of [0, 403, 404, 429, 500]) {
+  test(`a new status ${status} failure remains fatal`, (t) => {
+    const checker = canonicalChecker(t);
+    const url = `https://status.invalid/${status}`;
+    const result = runLinkCheck(t, {
+      checker,
+      env: {
+        FAKE_CHECKER_FAILURES: JSON.stringify({
+          "status.md": [{ url, status }],
+        }),
+      },
+      files: { "status.md": "# Status\n" },
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.unexpected, new RegExp(`Status: ${status}`));
+  });
+}
+
+test("a transient unbaselined network tuple is confirmed, visible, and nonfatal", (t) => {
+  const checker = canonicalChecker(t);
+  const invocationLog = path.join(
+    os.tmpdir(),
+    `link-check-transient-${process.pid}-${Date.now()}`,
+  );
+  t.after(() => fs.rmSync(invocationLog, { force: true }));
+  const url = "https://transient.invalid/flaky";
+  const result = runLinkCheck(t, {
+    checker,
+    env: {
+      FAKE_CHECKER_ATTEMPTS: JSON.stringify({
+        "transient.md": [[{ url, status: 429 }], []],
+      }),
+      FAKE_CHECKER_INVOCATIONS: invocationLog,
+    },
+    files: { "transient.md": "# Transient\n" },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.readFileSync(invocationLog, "utf8").trim().split(/\r?\n/).length, 2);
+  assert.match(result.raw, /attempt 1\/3/);
+  assert.match(result.raw, /attempt 2\/3/);
+  assert.match(result.known, /\[transient\].*transient\.invalid\/flaky/);
+  assert.match(result.known, /attempts: 1=429, 2=recovered/);
+  assert.equal(result.unexpected, "");
+});
+
+test("a persistent unbaselined network tuple remains fatal after bounded attempts", (t) => {
+  const checker = canonicalChecker(t);
+  const invocationLog = path.join(
+    os.tmpdir(),
+    `link-check-persistent-${process.pid}-${Date.now()}`,
+  );
+  t.after(() => fs.rmSync(invocationLog, { force: true }));
+  const url = "https://persistent.invalid/failing";
+  const result = runLinkCheck(t, {
+    checker,
+    env: {
+      FAKE_CHECKER_ATTEMPTS: JSON.stringify({
+        "persistent.md": [[{ url, status: 503 }]],
+      }),
+      FAKE_CHECKER_INVOCATIONS: invocationLog,
+    },
+    files: { "persistent.md": "# Persistent\n" },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(fs.readFileSync(invocationLog, "utf8").trim().split(/\r?\n/).length, 3);
+  assert.match(result.raw, /attempt 1\/3/);
+  assert.match(result.raw, /attempt 2\/3/);
+  assert.match(result.raw, /attempt 3\/3/);
+  assert.match(result.unexpected, /persistent\.invalid\/failing/);
+  assert.match(result.unexpected, /attempts: 1=503, 2=503, 3=503/);
+});
+
+test("a missing baseline is fatal before checker invocation", (t) => {
+  const result = runLinkCheck(t, { missingBaseline: true });
+  assert.notEqual(result.status, 0);
+  assert.match(result.raw, /Known-failure baseline is unavailable/);
+  assert.equal(result.unexpected, "");
+});
+
+test("a malformed baseline is fatal", async (t) => {
+  await t.test("invalid JSON", (subtest) => {
+    const result = runLinkCheck(subtest, { baselineContents: "{not json" });
+    assert.notEqual(result.status, 0);
+    assert.match(result.raw, /Known-failure baseline is malformed/);
+    assert.equal(result.unexpected, "");
+  });
+  await t.test("invalid schema", (subtest) => {
+    const result = runLinkCheck(subtest, {
+      baselineContents: JSON.stringify({ ...baseline(), extra: true }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.raw,
+      /baseline must contain only schemaVersion, generatedFrom, and failures/,
+    );
+    assert.equal(result.unexpected, "");
+  });
+});
+
+test("a missing or malformed config is fatal", async (t) => {
+  await t.test("missing", (subtest) => {
+    const result = runLinkCheck(subtest, { missingConfig: true });
+    assert.notEqual(result.status, 0);
+    assert.match(result.raw, /Link checker configuration is unavailable/);
+    assert.equal(result.unexpected, "");
+  });
+  await t.test("malformed", (subtest) => {
+    const result = runLinkCheck(subtest, { configContents: "{not json" });
+    assert.notEqual(result.status, 0);
+    assert.match(result.raw, /Link checker configuration is malformed/);
+    assert.equal(result.unexpected, "");
+  });
+});
+
+test("a missing checker remains fatal even when its tuple is baselined", (t) => {
+  const result = runLinkCheck(t, {
+    baselineContents: JSON.stringify(
+      baseline([
+        {
+          file: "cheatsheets/valid.md",
+          url: "missing.md",
+          observedStatus: 400,
+        },
+      ]),
+    ),
+    checker: path.join(os.tmpdir(), "missing-markdown-link-check.js"),
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.raw, /Link checker executable is unavailable/);
+  assert.equal(result.unexpected, "");
+});
+
+test("a crashing checker without canonical diagnostics is fatal", (t) => {
+  const checker = createChecker(t, 'process.stderr.write("crash\\n"); process.exit(42);\n');
+  const result = runLinkCheck(t, {
+    checker,
+    baselineContents: JSON.stringify(
+      baseline([
+        {
+          file: "cheatsheets/valid.md",
+          url: "missing.md",
+          observedStatus: 400,
+        },
+      ]),
+    ),
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.raw, /crash/);
+  assert.match(result.raw, /checker exited with unexpected status 42/);
+  assert.doesNotMatch(result.known, /\[recovered\]/);
+  assert.doesNotMatch(result.known, /Status: not failing/);
+  assert.equal(result.unexpected, "");
+});
+
+test("a crashing checker with canonical-looking output is still internal and is not retried", (t) => {
+  const checker = createChecker(
+    t,
+    [
+      "const file = process.argv.at(-1);",
+      "console.log(`FILE: ${file}`);",
+      'console.log("  1 link checked.");',
+      'console.error("  ERROR: 1 dead link found!");',
+      'console.log("  [✖] https://crash.invalid/failure → Status: 503");',
+      "process.exit(42);",
+      "",
+    ].join("\n"),
+  );
+  const result = runLinkCheck(t, { checker });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.raw, /attempt 1\/3/);
+  assert.doesNotMatch(result.raw, /attempt 2\/3/);
+  assert.match(result.raw, /checker exited with unexpected status 42/);
+  assert.doesNotMatch(result.known, /\[transient\]/);
+  assert.equal(result.unexpected, "");
+});
+
+test("an internal retry failure cannot turn a network failure into success", (t) => {
+  const checker = canonicalChecker(t);
+  const invocationLog = path.join(
+    os.tmpdir(),
+    `link-check-internal-retry-${process.pid}-${Date.now()}`,
+  );
+  t.after(() => fs.rmSync(invocationLog, { force: true }));
+  const url = "https://transient.invalid/then-crash";
+  const result = runLinkCheck(t, {
+    baselineContents: JSON.stringify(
+      baseline([
+        {
+          file: "cheatsheets/internal.md",
+          url: "https://known.invalid/unassessed",
+          observedStatus: 404,
+        },
+      ]),
+    ),
+    checker,
+    env: {
+      FAKE_CHECKER_ATTEMPTS: JSON.stringify({
+        "internal.md": [[{ url, status: 429 }], { internal: "crash" }, []],
+      }),
+      FAKE_CHECKER_INVOCATIONS: invocationLog,
+    },
+    files: { "internal.md": "# Internal\n" },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(fs.readFileSync(invocationLog, "utf8").trim().split(/\r?\n/).length, 2);
+  assert.match(result.raw, /attempt 1\/3/);
+  assert.match(result.raw, /attempt 2\/3/);
+  assert.doesNotMatch(result.raw, /attempt 3\/3/);
+  assert.match(result.raw, /planned checker crash/);
+  assert.doesNotMatch(result.known, /\[transient\]/);
+  assert.doesNotMatch(result.known, /\[recovered\]/);
+  assert.equal(result.unexpected, "");
+});
+
+test("a silent zero-exit checker is fatal", (t) => {
+  const checker = createChecker(t, "process.exit(0);\n");
+  const result = runLinkCheck(t, { checker });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.raw, /successful checker result lacks the expected FILE header/);
+  assert.equal(result.unexpected, "");
+});
+
+test("every enumerated Markdown fixture is invoked", (t) => {
+  const checker = canonicalChecker(t);
+  const invocationLog = path.join(
+    os.tmpdir(),
+    `link-check-invocations-${process.pid}-${Date.now()}`,
+  );
+  t.after(() => fs.rmSync(invocationLog, { force: true }));
+  const result = runLinkCheck(t, {
+    checker,
+    env: { FAKE_CHECKER_INVOCATIONS: invocationLog },
+    files: {
+      "a.md": "# A\n",
+      "nested/b.md": "# B\n",
+      "nested/c.md": "# C\n",
+      "nested/ignored.txt": "not Markdown\n",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const invoked = fs
+    .readFileSync(invocationLog, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .map((file) => path.relative(result.targetDir, file).split(path.sep).join("/"))
+    .sort();
+  assert.deepEqual(invoked, ["a.md", "nested/b.md", "nested/c.md"]);
+});
+
+test("unexpected output excludes exact known rows in a mixed failure", (t) => {
+  const checker = canonicalChecker(t);
+  const knownUrl = "https://mixed.invalid/known";
+  const newUrl = "https://mixed.invalid/new";
+  const result = runLinkCheck(t, {
+    checker,
+    baselineContents: JSON.stringify(
+      baseline([
+        {
+          file: "cheatsheets/mixed.md",
+          url: knownUrl,
+          observedStatus: 403,
+        },
+      ]),
+    ),
+    env: {
+      FAKE_CHECKER_FAILURES: JSON.stringify({
+        "mixed.md": [
+          { url: knownUrl, status: 500 },
+          { url: newUrl, status: 429 },
+        ],
+      }),
+    },
+    files: { "mixed.md": "# Mixed\n" },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.known, /mixed\.invalid\/known/);
+  assert.doesNotMatch(result.unexpected, /mixed\.invalid\/known/);
+  assert.match(result.unexpected, /mixed\.invalid\/new/);
 });

--- a/tests/link-check/apply-link-check.test.js
+++ b/tests/link-check/apply-link-check.test.js
@@ -14,15 +14,29 @@ const realChecker = path.join(
 );
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const provenance = {
-  baseCommit: "e5420b90672011aa84d3e5de3c3e38f704a5033d",
+  attemptCount: 1,
+  checkedHead: "daae48ab4c94803f0250ff9beb5e4f815091e259",
+  contentBaseCommit: "e5420b90672011aa84d3e5de3c3e38f704a5033d",
   workflowRunId: 34185231643,
   workflowJobId: 101932122278,
   workflowUrl:
     "https://github.com/OWASP/CheatSheetSeries/actions/runs/34185231643/job/101932122278",
 };
+const supplementalProvenance = {
+  attemptCount: 3,
+  checkedHead: "47a37a9226052e03a516a536e9431813e23878b9",
+  contentBaseCommit: "e5420b90672011aa84d3e5de3c3e38f704a5033d",
+  workflowRunId: 34228838406,
+  workflowJobId: 102069549060,
+  workflowUrl:
+    "https://github.com/OWASP/CheatSheetSeries/actions/runs/34228838406/job/102069549060",
+};
 
 function baseline(failures = []) {
-  return { schemaVersion: 1, generatedFrom: provenance, failures };
+  return {
+    schemaVersion: 2,
+    batches: [{ generatedFrom: provenance, failures }],
+  };
 }
 
 function writeFiles(root, files) {
@@ -149,13 +163,32 @@ test("the committed baseline has exact reviewed provenance and tuples", () => {
   const value = JSON.parse(
     fs.readFileSync(path.join(repoRoot, "link-check-known-failures.json"), "utf8"),
   );
-  assert.deepEqual(value.generatedFrom, provenance);
-  assert.equal(value.failures.length, 168);
-  assert.equal(new Set(value.failures.map(({ file }) => file)).size, 62);
+  assert.equal(value.schemaVersion, 2);
+  assert.equal(value.batches.length, 2);
+  assert.deepEqual(value.batches[0].generatedFrom, provenance);
+  assert.deepEqual(value.batches[1].generatedFrom, supplementalProvenance);
+  assert.equal(value.batches[0].failures.length, 168);
+  assert.equal(value.batches[1].failures.length, 7);
+  const failures = value.batches.flatMap((batch) => batch.failures);
+  assert.equal(failures.length, 175);
+  assert.equal(new Set(failures.map(({ file }) => file)).size, 64);
   assert.equal(
-    new Set(value.failures.map(({ file, url }) => `${file}\0${url}`)).size,
-    168,
+    new Set(failures.map(({ file, url }) => `${file}\0${url}`)).size,
+    175,
   );
+  assert.ok(
+    value.batches[1].failures.every(
+      ({ observedStatuses }) =>
+        observedStatuses.length === 3 && observedStatuses.every(Number.isInteger),
+    ),
+  );
+  for (const inconsistentUrl of [
+    "https://github.com/jdereg/json-io/blob/master/user-guide.md#non-typed-usage",
+    "https://github.com/OWASP/owasp-mstg/blob/master/Document/0x06g-Testing-Network-Communication.md",
+    "https://azure.microsoft.com/nl-nl/services/key-vault/",
+  ]) {
+    assert.equal(failures.some(({ url }) => url === inconsistentUrl), false);
+  }
 });
 
 test("a valid local-link fixture exits zero", (t) => {
@@ -227,7 +260,7 @@ test("an exact known tuple is nonblocking and separately reported", (t) => {
   assert.match(result.known, /\[known\] missing\.md → Status: 400; baseline observed 404/);
   assert.equal(result.unexpected, "");
   assert.deepEqual(
-    JSON.parse(fs.readFileSync(result.baselinePath, "utf8")).failures,
+    JSON.parse(fs.readFileSync(result.baselinePath, "utf8")).batches[0].failures,
     [
       {
         file: "cheatsheets/known.md",
@@ -236,6 +269,31 @@ test("an exact known tuple is nonblocking and separately reported", (t) => {
       },
     ],
   );
+});
+
+test("an exact tuple from a multi-observation evidence batch is known", (t) => {
+  const result = runLinkCheck(t, {
+    baselineContents: JSON.stringify({
+      schemaVersion: 2,
+      batches: [
+        {
+          generatedFrom: supplementalProvenance,
+          failures: [
+            {
+              file: "cheatsheets/known.md",
+              url: "missing.md",
+              observedStatuses: [404, 404, 404],
+            },
+          ],
+        },
+      ],
+    }),
+    files: { "known.md": "# Known\n\n[Missing target](missing.md)\n" },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.known, /\[known\] missing\.md → Status: 400; baseline observed 404/);
+  assert.equal(result.unexpected, "");
 });
 
 test("the same URL in a different file remains fatal", (t) => {
@@ -349,6 +407,79 @@ test("a transient unbaselined network tuple is confirmed, visible, and nonfatal"
   assert.equal(result.unexpected, "");
 });
 
+test("a network tuple failing only on the final observation is transient", (t) => {
+  const checker = canonicalChecker(t);
+  const invocationLog = path.join(
+    os.tmpdir(),
+    `link-check-late-${process.pid}-${Date.now()}`,
+  );
+  t.after(() => fs.rmSync(invocationLog, { force: true }));
+  const persistentUrl = "https://persistent.invalid/trigger";
+  const lateUrl = "https://transient.invalid/late";
+  const result = runLinkCheck(t, {
+    checker,
+    env: {
+      FAKE_CHECKER_INVOCATIONS: invocationLog,
+      FAKE_CHECKER_ATTEMPTS: JSON.stringify({
+        "late.md": [
+          [{ url: persistentUrl, status: 503 }],
+          [{ url: persistentUrl, status: 503 }],
+          [
+            { url: persistentUrl, status: 503 },
+            { url: lateUrl, status: 429 },
+          ],
+        ],
+      }),
+    },
+    files: { "late.md": "# Late\n" },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(fs.readFileSync(invocationLog, "utf8").trim().split(/\r?\n/).length, 3);
+  assert.match(result.known, /\[transient\].*transient\.invalid\/late/);
+  assert.match(result.known, /attempts: 1=not failing, 2=not failing, 3=429/);
+  assert.doesNotMatch(result.unexpected, /transient\.invalid\/late/);
+  assert.match(result.unexpected, /persistent\.invalid\/trigger/);
+});
+
+test("a network tuple that fails, recovers, and fails is transient", (t) => {
+  const checker = canonicalChecker(t);
+  const invocationLog = path.join(
+    os.tmpdir(),
+    `link-check-intermittent-${process.pid}-${Date.now()}`,
+  );
+  t.after(() => fs.rmSync(invocationLog, { force: true }));
+  const persistentUrl = "https://persistent.invalid/trigger";
+  const flakyUrl = "https://transient.invalid/intermittent";
+  const result = runLinkCheck(t, {
+    checker,
+    env: {
+      FAKE_CHECKER_INVOCATIONS: invocationLog,
+      FAKE_CHECKER_ATTEMPTS: JSON.stringify({
+        "intermittent.md": [
+          [
+            { url: persistentUrl, status: 503 },
+            { url: flakyUrl, status: 429 },
+          ],
+          [{ url: persistentUrl, status: 503 }],
+          [
+            { url: persistentUrl, status: 503 },
+            { url: flakyUrl, status: 500 },
+          ],
+        ],
+      }),
+    },
+    files: { "intermittent.md": "# Intermittent\n" },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(fs.readFileSync(invocationLog, "utf8").trim().split(/\r?\n/).length, 3);
+  assert.match(result.known, /\[transient\].*transient\.invalid\/intermittent/);
+  assert.match(result.known, /attempts: 1=429, 2=recovered, 3=500/);
+  assert.doesNotMatch(result.unexpected, /transient\.invalid\/intermittent/);
+  assert.match(result.unexpected, /persistent\.invalid\/trigger/);
+});
+
 test("a persistent unbaselined network tuple remains fatal after bounded attempts", (t) => {
   const checker = canonicalChecker(t);
   const invocationLog = path.join(
@@ -361,7 +492,11 @@ test("a persistent unbaselined network tuple remains fatal after bounded attempt
     checker,
     env: {
       FAKE_CHECKER_ATTEMPTS: JSON.stringify({
-        "persistent.md": [[{ url, status: 503 }]],
+        "persistent.md": [
+          [{ url, status: 503 }],
+          [{ url, status: 429 }],
+          [{ url, status: 502 }],
+        ],
       }),
       FAKE_CHECKER_INVOCATIONS: invocationLog,
     },
@@ -374,7 +509,7 @@ test("a persistent unbaselined network tuple remains fatal after bounded attempt
   assert.match(result.raw, /attempt 2\/3/);
   assert.match(result.raw, /attempt 3\/3/);
   assert.match(result.unexpected, /persistent\.invalid\/failing/);
-  assert.match(result.unexpected, /attempts: 1=503, 2=503, 3=503/);
+  assert.match(result.unexpected, /attempts: 1=503, 2=429, 3=502/);
 });
 
 test("a missing baseline is fatal before checker invocation", (t) => {
@@ -398,8 +533,70 @@ test("a malformed baseline is fatal", async (t) => {
     assert.notEqual(result.status, 0);
     assert.match(
       result.raw,
-      /baseline must contain only schemaVersion, generatedFrom, and failures/,
+      /baseline must contain only schemaVersion and batches/,
     );
+    assert.equal(result.unexpected, "");
+  });
+  await t.test("batch without provenance", (subtest) => {
+    const result = runLinkCheck(subtest, {
+      baselineContents: JSON.stringify({
+        schemaVersion: 2,
+        batches: [
+          {
+            failures: [
+              {
+                file: "cheatsheets/valid.md",
+                url: "https://example.invalid/missing-source",
+                observedStatus: 404,
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.raw, /baseline batch 0 has an invalid shape/);
+    assert.equal(result.unexpected, "");
+  });
+  await t.test("malformed provenance", (subtest) => {
+    const result = runLinkCheck(subtest, {
+      baselineContents: JSON.stringify({
+        schemaVersion: 2,
+        batches: [
+          {
+            generatedFrom: { ...provenance, checkedHead: "unknown" },
+            failures: [
+              {
+                file: "cheatsheets/valid.md",
+                url: "https://example.invalid/bad-source",
+                observedStatus: 404,
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.raw, /baseline batch 0 provenance is malformed/);
+    assert.equal(result.unexpected, "");
+  });
+  await t.test("duplicate tuple across evidence batches", (subtest) => {
+    const failure = {
+      file: "cheatsheets/valid.md",
+      url: "https://example.invalid/duplicate",
+      observedStatus: 404,
+    };
+    const result = runLinkCheck(subtest, {
+      baselineContents: JSON.stringify({
+        schemaVersion: 2,
+        batches: [
+          { generatedFrom: provenance, failures: [failure] },
+          { generatedFrom: provenance, failures: [failure] },
+        ],
+      }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.raw, /baseline contains a duplicate tuple/);
     assert.equal(result.unexpected, "");
   });
 });

--- a/tests/link-check/apply-link-check.test.js
+++ b/tests/link-check/apply-link-check.test.js
@@ -1,0 +1,126 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const realChecker = path.join(
+  repoRoot,
+  "node_modules",
+  ".bin",
+  "markdown-link-check",
+);
+
+function runLinkCheck(t, { checker = realChecker, files }) {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "cheatsheet-link-check-"),
+  );
+  const targetDir = path.join(fixtureRoot, "cheatsheets");
+  const config = path.join(fixtureRoot, "markdown-link-check-config.json");
+  const log = path.join(fixtureRoot, "log");
+
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+  fs.mkdirSync(targetDir);
+  fs.writeFileSync(config, "{}\n");
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(targetDir, name), content);
+  }
+
+  const result = spawnSync("npm", ["run", "link-check", "--silent"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      MARKDOWN_LINK_CHECK_BIN: checker,
+      MARKDOWN_LINK_CHECK_CONFIG: config,
+      MARKDOWN_LINK_CHECK_LOG: log,
+      MARKDOWN_LINK_CHECK_TARGET: targetDir,
+    },
+  });
+
+  return {
+    ...result,
+    log: fs.existsSync(log) ? fs.readFileSync(log, "utf8") : "",
+    targetDir,
+  };
+}
+
+function createFailingChecker(t) {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "cheatsheet-failing-checker-"),
+  );
+  const checker = path.join(fixtureRoot, "markdown-link-check");
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+  fs.writeFileSync(
+    checker,
+    [
+      "#!/bin/bash",
+      'printf \'FILE: %s\\n\' "$3"',
+      'if [[ "$3" == *failing.md ]]; then',
+      '  printf \'checker crashed for %s\\n\' "$3" >&2',
+      "  exit 42",
+      "fi",
+      'printf \'[✓] local fixture\\n\'',
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return checker;
+}
+
+test("a valid local-link fixture exits zero", (t) => {
+  const result = runLinkCheck(t, {
+    files: {
+      "target.md": "# Target\n",
+      "valid.md": "# Valid\n\n[Existing target](target.md)\n",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No error found by the link validator/);
+  assert.match(result.log, /FILE: .*valid\.md/);
+});
+
+test("a broken local link exits nonzero and leaves workflow diagnostics", (t) => {
+  const result = runLinkCheck(t, {
+    files: {
+      "broken.md": "# Broken\n\n[Missing target](missing.md)\n",
+    },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.doesNotMatch(result.stdout, /All good/);
+  assert.match(result.log, /FILE: .*broken\.md/);
+  assert.match(result.log, /ERROR:/);
+  assert.match(result.log, /\[✖\] missing\.md/);
+});
+
+test("a missing checker exits nonzero and cannot report success", (t) => {
+  const result = runLinkCheck(t, {
+    checker: path.join(os.tmpdir(), "missing-markdown-link-check"),
+    files: { "valid.md": "# Valid\n" },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.doesNotMatch(result.stdout, /All good/);
+  assert.match(result.stderr, /Link checker executable is unavailable/);
+  assert.match(result.log, /Link checker executable is unavailable/);
+});
+
+test("any failing per-file invocation makes the command fail", (t) => {
+  const checker = createFailingChecker(t);
+  const result = runLinkCheck(t, {
+    checker,
+    files: {
+      "failing.md": "# Failing\n",
+      "valid.md": "# Valid\n",
+    },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.doesNotMatch(result.stdout, /All good/);
+  assert.match(result.log, /checker crashed for .*failing\.md/);
+  assert.match(result.log, /FILE: .*valid\.md/);
+});

--- a/tests/link-check/workflow-diagnostics.test.js
+++ b/tests/link-check/workflow-diagnostics.test.js
@@ -104,7 +104,10 @@ test("a successful run reports known and recovered counts without a comment", (t
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.summary, /2 exact known-failure tuple\(s\) remain/);
   assert.match(result.summary, /1 baseline row\(s\) are recovered or stale/);
-  assert.match(result.summary, /1 unbaselined network failure\(s\) recovered/);
+  assert.match(
+    result.summary,
+    /1 unbaselined network failure\(s\) were not persistent across every observation/,
+  );
   assert.match(result.output, /^should_comment=false$/m);
 });
 

--- a/tests/link-check/workflow-diagnostics.test.js
+++ b/tests/link-check/workflow-diagnostics.test.js
@@ -1,0 +1,138 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const prepareScript = path.join(
+  repoRoot,
+  "scripts",
+  "Prepare_Link_Check_Diagnostics.js",
+);
+
+function runPrepare(
+  t,
+  {
+    eventName = "pull_request",
+    headRepository = "contributor/CheatSheetSeries",
+    known = "## Known\n\n    [known] old.example\n",
+    outcome = "failure",
+    repository = "OWASP/CheatSheetSeries",
+    unexpected = "## Unexpected\n\n    FILE: cheatsheets/example.md\n      [✖] new.example → Status: 404\n",
+  } = {},
+) {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "cheatsheet-workflow-diagnostics-"),
+  );
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+  const knownPath = path.join(fixtureRoot, "known.md");
+  const unexpectedPath = path.join(fixtureRoot, "unexpected.md");
+  const summaryPath = path.join(fixtureRoot, "summary.md");
+  const outputPath = path.join(fixtureRoot, "output");
+  fs.writeFileSync(knownPath, known);
+  fs.writeFileSync(unexpectedPath, unexpected);
+  fs.writeFileSync(summaryPath, "");
+  fs.writeFileSync(outputPath, "");
+
+  const result = spawnSync(process.execPath, [prepareScript], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_STEP_SUMMARY: summaryPath,
+      LINK_CHECK_EVENT_NAME: eventName,
+      LINK_CHECK_HEAD_REPOSITORY: headRepository,
+      LINK_CHECK_OUTCOME: outcome,
+      LINK_CHECK_REPOSITORY: repository,
+      MARKDOWN_LINK_CHECK_KNOWN: knownPath,
+      MARKDOWN_LINK_CHECK_UNEXPECTED: unexpectedPath,
+    },
+  });
+
+  return {
+    ...result,
+    output: fs.readFileSync(outputPath, "utf8"),
+    summary: fs.readFileSync(summaryPath, "utf8"),
+  };
+}
+
+test("a fork failure writes unexpected diagnostics to the summary and skips comment", (t) => {
+  const result = runPrepare(t);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.summary, /FILE: cheatsheets\/example\.md/);
+  assert.match(result.summary, /new\.example/);
+  assert.doesNotMatch(result.summary, /old\.example/);
+  assert.match(result.output, /^should_comment=false$/m);
+});
+
+test("a same-repository failure enables a comment containing only unexpected output", (t) => {
+  const result = runPrepare(t, {
+    headRepository: "OWASP/CheatSheetSeries",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.output, /^should_comment=true$/m);
+  assert.doesNotMatch(result.summary, /old\.example/);
+});
+
+test("an internal failure without recovered diagnostics produces a generic summary", (t) => {
+  const result = runPrepare(t, {
+    headRepository: "OWASP/CheatSheetSeries",
+    unexpected: "",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.summary, /failed before actionable diagnostics could be recovered/);
+  assert.match(result.output, /^should_comment=false$/m);
+});
+
+test("a successful run reports known and recovered counts without a comment", (t) => {
+  const result = runPrepare(t, {
+    known: [
+      "## Known",
+      "",
+      "    [known] first.example",
+      "    [known] second.example",
+      "    [recovered] third.example",
+      "    [transient] fourth.example",
+      "",
+    ].join("\n"),
+    outcome: "success",
+    unexpected: "",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.summary, /2 exact known-failure tuple\(s\) remain/);
+  assert.match(result.summary, /1 baseline row\(s\) are recovered or stale/);
+  assert.match(result.summary, /1 unbaselined network failure\(s\) recovered/);
+  assert.match(result.output, /^should_comment=false$/m);
+});
+
+test("the workflow keeps fork execution unprivileged and comments only unexpected rows", () => {
+  const workflow = fs.readFileSync(
+    path.join(repoRoot, ".github", "workflows", "md-link-check.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /^\s*pull_request:\s*$/m);
+  assert.doesNotMatch(workflow, /pull_request_target/);
+  assert.doesNotMatch(workflow, /secrets\./);
+  assert.doesNotMatch(workflow, /GITHUB_TOKEN/);
+  assert.match(workflow, /github-token:\s*\$\{\{ github\.token \}\}/);
+  assert.match(
+    workflow,
+    /steps\.link_check_diagnostics\.outputs\.should_comment == 'true'/,
+  );
+  assert.match(workflow, /file-path:\s*link-check-unexpected\.md/);
+  assert.doesNotMatch(workflow, /file-path:\s*link-check-known-debt\.md/);
+});
+
+test("the package test command uses explicit Windows-cmd-portable file paths", () => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+  );
+  assert.equal(
+    packageJson.scripts["test:link-check"],
+    "node --test tests/link-check/apply-link-check.test.js tests/link-check/workflow-diagnostics.test.js",
+  );
+  assert.doesNotMatch(packageJson.scripts["test:link-check"], /[*?\[\]]/);
+});


### PR DESCRIPTION
## Summary

- pin `markdown-link-check` 3.14.2 as a direct development dependency and use the canonical `markdown-link-check-config.json`
- replace the fail-open `find -exec` path with a deterministic whole-corpus driver that rejects missing, crashing, silent, malformed, or unexpectedly exiting checker invocations
- record the 168 failures from the first honest hosted run as exact `(repository-relative file, URL)` tuples, preserving their source commit and run/job provenance without accepting broad domains or status codes
- confirm newly observed network failures with at most three recorded attempts; transient results remain visible, while persistent unbaselined failures remain fatal
- separate raw, known, recovered, transient, unexpected, and internal diagnostics; always publish a job summary and comment only on same-repository pull requests using the valid `github-token` input
- add production-seam regression coverage and use explicit test paths so `npm test` does not depend on POSIX glob expansion, addressing Copilot's review comment

The baseline does not hide missing tooling, parse failures, checker crashes, enumeration failures, or new link failures. It is not updated automatically.

## Verification

- [x] `npm ci --ignore-scripts`
- [x] `npm test` (markdownlint, textlint, and 35/35 link-check/workflow tests)
- [x] `actionlint .github/workflows/md-link-check.yml`
- [x] `bash -n scripts/Apply_Link_Check.sh`
- [x] `shellcheck scripts/Apply_Link_Check.sh`
- [x] `node --check` for both Node scripts and both test files
- [x] `git diff --check`
- [x] independent acceptance verification against exact commit `47a37a9226052e03a516a536e9431813e23878b9`, including mutation controls for the exact-tuple key, three-attempt ceiling, and assessed-file-only recovery reporting
- [x] deterministic outage replay exercised all 121 Markdown files and proved the three-attempt ceiling while persistent unbaselined failures remained fatal
- [ ] hosted checks for the updated head must pass before merge

## Scope and sourcing

- [x] This PR is focused on the acknowledged link-check infrastructure defect and the baseline/workflow handling required by the first honest hosted failure.
- [x] No cheat-sheet claims, recommendations, sources, or assets are added or changed.
- [x] The known-failure baseline is mechanically bound to base commit `e5420b90672011aa84d3e5de3c3e38f704a5033d` and hosted run/job `34185231643/101932122278`.

## AI Tool Usage Disclosure

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I verified the contents and affirm the results. The LLM used is `OpenAI Codex (GPT-5)`. The prompt was to reproduce issue #2407, implement a fail-closed whole-corpus link checker, preserve safe fork-compatible diagnostics, classify only exact provenance-bound known failures, add bounded network confirmation without absorbing internal failures, address Copilot's portability comment, run falsifiable regression tests, and obtain independent exact-head acceptance verification. No citations or new cheat-sheet technical content were added.

Closes #2407
