### PR TITLE
chore: add Next.js cheat sheet CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,10 @@
 
 - @mackowski @jmanico
 
+## jharvieux
+
+/cheatsheets/Nextjs_Security_Cheat_Sheet.md @jharvieux @mackowski @jmanico
+
 ## Kevin W. Wall (kwwall)
 
 /cheatsheets/Authentication_Cheat_Sheet.md @kwwall @mackowski @jmanico


### PR DESCRIPTION
## Summary

- add `@jharvieux` as the subject-matter CODEOWNER for `Nextjs_Security_Cheat_Sheet.md`
- retain `@mackowski` and `@jmanico` as co-owners, following the existing CODEOWNERS pattern

This is the Next.js ownership follow-up invited by @mackowski in https://github.com/OWASP/CheatSheetSeries/issues/2175#issuecomment-5635650887.

Related: #2175

## Validation

- [x] Confirmed the target cheat sheet exists.
- [x] Confirmed the exact-path CODEOWNERS rule appears once.
- [x] Confirmed this PR changes only `.github/CODEOWNERS`.
- [x] Ran `git diff --check`.

## Scope and sourcing (required)

- [x] This PR is focused: it modifies one CODEOWNERS entry for one existing cheat sheet.
- [x] This PR adds no technical claims, recommendations, threat assertions, citations, Markdown, assets, or images.

## AI Tool Usage Disclosure (required for all PRs)

- [ ] I have NOT used any AI tool to generate the contents of this PR.
- [x] I have used AI tools to generate the contents of this PR. I have verified
    the contents and I affirm the results. The LLM used is `OpenAI Codex (GPT-5)`
    and the prompt used is `Create a pr to add me as codeowner for the next.js cheat sheet`. No citations or technical claims are introduced by this change.

